### PR TITLE
higher_order typedispatch fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 script:
   - python setup.py sdist >/dev/null
   - echo "check_stable=False" >libpysal/config.py
-  - nosetests --with-coverage --cover-package=libpysal;
+  - nosetests --verbose --with-coverage --cover-package=libpysal;
   #- cd doc; make pickle; make doctest
 notifications:
     email:

--- a/libpysal/weights/Distance.py
+++ b/libpysal/weights/Distance.py
@@ -110,7 +110,7 @@ class KNN(W):
         W.__init__(self, neighbors, id_order=ids)
     
     @classmethod
-    def from_shapefile(cls, filepath, **kwargs):
+    def from_shapefile(cls, filepath, *args, **kwargs):
         """
         Nearest neighbor weights from a shapefile.
 
@@ -183,10 +183,10 @@ class KNN(W):
         :class:`pysal.weights.KNN`
         :class:`pysal.weights.W`
         """
-        return cls(get_points_array_from_shapefile(filepath), **kwargs)
+        return cls(get_points_array_from_shapefile(filepath), *args, **kwargs)
     
     @classmethod
-    def from_array(cls, array, **kwargs):
+    def from_array(cls, array, *args, **kwargs):
         """
         Creates nearest neighbor weights matrix based on k nearest
         neighbors.
@@ -240,10 +240,10 @@ class KNN(W):
         :class: `pysal.weights.KNN`
         :class:`pysal.weights.W`
         """
-        return cls(array, **kwargs)
+        return cls(array, *args, **kwargs)
 
     @classmethod
-    def from_dataframe(cls, df, geom_col='geometry', ids=None, **kwargs):
+    def from_dataframe(cls, df, geom_col='geometry', ids=None, *args, **kwargs):
         """
         Make KNN weights from a dataframe.
 
@@ -269,7 +269,7 @@ class KNN(W):
             ids = df.index.tolist()
         elif isinstance(ids, str):
             ids = df[ids].tolist()
-        return cls(pts, ids=ids, **kwargs)
+        return cls(pts, *args, ids=ids, **kwargs)
 
     def reweight(self, k=None, p=None, new_data=None, new_ids=None, inplace=True):
         """

--- a/libpysal/weights/tests/test_util.py
+++ b/libpysal/weights/tests/test_util.py
@@ -3,6 +3,8 @@ from .. import user
 from ..util import lat2W
 from .. import util
 from ..weights import W, WSP
+from ..Distance import DistanceBand, KNN
+from ..Contiguity import Queen, Rook
 from ...io.FileIO import FileIO as psopen
 from ... import examples as pysal_examples
 import numpy as np
@@ -89,6 +91,27 @@ class Testutil(unittest.TestCase):
         w5_2 = util.higher_order(w5, 2)
         w5_20 = {2: 1.0, 10: 1.0, 6: 1.0}
         self.assertEquals(w5_20, w5_2[0])
+    
+    def test_higher_order_classes(self):
+        wdb = DistanceBand.from_shapefile(pysal_examples.get_path('baltim.shp'), 34)
+        wknn = KNN.from_shapefile(pysal_examples.get_path('baltim.shp'), 10)
+        wrook = Rook.from_shapefile(pysal_examples.get_path('columbus.shp'))
+        wqueen = Queen.from_shapefile(pysal_examples.get_path('columbus.shp'))
+        wsparse = wqueen.sparse
+        ww = W(wknn.neighbors, wknn.weights)
+        util.higher_order(wdb, 2)
+        util.higher_order(wknn, 3)
+        util.higher_order(wrook, 4)
+        util.higher_order(wqueen, 5)
+        util.higher_order(wsparse, 2)
+        util.higher_order(ww, 2)
+        ww.transform = 'r'
+        wsparse_notbinary = wrook.sparse
+        with self.assertRaises(ValueError):
+            util.higher_order(wsparse, 2)
+            util.higher_order(ww, 3)
+
+
 
     def test_shimbel(self):
         w5 = lat2W()

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -523,10 +523,12 @@ def higher_order_sp(w, k=2, shortest_path=True, diagonal=False):
 
     """
     id_order = None
-    if issubclass(type(w), W):
+    if issubclass(type(w), W) or isinstance(w, W):
         if np.unique(np.hstack(w.weights.values())) == np.array([1.0]):
             id_order = w.id_order
             w = w.sparse
+        else:
+            raise ValueError('Weights are not binary (0,1)')
     elif scipy.sparse.isspmatrix_csr(w):
         if not np.unique(w.data) == np.array([1.0]):
             raise ValueError('Sparse weights matrix is not binary (0,1) weights matrix.')


### PR DESCRIPTION
I'm quite frustrated I clobbered what looked like quite a bit of work in [pysal/#922](https://github.com/pysal/pysal/pull/922). 

I'm pushing this here because now Github won't let me resurrect my dev branch on pysal proper without just pushing that PR again. 

This fixes [pysal/#944](https://github.com/pysal/pysal/issues/944) by allowing any binary W to be higher-ordered. Also, it enforces that the source weights are binary. 

We need to finish this reorg soon & plug all those tickets up when we can :frowning_face: 