### PR TITLE
bump version for point release of lag cat fix

### DIFF
--- a/libpysal/version.py
+++ b/libpysal/version.py
@@ -1,3 +1,3 @@
 import datetime
-version = "1.14.0dev"
+version = "3.0.2dev"
 stable_release_date = datetime.date(2016, 12, 9)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('README.rst') as file:
 
 MAJOR = 3
 MINOR = 0
-MICRO = 1
+MICRO = 2
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
This is bumping the version strings off of the old PySAL versions here. 

I'd like to get a point release of this up on PyPI asap, since the version currently up there has the lag_categorical bug we found in the summer at scipy. 