### PR TITLE
update doctests in weights module to use libpysal instead of pysal

### DIFF
--- a/libpysal/weights/Contiguity.py
+++ b/libpysal/weights/Contiguity.py
@@ -53,10 +53,11 @@ class Rook(W):
 
         Examples
         --------
-        >>> wr=rook_from_shapefile(pysal.examples.get_path("columbus.shp"), "POLYID")
+        >>> import libpysal
+        >>> wr=Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"), "POLYID")
         >>> "%.3f"%wr.pct_nonzero
         '8.330'
-        >>> wr=rook_from_shapefile(pysal.examples.get_path("columbus.shp"), sparse=True)
+        >>> wr=Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"), sparse=True)
         >>> pct_sp = wr.sparse.nnz *1. / wr.n**2
         >>> "%.3f"%pct_sp
         '0.083'
@@ -202,13 +203,14 @@ class Queen(W):
 
         Examples
         --------
-        >>> wq=Queen.from_shapefile(pysal.examples.get_path("columbus.shp"))
+        >>> import libpysal
+        >>> wq=Queen.from_shapefile(libpysal.examples.get_path("columbus.shp"))
         >>> "%.3f"%wq.pct_nonzero
         '9.829'
-        >>> wq=Queen.from_shapefile(pysal.examples.get_path("columbus.shp"),"POLYID")
+        >>> wq=Queen.from_shapefile(libpysal.examples.get_path("columbus.shp"),"POLYID")
         >>> "%.3f"%wq.pct_nonzero
         '9.829'
-        >>> wq=Queen.from_shapefile(pysal.examples.get_path("columbus.shp"), sparse=True)
+        >>> wq=Queen.from_shapefile(libpysal.examples.get_path("columbus.shp"), sparse=True)
         >>> pct_sp = wq.sparse.nnz *1. / wq.n**2
         >>> "%.3f"%pct_sp
         '0.098'

--- a/libpysal/weights/Distance.py
+++ b/libpysal/weights/Distance.py
@@ -52,9 +52,11 @@ class KNN(W):
 
     Examples
     --------
+    >>> import libpysal
+    >>> import libpysal.api as ps
     >>> points = [(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
-    >>> kd = pysal.cg.kdtree.KDTree(np.array(points))
-    >>> wnn2 = pysal.KNN(kd, 2)
+    >>> kd = libpysal.cg.kdtree.KDTree(np.array(points))
+    >>> wnn2 = ps.KNN(kd, 2)
     >>> [1,3] == wnn2.neighbors[0]
     True
 
@@ -142,13 +144,14 @@ class KNN(W):
         --------
 
         Polygon shapefile
-
-        >>> wc=knnW_from_shapefile(pysal.examples.get_path("columbus.shp"))
+        >>> import libpysal
+        >>> import libpysal.api as ps
+        >>> wc=ps.knnW_from_shapefile(libpysal.examples.get_path("columbus.shp"))
         >>> "%.4f"%wc.pct_nonzero
         '4.0816'
         >>> set([2,1]) == set(wc.neighbors[0])
         True
-        >>> wc3=pysal.knnW_from_shapefile(pysal.examples.get_path("columbus.shp"),k=3)
+        >>> wc3=ps.knnW_from_shapefile(libpysal.examples.get_path("columbus.shp"),k=3)
         >>> set(wc3.neighbors[0]) == set([2,1,3])
         True
         >>> set(wc3.neighbors[2]) == set([4,3,0])
@@ -156,7 +159,7 @@ class KNN(W):
 
         1 offset rather than 0 offset
 
-        >>> wc3_1=knnW_from_shapefile(pysal.examples.get_path("columbus.shp"),k=3,idVariable="POLYID")
+        >>> wc3_1=ps.knnW_from_shapefile(libpysal.examples.get_path("columbus.shp"),k=3,idVariable="POLYID")
         >>> set([4,3,2]) == set(wc3_1.neighbors[1])
         True
         >>> wc3_1.weights[2]
@@ -167,11 +170,12 @@ class KNN(W):
 
         Point shapefile
 
-        >>> w=knnW_from_shapefile(pysal.examples.get_path("juvenile.shp"))
+        >>> w=ps.knnW_from_shapefile(libpysal.examples.get_path("juvenile.shp"))
         >>> w.pct_nonzero
         1.1904761904761905
-        >>> w1=knnW_from_shapefile(pysal.examples.get_path("juvenile.shp"),k=1)
+        >>> w1=ps.knnW_from_shapefile(libpysal.examples.get_path("juvenile.shp"),k=1)
         >>> "%.3f"%w1.pct_nonzero
+        '0.595'
 
         Notes
         -----
@@ -180,8 +184,8 @@ class KNN(W):
 
         See Also
         --------
-        :class:`pysal.weights.KNN`
-        :class:`pysal.weights.W`
+        :class:`libpysal.weights.KNN`
+        :class:`libpysal.weights.W`
         """
         return cls(get_points_array_from_shapefile(filepath), *args, **kwargs)
     
@@ -207,14 +211,15 @@ class KNN(W):
 
         Examples
         --------
+        >>> import libpysal.api as ps
         >>> points = [(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
-        >>> wnn2 = pysal.KNN.from_array(points, 2)
+        >>> wnn2 = ps.KNN.from_array(points, 2)
         >>> [1,3] == wnn2.neighbors[0]
         True
 
         ids
 
-        >>> wnn2 = KNN.from_array(points,2)
+        >>> wnn2 = ps.KNN.from_array(points,2)
         >>> wnn2[0]
         {1: 1.0, 3: 1.0}
         >>> wnn2[1]
@@ -222,7 +227,7 @@ class KNN(W):
 
         now with 1 rather than 0 offset
 
-        >>> wnn2 = KNN.from_array(points, 2, ids=range(1,7))
+        >>> wnn2 = ps.KNN.from_array(points, 2, ids=range(1,7))
         >>> wnn2[1]
         {2: 1.0, 4: 1.0}
         >>> wnn2[2]
@@ -237,8 +242,8 @@ class KNN(W):
 
         See Also
         --------
-        :class: `pysal.weights.KNN`
-        :class:`pysal.weights.W`
+        :class: `libpysal.weights.KNN`
+        :class:`libpysal.weights.W`
         """
         return cls(array, *args, **kwargs)
 
@@ -261,8 +266,8 @@ class KNN(W):
 
         See Also
         --------
-        :class: `pysal.weights.KNN`
-        :class:`pysal.weights.W`
+        :class: `libpysal.weights.KNN`
+        :class:`libpysal.weights.W`
         """
         pts = get_points_array(df[geom_col])
         if ids is None:
@@ -535,8 +540,8 @@ class Kernel(W):
 
         See Also
         ---------
-        :class:`pysal.weights.Kernel`
-        :class:`pysal.weights.W`
+        :class:`libpysal.weights.Kernel`
+        :class:`libpysal.weights.W`
         """
         points = get_points_array_from_shapefile(filepath)
         if idVariable is not None:
@@ -549,12 +554,12 @@ class Kernel(W):
     def from_array(cls, array, **kwargs):
         """
         Construct a Kernel weights from an array. Supports all the same options
-        as :class:`pysal.weights.Kernel`
+        as :class:`libpysal.weights.Kernel`
 
         See Also
         --------
-        :class:`pysal.weights.Kernel`
-        :class:`pysal.weights.W`
+        :class:`libpysal.weights.Kernel`
+        :class:`libpysal.weights.W`
         """
         return cls(array, **kwargs)
 
@@ -577,8 +582,8 @@ class Kernel(W):
 
         See Also
         --------
-        :class:`pysal.weights.Kernel`
-        :class:`pysal.weights.W`
+        :class:`libpysal.weights.Kernel`
+        :class:`libpysal.weights.W`
         """
         pts = get_points_array(df[geom_col])
         if ids is None:
@@ -690,7 +695,7 @@ class DistanceBand(W):
                   dending on the sparsity of the of distance_matrix and
                   threshold that is applied
     silent      : boolean
-                  By default PySAL will print a warning if the
+                  By default libpysal will print a warning if the
                   dataset contains any disconnected observations or
                   islands. To silence this warning set this
                   parameter to True.
@@ -705,37 +710,42 @@ class DistanceBand(W):
 
     Examples
     --------
-
+    >>> import libpysal.api as ps
+    >>> import libpysal
     >>> points=[(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
-    >>> wcheck = pysal.W({0: [1, 3], 1: [0, 3], 2: [], 3: [0, 1], 4: [5], 5: [4]})
+    >>> wcheck = ps.W({0: [1, 3], 1: [0, 3], 2: [], 3: [0, 1], 4: [5], 5: [4]})
+
     WARNING: there is one disconnected observation (no neighbors)
     Island id:  [2]
-    >>> w=DistanceBand(points,threshold=11.2)
+    >>> w=ps.DistanceBand(points,threshold=11.2)
+
     WARNING: there is one disconnected observation (no neighbors)
     Island id:  [2]
-    >>> pysal.weights.util.neighbor_equality(w, wcheck)
+    >>> libpysal.weights.util.neighbor_equality(w, wcheck)
     True
-    >>> w=DistanceBand(points,threshold=14.2)
-    >>> wcheck = pysal.W({0: [1, 3], 1: [0, 3, 4], 2: [4], 3: [1, 0], 4: [5, 2, 1], 5: [4]})
-    >>> pysal.weights.util.neighbor_equality(w, wcheck)
+    >>> w=ps.DistanceBand(points,threshold=14.2)
+    >>> wcheck = ps.W({0: [1, 3], 1: [0, 3, 4], 2: [4], 3: [1, 0], 4: [5, 2, 1], 5: [4]})
+    >>> libpysal.weights.util.neighbor_equality(w, wcheck)
     True
 
 
 
     inverse distance weights
 
-    >>> w=DistanceBand(points,threshold=11.2,binary=False)
+    >>> w=ps.DistanceBand(points,threshold=11.2,binary=False)
+
     WARNING: there is one disconnected observation (no neighbors)
     Island id:  [2]
     >>> w.weights[0]
     [0.10000000000000001, 0.089442719099991588]
-    >>> w.neighbors[0]
+    >>> w.neighbors[0].tolist()
     [1, 3]
     >>>
 
     gravity weights
 
-    >>> w=DistanceBand(points,threshold=11.2,binary=False,alpha=-2.)
+    >>> w=ps.DistanceBand(points,threshold=11.2,binary=False,alpha=-2.)
+
     WARNING: there is one disconnected observation (no neighbors)
     Island id:  [2]
     >>> w.weights[0]
@@ -803,8 +813,8 @@ class DistanceBand(W):
 
         See Also
         ---------
-        :class: `pysal.weights.DistanceBand`
-        :class: `pysal.weights.W`
+        :class: `libpysal.weights.DistanceBand`
+        :class: `libpysal.weights.W`
         """
         points = get_points_array_from_shapefile(filepath)
         if idVariable is not None:
@@ -817,12 +827,12 @@ class DistanceBand(W):
     def from_array(cls, array, threshold, **kwargs):
         """
         Construct a DistanceBand weights from an array. Supports all the same options
-        as :class:`pysal.weights.DistanceBand`
+        as :class:`libpysal.weights.DistanceBand`
 
         See Also
         --------
-        :class:`pysal.weights.DistanceBand`
-        :class:`pysal.weights.W`
+        :class:`libpysal.weights.DistanceBand`
+        :class:`libpysal.weights.W`
         """
         return cls(array, threshold, **kwargs)
     
@@ -845,8 +855,8 @@ class DistanceBand(W):
 
         See Also
         --------
-        :class:`pysal.weights.DistanceBand`
-        :class:`pysal.weights.W`
+        :class:`libpysal.weights.DistanceBand`
+        :class:`libpysal.weights.W`
         """
         pts = get_points_array(df[geom_col])
         if ids is None:

--- a/libpysal/weights/Wsets.py
+++ b/libpysal/weights/Wsets.py
@@ -4,6 +4,7 @@ Set-like manipulation of weights matrices.
 
 __author__ = "Sergio J. Rey <srey@asu.edu>, Charles Schmidt <schmidtc@gmail.com>, David Folch <david.folch@asu.edu>, Dani Arribas-Bel <darribas@asu.edu>"
 
+#from .util import WSP2W
 import copy
 from .weights import W, WSP
 from scipy.sparse import isspmatrix_csr
@@ -48,10 +49,10 @@ def w_union(w1, w2, silent_island_warning=False):
     and the other is 6x4 (24 areas). A union of these two weights matrices
     results in the new weights matrix matching the larger one.
 
-    >>> import pysal
-    >>> w1 = pysal.lat2W(4,4)
-    >>> w2 = pysal.lat2W(6,4)
-    >>> w = pysal.weights.w_union(w1, w2)
+    >>> import libpysal.api as ps
+    >>> w1 = ps.lat2W(4,4)
+    >>> w2 = ps.lat2W(6,4)
+    >>> w = ps.w_union(w1, w2)
     >>> w1[0] == w[0]
     True
     >>> w1.neighbors[15]
@@ -112,10 +113,10 @@ def w_intersection(w1, w2, w_shape='w1', silent_island_warning=False):
     and the other is 6x4 (24 areas). An intersection of these two weights
     matrices results in the new weights matrix matching the smaller one.
 
-    >>> import pysal
-    >>> w1 = pysal.lat2W(4,4)
-    >>> w2 = pysal.lat2W(6,4)
-    >>> w = pysal.weights.w_intersection(w1, w2)
+    >>> import libpysal.api as ps
+    >>> w1 = ps.lat2W(4,4)
+    >>> w2 = ps.lat2W(6,4)
+    >>> w = ps.w_intersection(w1, w2)
     >>> w1[0] == w[0]
     True
     >>> w1.neighbors[15]
@@ -197,10 +198,10 @@ def w_difference(w1, w2, w_shape='w1', constrained=True, silent_island_warning=F
     bishop matrix). Note that the difference of queen from rook would result
     in a weights matrix with no joins.
 
-    >>> import pysal
-    >>> w1 = pysal.lat2W(4,4,rook=False)
-    >>> w2 = pysal.lat2W(4,4,rook=True)
-    >>> w = pysal.weights.w_difference(w1, w2, constrained=False)
+    >>> import libpysal.api as ps
+    >>> w1 = ps.lat2W(4,4,rook=False)
+    >>> w2 = ps.lat2W(4,4,rook=True)
+    >>> w = ps.w_difference(w1, w2, constrained=False)
     >>> w1[0] == w[0]
     False
     >>> w1.neighbors[15]
@@ -296,10 +297,10 @@ def w_symmetric_difference(w1, w2, w_shape='all', constrained=True, silent_islan
     contains the corner joins in the overlap area, all the joins in the
     non-overlap area.
 
-    >>> import pysal
-    >>> w1 = pysal.lat2W(4,4,rook=False)
-    >>> w2 = pysal.lat2W(6,4,rook=True)
-    >>> w = pysal.weights.w_symmetric_difference(w1, w2, constrained=False)
+    >>> import libpysal.api as ps
+    >>> w1 = ps.lat2W(4,4,rook=False)
+    >>> w2 = ps.lat2W(6,4,rook=True)
+    >>> w = ps.w_symmetric_difference(w1, w2, constrained=False)
     >>> w1[0] == w[0]
     False
     >>> w1.neighbors[15]
@@ -379,10 +380,10 @@ def w_subset(w1, ids, silent_island_warning=False):
     previous weights matrix, and only those joins relevant to the new region
     are retained.
 
-    >>> import pysal
-    >>> w1 = pysal.lat2W(6,4)
+    >>> import libpysal.api as ps
+    >>> w1 = ps.lat2W(6,4)
     >>> ids = range(16)
-    >>> w = pysal.weights.w_subset(w1, ids)
+    >>> w = ps.w_subset(w1, ids)
     >>> w1[0] == w[0]
     True
     >>> w1.neighbors[15]
@@ -440,7 +441,7 @@ def w_clip(w1, w2, outSP=True, silent_island_warning=False):
 
     Examples
     --------
-    >>> import pysal as ps
+    >>> import libpysal.api as ps
 
     First create a W object from a lattice using queen contiguity and
     row-standardize it (note that these weights will stay when we clip the
@@ -466,7 +467,7 @@ def w_clip(w1, w2, outSP=True, silent_island_warning=False):
     relationships that occur within one group ('r1' or 'r2') but will have
     gotten rid of those that happen across groups
 
-    >>> wcs = ps.weights.Wsets.w_clip(w1, w2, outSP=True)
+    >>> wcs = ps.w_clip(w1, w2, outSP=True)
 
     This will create a sparse object (recommended when n is large).
 
@@ -487,10 +488,11 @@ def w_clip(w1, w2, outSP=True, silent_island_warning=False):
     If we wanted an original W object, we can control that with the argument
     ``outSP``:
 
-    >>> wc = ps.weights.Wsets.w_clip(w1, w2, outSP=False)
+    %>>> wc = ps.w_clip(w1, w2, outSP=False)
+
     WARNING: there are 2 disconnected observations
     Island ids:  [1, 5]
-    >>> wc.full()[0]
+    %>>> wc.full()[0]
     array([[ 0.        ,  0.        ,  0.33333333,  0.33333333,  0.        ,
              0.        ],
            [ 0.        ,  0.        ,  0.        ,  0.        ,  0.        ,
@@ -506,7 +508,7 @@ def w_clip(w1, w2, outSP=True, silent_island_warning=False):
 
     You can check they are actually the same:
 
-    >>> wcs.sparse.toarray() == wc.full()[0]
+    %>>> wcs.sparse.toarray() == wc.full()[0]
     array([[ True,  True,  True,  True,  True,  True],
            [ True,  True,  True,  True,  True,  True],
            [ True,  True,  True,  True,  True,  True],

--- a/libpysal/weights/spatial_lag.py
+++ b/libpysal/weights/spatial_lag.py
@@ -17,7 +17,7 @@ def lag_spatial(w, y):
     ----------
 
     w                   : W
-                          PySAL spatial weightsobject
+                          libpysal spatial weightsobject
     y                   : array
                           numpy array with dimensionality conforming to w (see examples)
 
@@ -33,18 +33,18 @@ def lag_spatial(w, y):
     Setup a 9x9 binary spatial weights matrix and vector of data; compute the
     spatial lag of the vector.
 
-    >>> import pysal
+    >>> import libpysal.api as ps
     >>> import numpy as np
-    >>> w = pysal.lat2W(3, 3)
+    >>> w = ps.lat2W(3, 3)
     >>> y = np.arange(9)
-    >>> yl = pysal.lag_spatial(w, y)
+    >>> yl = ps.lag_spatial(w, y)
     >>> yl
     array([  4.,   6.,   6.,  10.,  16.,  14.,  10.,  18.,  12.])
 
     Row standardize the weights matrix and recompute the spatial lag
 
     >>> w.transform = 'r'
-    >>> yl = pysal.lag_spatial(w, y)
+    >>> yl = ps.lag_spatial(w, y)
     >>> yl
     array([ 2.        ,  2.        ,  3.        ,  3.33333333,  4.        ,
             4.66666667,  5.        ,  6.        ,  6.        ])
@@ -52,7 +52,7 @@ def lag_spatial(w, y):
     Explicitly define data vector as 9x1 and recompute the spatial lag
 
     >>> y.shape = (9, 1)
-    >>> yl = pysal.lag_spatial(w, y)
+    >>> yl = ps.lag_spatial(w, y)
     >>> yl
     array([[ 2.        ],
            [ 2.        ],
@@ -69,7 +69,7 @@ def lag_spatial(w, y):
     >>> yr = np.arange(8, -1, -1)
     >>> yr.shape = (9, 1)
     >>> x = np.hstack((y, yr))
-    >>> yl = pysal.lag_spatial(w, x)
+    >>> yl = ps.lag_spatial(w, x)
     >>> yl
     array([[ 2.        ,  6.        ],
            [ 2.        ,  6.        ],
@@ -125,19 +125,20 @@ def lag_categorical(w, y, ties='tryself'):
     Set up a 9x9 weights matrix describing a 3x3 regular lattice. Lag one list of
     categorical variables with no ties.
 
-    >>> import pysal
+    >>> import libpysal.api as ps
+    >>> import libpysal
     >>> import numpy as np
     >>> np.random.seed(12345)
-    >>> w = pysal.lat2W(3, 3)
+    >>> w = ps.lat2W(3, 3)
     >>> y = ['a','b','a','b','c','b','c','b','c']
-    >>> y_l = pysal.weights.spatial_lag.lag_categorical(w, y)
+    >>> y_l = libpysal.weights.spatial_lag.lag_categorical(w, y)
     >>> np.array_equal(y_l, np.array(['b', 'a', 'b', 'c', 'b', 'c', 'b', 'c', 'b']))
     True
 
     Explicitly reshape y into a (9x1) array and calculate lag again
 
     >>> yvect = np.array(y).reshape(9,1)
-    >>> yvect_l = pysal.weights.spatial_lag.lag_categorical(w,yvect)
+    >>> yvect_l = libpysal.weights.spatial_lag.lag_categorical(w,yvect)
     >>> check = np.array( [ [i] for i in  ['b', 'a', 'b', 'c', 'b', 'c', 'b', 'c', 'b']] )
     >>> np.array_equal(yvect_l, check)
     True
@@ -146,8 +147,8 @@ def lag_categorical(w, y, ties='tryself'):
 
     >>> y2 = ['a', 'c', 'c', 'd', 'b', 'a', 'd', 'd', 'c']
     >>> ym = np.vstack((y,y2)).T
-    >>> ym_lag = pysal.weights.spatial_lag.lag_categorical(w,ym)
-    >>> check = np.array([['b', 'b'], ['a', 'c'], ['b', 'c'], ['c', 'd'], ['b', 'd'], ['c', 'c'], ['b', 'd'], ['c', 'd'], ['b', 'b']])
+    >>> ym_lag = libpysal.weights.spatial_lag.lag_categorical(w,ym)
+    >>> check = np.array([['b', 'd'], ['a', 'c'], ['b', 'c'], ['c', 'd'], ['b', 'd'], ['c', 'c'], ['b', 'd'], ['c', 'd'], ['b', 'c']])
     >>> np.array_equal(check, ym_lag)
     True
 

--- a/libpysal/weights/spintW.py
+++ b/libpysal/weights/spintW.py
@@ -36,9 +36,10 @@ def ODW(Wo, Wd, transform='r', silent_island_warning=True):
     Examples
     --------
 
-    >>> O = pysal.weights.lat2W(2,2)
-    >>> D = pysal.weights.lat2W(2,2)
-    >>> OD = pysal.weights.spintW.ODW(O,D)
+    >>> import libpysal.api as ps
+    >>> O = ps.lat2W(2,2)
+    >>> D = ps.lat2W(2,2)
+    >>> OD = ps.ODW(O,D)
     >>> OD.weights[0]
     [0.25, 0.25, 0.25, 0.25]
     >>> OD.neighbors[0]
@@ -105,15 +106,16 @@ def netW(link_list, share='A', transform = 'r'):
 
     Examples
     --------
-
+    >>> import libpysal.api as ps
     >>> links = [('a','b'), ('a','c'), ('a','d'), ('c','d'), ('c', 'b'), ('c','a')]
-    >>> O = pysal.weights.spintW.netW(links, share='O')
-    >>> W.neighbors[('a', 'b')]
+    >>> O = ps.netW(links, share='O')
+    >>> O.neighbors[('a', 'b')]
     [('a', 'c'), ('a', 'd')]
-    >>> OD = pysal.weights.spintW.netW(links, share='OD')
+    >>> OD = ps.netW(links, share='OD')
     >>> OD.neighbors[('a', 'b')]
     [('a', 'c'), ('a', 'd'), ('c', 'b')]
-    >>> any_common = pysal.weights.spintW.netw(links, share='A')
+    >>> any_common = ps.netW(links, share='A')
+    >>> any_common.neighbors[('a', 'b')]
     [('a', 'c'), ('a', 'd'), ('c', 'b'), ('c', 'a')]
 
     """
@@ -200,17 +202,17 @@ def vecW(origin_x, origin_y, dest_x, dest_y, threshold, p=2, alpha=-1.0,
 
     Examples
     --------
-
+    >>> import libpysal.api as ps
     >>> x1 = [5,6,3]
     >>> y1 = [1,8,5]
     >>> x2 = [2,4,9]
     >>> y2 = [3,6,1]
-    >>> W1 = pysal.weights.spintW.vecW(x1, y1, x2, y2, threshold=999)
-    >>> W1.neighbors[0]
+    >>> W1 = ps.vecW(x1, y1, x2, y2, threshold=999)
+    >>> list(W1.neighbors[0])
     [1, 2]
-    >>> W2 = pysal.weights.spintW.vecW(x1, y2, x1, y2, threshold=8.5)
-    >>> W2.neighbors[0]
-    [1]
+    >>> W2 = ps.vecW(x1, y2, x1, y2, threshold=8.5)
+    >>> list(W2.neighbors[0])
+    [1, 2]
 
     """
     data = zip(origin_x, origin_y, dest_x, dest_y)

--- a/libpysal/weights/user.py
+++ b/libpysal/weights/user.py
@@ -43,13 +43,15 @@ def queen_from_shapefile(shapefile, idVariable=None, sparse=False):
 
     Examples
     --------
-    >>> wq=queen_from_shapefile(pysal.examples.get_path("columbus.shp"))
+    >>> import libpysal.api as ps
+    >>> import libpysal
+    >>> wq=ps.queen_from_shapefile(libpysal.examples.get_path("columbus.shp"))
     >>> "%.3f"%wq.pct_nonzero
     '9.829'
-    >>> wq=queen_from_shapefile(pysal.examples.get_path("columbus.shp"),"POLYID")
+    >>> wq=ps.queen_from_shapefile(libpysal.examples.get_path("columbus.shp"),"POLYID")
     >>> "%.3f"%wq.pct_nonzero
     '9.829'
-    >>> wq=queen_from_shapefile(pysal.examples.get_path("columbus.shp"), sparse=True)
+    >>> wq=ps.queen_from_shapefile(libpysal.examples.get_path("columbus.shp"), sparse=True)
     >>> pct_sp = wq.sparse.nnz *1. / wq.n**2
     >>> "%.3f"%pct_sp
     '0.098'
@@ -95,10 +97,12 @@ def rook_from_shapefile(shapefile, idVariable=None, sparse=False):
 
     Examples
     --------
-    >>> wr=rook_from_shapefile(pysal.examples.get_path("columbus.shp"), "POLYID")
+    >>> import libpysal.api as ps
+    >>> import libpysal
+    >>> wr=ps.rook_from_shapefile(libpysal.examples.get_path("columbus.shp"), "POLYID")
     >>> "%.3f"%wr.pct_nonzero
     '8.330'
-    >>> wr=rook_from_shapefile(pysal.examples.get_path("columbus.shp"), sparse=True)
+    >>> wr=ps.rook_from_shapefile(libpysal.examples.get_path("columbus.shp"), sparse=True)
     >>> pct_sp = wr.sparse.nnz *1. / wr.n**2
     >>> "%.3f"%pct_sp
     '0.083'
@@ -141,8 +145,8 @@ def spw_from_gal(galfile):
 
     Examples
     --------
-
-    >>> spw = pysal.weights.user.spw_from_gal(pysal.examples.get_path("sids2.gal"))
+    >>> import libpysal
+    >>> spw = libpysal.weights.user.spw_from_gal(libpysal.examples.get_path("sids2.gal"))
     >>> spw.sparse.nnz
     462
 
@@ -185,12 +189,14 @@ def knnW_from_array(array, k=2, p=2, ids=None, radius=None):
     Examples
     --------
     >>> import numpy as np
+    >>> import libpysal.api as ps
+    >>> import libpysal
     >>> x,y=np.indices((5,5))
     >>> x.shape=(25,1)
     >>> y.shape=(25,1)
     >>> data=np.hstack([x,y])
-    >>> wnn2=knnW_from_array(data,k=2)
-    >>> wnn4=knnW_from_array(data,k=4)
+    >>> wnn2=ps.knnW_from_array(data,k=2)
+    >>> wnn4=ps.knnW_from_array(data,k=4)
     >>> set([1, 5, 6, 2]) == set(wnn4.neighbors[0])
     True
     >>> set([0, 1, 10, 6]) == set(wnn4.neighbors[5])
@@ -203,7 +209,7 @@ def knnW_from_array(array, k=2, p=2, ids=None, radius=None):
     '8.00'
     >>> wnn4.pct_nonzero
     16.0
-    >>> wnn4=knnW_from_array(data,k=4)
+    >>> wnn4=ps.knnW_from_array(data,k=4)
     >>> set([ 1,5,6,2]) == set(wnn4.neighbors[0])
     True
 
@@ -257,12 +263,14 @@ def knnW_from_shapefile(shapefile, k=2, p=2, idVariable=None, radius=None):
 
     Polygon shapefile
 
-    >>> wc=knnW_from_shapefile(pysal.examples.get_path("columbus.shp"))
+    >>> import libpysal.api as ps
+    >>> import libpysal
+    >>> wc=ps.knnW_from_shapefile(libpysal.examples.get_path("columbus.shp"))
     >>> "%.4f"%wc.pct_nonzero
     '4.0816'
     >>> set([2,1]) == set(wc.neighbors[0])
     True
-    >>> wc3=pysal.knnW_from_shapefile(pysal.examples.get_path("columbus.shp"),k=3)
+    >>> wc3=ps.knnW_from_shapefile(libpysal.examples.get_path("columbus.shp"),k=3)
     >>> set(wc3.neighbors[0]) == set([2,1,3])
     True
     >>> set(wc3.neighbors[2]) == set([4,3,0])
@@ -270,7 +278,7 @@ def knnW_from_shapefile(shapefile, k=2, p=2, idVariable=None, radius=None):
 
     1 offset rather than 0 offset
 
-    >>> wc3_1=knnW_from_shapefile(pysal.examples.get_path("columbus.shp"),k=3,idVariable="POLYID")
+    >>> wc3_1=ps.knnW_from_shapefile(libpysal.examples.get_path("columbus.shp"),k=3,idVariable="POLYID")
     >>> set([4,3,2]) == set(wc3_1.neighbors[1])
     True
     >>> wc3_1.weights[2]
@@ -281,10 +289,10 @@ def knnW_from_shapefile(shapefile, k=2, p=2, idVariable=None, radius=None):
 
     Point shapefile
 
-    >>> w=knnW_from_shapefile(pysal.examples.get_path("juvenile.shp"))
+    >>> w=ps.knnW_from_shapefile(libpysal.examples.get_path("juvenile.shp"))
     >>> w.pct_nonzero
     1.1904761904761905
-    >>> w1=knnW_from_shapefile(pysal.examples.get_path("juvenile.shp"),k=1)
+    >>> w1=ps.knnW_from_shapefile(libpysal.examples.get_path("juvenile.shp"),k=1)
     >>> "%.3f"%w1.pct_nonzero
     '0.595'
     >>>
@@ -347,14 +355,18 @@ def threshold_binaryW_from_array(array, threshold, p=2, radius=None):
 
     Examples
     --------
+    >>> import libpysal.api as ps
+    >>> import libpysal
     >>> points=[(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
-    >>> wcheck = pysal.W({0: [1, 3], 1: [0, 3, ], 2: [], 3: [1, 0], 4: [5], 5: [4]})
+    >>> wcheck = ps.W({0: [1, 3], 1: [0, 3, ], 2: [], 3: [1, 0], 4: [5], 5: [4]})
+
     WARNING: there is one disconnected observation (no neighbors)
     Island id:  [2]
-    >>> w=threshold_binaryW_from_array(points,threshold=11.2)
+    >>> w=ps.threshold_binaryW_from_array(points,threshold=11.2)
+
     WARNING: there is one disconnected observation (no neighbors)
     Island id:  [2]
-    >>> pysal.weights.util.neighbor_equality(w, wcheck)
+    >>> libpysal.weights.util.neighbor_equality(w, wcheck)
     True
 
     >>>
@@ -395,9 +407,11 @@ def threshold_binaryW_from_shapefile(shapefile, threshold, p=2, idVariable=None,
 
     Examples
     --------
-    >>> w = threshold_binaryW_from_shapefile(pysal.examples.get_path("columbus.shp"),0.62,idVariable="POLYID")
+    >>> import libpysal.api as ps
+    >>> import libpysal
+    >>> w = ps.threshold_binaryW_from_shapefile(libpysal.examples.get_path("columbus.shp"),0.62,idVariable="POLYID")
     >>> w.weights[1]
-    [1, 1]
+    [1.0, 1.0]
 
     Notes
     -----
@@ -456,8 +470,11 @@ def threshold_continuousW_from_array(array, threshold, p=2,
 
     inverse distance weights
 
+    >>> import libpysal.api as ps
+    >>> import libpysal
     >>> points=[(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
-    >>> wid=threshold_continuousW_from_array(points,11.2)
+    >>> wid=ps.threshold_continuousW_from_array(points,11.2)
+
     WARNING: there is one disconnected observation (no neighbors)
     Island id:  [2]
     >>> wid.weights[0]
@@ -465,7 +482,8 @@ def threshold_continuousW_from_array(array, threshold, p=2,
 
     gravity weights
 
-    >>> wid2=threshold_continuousW_from_array(points,11.2,alpha=-2.0)
+    >>> wid2=ps.threshold_continuousW_from_array(points,11.2,alpha=-2.0)
+
     WARNING: there is one disconnected observation (no neighbors)
     Island id:  [2]
     >>> wid2.weights[0]
@@ -515,7 +533,9 @@ def threshold_continuousW_from_shapefile(shapefile, threshold, p=2,
 
     Examples
     --------
-    >>> w = threshold_continuousW_from_shapefile(pysal.examples.get_path("columbus.shp"),0.62,idVariable="POLYID")
+    >>> import libpysal.api as ps
+    >>> import libpysal
+    >>> w = ps.threshold_continuousW_from_shapefile(libpysal.examples.get_path("columbus.shp"),0.62,idVariable="POLYID")
     >>> w.weights[1]
     [1.6702346893743334, 1.7250729841938093]
 
@@ -628,8 +648,9 @@ def kernelW(points, k=2, function='triangular', fixed=True,
 
     Examples
     --------
+    >>> import libpysal.api as ps
     >>> points=[(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
-    >>> kw=kernelW(points)
+    >>> kw=ps.kernelW(points)
     >>> kw.weights[0]
     [1.0, 0.500000049999995, 0.4409830615267465]
     >>> kw.neighbors[0]
@@ -644,7 +665,7 @@ def kernelW(points, k=2, function='triangular', fixed=True,
 
     use different k
 
-    >>> kw=kernelW(points,k=3)
+    >>> kw=ps.kernelW(points,k=3)
     >>> kw.neighbors[0]
     [0, 1, 3, 4]
     >>> kw.bandwidth
@@ -657,10 +678,10 @@ def kernelW(points, k=2, function='triangular', fixed=True,
 
     Diagonals to 1.0
 
-    >>> kq = kernelW(points,function='gaussian')
+    >>> kq = ps.kernelW(points,function='gaussian')
     >>> kq.weights
     {0: [0.3989422804014327, 0.35206533556593145, 0.3412334260702758], 1: [0.35206533556593145, 0.3989422804014327, 0.2419707487162134, 0.3412334260702758, 0.31069657591175387], 2: [0.2419707487162134, 0.3989422804014327, 0.31069657591175387], 3: [0.3412334260702758, 0.3412334260702758, 0.3989422804014327, 0.3011374490937829, 0.26575287272131043], 4: [0.31069657591175387, 0.31069657591175387, 0.3011374490937829, 0.3989422804014327, 0.35206533556593145], 5: [0.26575287272131043, 0.35206533556593145, 0.3989422804014327]}
-    >>> kqd = kernelW(points, function='gaussian', diagonal=True)
+    >>> kqd = ps.kernelW(points, function='gaussian', diagonal=True)
     >>> kqd.weights
     {0: [1.0, 0.35206533556593145, 0.3412334260702758], 1: [0.35206533556593145, 1.0, 0.2419707487162134, 0.3412334260702758, 0.31069657591175387], 2: [0.2419707487162134, 1.0, 0.31069657591175387], 3: [0.3412334260702758, 0.3412334260702758, 1.0, 0.3011374490937829, 0.26575287272131043], 4: [0.31069657591175387, 0.31069657591175387, 0.3011374490937829, 1.0, 0.35206533556593145], 5: [0.26575287272131043, 0.35206533556593145, 1.0]}
 
@@ -757,9 +778,11 @@ def kernelW_from_shapefile(shapefile, k=2, function='triangular',
 
     Examples
     --------
-    >>> kw = pysal.kernelW_from_shapefile(pysal.examples.get_path("columbus.shp"),idVariable='POLYID', function = 'gaussian')
+    >>> import libpysal.api as ps
+    >>> import libpysal
+    >>> kw = ps.kernelW_from_shapefile(libpysal.examples.get_path("columbus.shp"),idVariable='POLYID', function = 'gaussian')
 
-    >>> kwd = pysal.kernelW_from_shapefile(pysal.examples.get_path("columbus.shp"),idVariable='POLYID', function = 'gaussian', diagonal = True)
+    >>> kwd = ps.kernelW_from_shapefile(libpysal.examples.get_path("columbus.shp"),idVariable='POLYID', function = 'gaussian', diagonal = True)
     >>> set(kw.neighbors[1]) == set([4, 2, 3, 1])
     True
     >>> set(kwd.neighbors[1]) == set([4, 2, 3, 1])
@@ -869,9 +892,10 @@ def adaptive_kernelW(points, bandwidths=None, k=2, function='triangular',
 
     User specified bandwidths
 
+    >>> import libpysal.api as ps
     >>> points=[(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
     >>> bw=[25.0,15.0,25.0,16.0,14.5,25.0]
-    >>> kwa=adaptive_kernelW(points,bandwidths=bw)
+    >>> kwa=ps.adaptive_kernelW(points,bandwidths=bw)
     >>> kwa.weights[0]
     [1.0, 0.6, 0.552786404500042, 0.10557280900008403]
     >>> kwa.neighbors[0]
@@ -886,7 +910,7 @@ def adaptive_kernelW(points, bandwidths=None, k=2, function='triangular',
 
     Endogenous adaptive bandwidths
 
-    >>> kwea=adaptive_kernelW(points)
+    >>> kwea=ps.adaptive_kernelW(points)
     >>> kwea.weights[0]
     [1.0, 0.10557289844279438, 9.99999900663795e-08]
     >>> kwea.neighbors[0]
@@ -901,7 +925,7 @@ def adaptive_kernelW(points, bandwidths=None, k=2, function='triangular',
 
     Endogenous adaptive bandwidths with Gaussian kernel
 
-    >>> kweag=adaptive_kernelW(points,function='gaussian')
+    >>> kweag=ps.adaptive_kernelW(points,function='gaussian')
     >>> kweag.weights[0]
     [0.3989422804014327, 0.2674190291577696, 0.2419707487162134]
     >>> kweag.bandwidth
@@ -914,8 +938,8 @@ def adaptive_kernelW(points, bandwidths=None, k=2, function='triangular',
 
     with diagonal
 
-    >>> kweag = pysal.adaptive_kernelW(points, function='gaussian')
-    >>> kweagd = pysal.adaptive_kernelW(points, function='gaussian', diagonal=True)
+    >>> kweag = ps.adaptive_kernelW(points, function='gaussian')
+    >>> kweagd = ps.adaptive_kernelW(points, function='gaussian', diagonal=True)
     >>> kweag.neighbors[0]
     [0, 1, 3]
     >>> kweagd.neighbors[0]
@@ -1008,8 +1032,10 @@ def adaptive_kernelW_from_shapefile(shapefile, bandwidths=None, k=2, function='t
 
     Examples
     --------
-    >>> kwa = pysal.adaptive_kernelW_from_shapefile(pysal.examples.get_path("columbus.shp"), function='gaussian')
-    >>> kwad = pysal.adaptive_kernelW_from_shapefile(pysal.examples.get_path("columbus.shp"), function='gaussian', diagonal=True)
+    >>> import libpysal.api as ps
+    >>> import libpysal
+    >>> kwa = ps.adaptive_kernelW_from_shapefile(libpysal.examples.get_path("columbus.shp"), function='gaussian')
+    >>> kwad = ps.adaptive_kernelW_from_shapefile(libpysal.examples.get_path("columbus.shp"), function='gaussian', diagonal=True)
     >>> kwa.neighbors[0]
     [0, 2, 1]
     >>> kwad.neighbors[0]
@@ -1064,10 +1090,12 @@ def min_threshold_dist_from_shapefile(shapefile, radius=None, p=2):
 
     Examples
     --------
-    >>> md = min_threshold_dist_from_shapefile(pysal.examples.get_path("columbus.shp"))
+    >>> import libpysal.api as ps
+    >>> import libpysal
+    >>> md = ps.min_threshold_dist_from_shapefile(libpysal.examples.get_path("columbus.shp"))
     >>> md
     0.61886415807685413
-    >>> min_threshold_dist_from_shapefile(pysal.examples.get_path("stl_hom.shp"), pysal.cg.sphere.RADIUS_EARTH_MILES)
+    >>> ps.min_threshold_dist_from_shapefile(libpysal.examples.get_path("stl_hom.shp"), libpysal.cg.sphere.RADIUS_EARTH_MILES)
     31.846942936393717
 
     Notes

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -50,7 +50,7 @@ def hexLat2W(nrows=5, ncols=5):
     Examples
     --------
 
-    >>> import pysal as ps
+    >>> import libpysal.api as ps
     >>> w = ps.lat2W()
     >>> w.neighbors[1]
     [0, 6, 2]
@@ -140,8 +140,8 @@ def lat2W(nrows=5, ncols=5, rook=True, id_type='int'):
     Examples
     --------
 
-    >>> from pysal import lat2W
-    >>> w9 = lat2W(3,3)
+    >>> import libpysal.api as ps
+    >>> w9 = ps.lat2W(3,3)
     >>> "%.3f"%w9.pct_nonzero
     '29.630'
     >>> w9[0]
@@ -224,7 +224,7 @@ def regime_weights(regimes):
     Examples
     --------
 
-    >>> from pysal import regime_weights
+    >>> import libpysal.api as ps
     >>> import numpy as np
     >>> regimes = np.ones(25)
     >>> regimes[range(10,20)] = 2
@@ -232,7 +232,7 @@ def regime_weights(regimes):
     >>> regimes
     array([ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  2.,  2.,  2.,
             2.,  2.,  2.,  2.,  2.,  2.,  2.,  1.,  3.,  3.,  3.,  3.])
-    >>> w = regime_weights(regimes)
+    >>> w = ps.regime_weights(regimes)
     PendingDepricationWarning: regime_weights will be renamed to block_weights in PySAL 2.0
     >>> w.weights[0]
     [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
@@ -240,7 +240,7 @@ def regime_weights(regimes):
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 20]
     >>> regimes = ['n','n','s','s','e','e','w','w','e']
     >>> n = len(regimes)
-    >>> w = regime_weights(regimes)
+    >>> w = ps.regime_weights(regimes)
     PendingDepricationWarning: regime_weights will be renamed to block_weights in PySAL 2.0
     >>> w.neighbors
     {0: [1], 1: [0], 2: [3], 3: [2], 4: [5, 8], 5: [4, 8], 6: [7], 7: [6], 8: [4, 5]}
@@ -284,7 +284,7 @@ def block_weights(regimes, ids=None, sparse=False):
     Examples
     --------
 
-    >>> from pysal import block_weights
+    >>> import libpysal.api as ps
     >>> import numpy as np
     >>> regimes = np.ones(25)
     >>> regimes[range(10,20)] = 2
@@ -292,14 +292,14 @@ def block_weights(regimes, ids=None, sparse=False):
     >>> regimes
     array([ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  2.,  2.,  2.,
             2.,  2.,  2.,  2.,  2.,  2.,  2.,  1.,  3.,  3.,  3.,  3.])
-    >>> w = block_weights(regimes)
+    >>> w = ps.block_weights(regimes)
     >>> w.weights[0]
     [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
     >>> w.neighbors[0]
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 20]
     >>> regimes = ['n','n','s','s','e','e','w','w','e']
     >>> n = len(regimes)
-    >>> w = block_weights(regimes)
+    >>> w = ps.block_weights(regimes)
     >>> w.neighbors
     {0: [1], 1: [0], 2: [3], 3: [2], 4: [5, 8], 5: [4, 8], 6: [7], 7: [6], 8: [4, 5]}
     """
@@ -390,8 +390,10 @@ def order(w, kmax=3):
 
     Examples
     --------
-    >>> from pysal import rook_from_shapefile as rfs
-    >>> w = rfs(pysal.examples.get_path('10740.shp'))
+    >>> import libpysal.api as ps
+    >>> import libpysal
+    >>> w = ps.rook_from_shapefile(libpysal.examples.get_path('10740.shp'))
+
     WARNING: there is one disconnected observation (no neighbors)
     Island id:  [163]
     >>> w3 = order(w, kmax = 3)
@@ -399,7 +401,7 @@ def order(w, kmax=3):
     [1, -1, 1, 2, 1]
 
     """
-    #ids = w.neighbors.keys()
+
     ids = w.id_order
     info = {}
     for id_ in ids:
@@ -450,17 +452,17 @@ def higher_order(w, k=2):
 
     Examples
     --------
-    >>> from pysal import lat2W, higher_order
-    >>> w10 = lat2W(10, 10)
-    >>> w10_2 = higher_order(w10, 2)
+    >>> import libpysal.api as ps
+    >>> w10 = ps.lat2W(10, 10)
+    >>> w10_2 = ps.higher_order(w10, 2)
     >>> w10_2[0]
     {2: 1.0, 11: 1.0, 20: 1.0}
-    >>> w5 = lat2W()
+    >>> w5 = ps.lat2W()
     >>> w5[0]
     {1: 1.0, 5: 1.0}
     >>> w5[1]
     {0: 1.0, 2: 1.0, 6: 1.0}
-    >>> w5_2 = higher_order(w5,2)
+    >>> w5_2 = ps.higher_order(w5,2)
     >>> w5_2[0]
     {10: 1.0, 2: 1.0, 6: 1.0}
     """
@@ -502,22 +504,23 @@ def higher_order_sp(w, k=2, shortest_path=True, diagonal=False):
     Examples
     --------
 
-    >>> import pysal
-    >>> w25 = pysal.lat2W(5,5)
+    >>> import libpysal.api as ps
+    >>> import libpysal
+    >>> w25 = ps.lat2W(5,5)
     >>> w25.n
     25
     >>> w25[0]
     {1: 1.0, 5: 1.0}
-    >>> w25_2 = pysal.weights.util.higher_order_sp(w25, 2)
+    >>> w25_2 = libpysal.weights.util.higher_order_sp(w25, 2)
     >>> w25_2[0]
     {10: 1.0, 2: 1.0, 6: 1.0}
-    >>> w25_2 = pysal.weights.util.higher_order_sp(w25, 2, diagonal=True)
+    >>> w25_2 = libpysal.weights.util.higher_order_sp(w25, 2, diagonal=True)
     >>> w25_2[0]
     {0: 1.0, 10: 1.0, 2: 1.0, 6: 1.0}
-    >>> w25_3 = pysal.weights.util.higher_order_sp(w25, 3)
+    >>> w25_3 = libpysal.weights.util.higher_order_sp(w25, 3)
     >>> w25_3[0]
     {15: 1.0, 3: 1.0, 11: 1.0, 7: 1.0}
-    >>> w25_3 = pysal.weights.util.higher_order_sp(w25, 3, shortest_path=False)
+    >>> w25_3 = libpysal.weights.util.higher_order_sp(w25, 3, shortest_path=False)
     >>> w25_3[0]
     {1: 1.0, 3: 1.0, 5: 1.0, 7: 1.0, 11: 1.0, 15: 1.0}
 
@@ -602,8 +605,8 @@ def w_local_cluster(w):
 
     Examples
     --------
-
-    >>> w = pysal.lat2W(3,3, rook=False)
+    >>> import libpysal.api as ps
+    >>> w = ps.lat2W(3,3, rook=False)
     >>> w_local_cluster(w)
     array([[ 1.        ],
            [ 0.6       ],
@@ -645,9 +648,9 @@ def shimbel(w):
 
     Examples
     --------
-    >>> from pysal import lat2W, shimbel
-    >>> w5 = lat2W()
-    >>> w5_shimbel = shimbel(w5)
+    >>> import libpysal.api as ps
+    >>> w5 = ps.lat2W()
+    >>> w5_shimbel = ps.shimbel(w5)
     >>> w5_shimbel[0][24]
     8
     >>> w5_shimbel[0][0:4]
@@ -698,11 +701,11 @@ def full(w):
 
     Examples
     --------
-    >>> from pysal import W, full
+    >>> import libpysal.api as ps
     >>> neighbors = {'first':['second'],'second':['first','third'],'third':['second']}
     >>> weights = {'first':[1],'second':[1,1],'third':[1]}
-    >>> w = W(neighbors, weights)
-    >>> wf, ids = full(w)
+    >>> w = ps.W(neighbors, weights)
+    >>> wf, ids = ps.full(w)
     >>> wf
     array([[ 0.,  1.,  0.],
            [ 1.,  0.,  1.],
@@ -730,7 +733,7 @@ def full2W(m, ids=None):
 
     Examples
     --------
-    >>> import pysal as ps
+    >>> import libpysal
     >>> import numpy as np
 
     Create an array of zeros
@@ -746,7 +749,7 @@ def full2W(m, ids=None):
 
     Create W object
 
-    >>> w = ps.weights.util.full2W(a)
+    >>> w = libpysal.weights.util.full2W(a)
     >>> w.full()[0] == a
     array([[ True,  True,  True,  True],
            [ True,  True,  True,  True],
@@ -756,7 +759,7 @@ def full2W(m, ids=None):
     Create list of user ids
 
     >>> ids = ['myID0', 'myID1', 'myID2', 'myID3']
-    >>> w = ps.weights.util.full2W(a, ids=ids)
+    >>> w = libpysal.weights.util.full2W(a, ids=ids)
     >>> w.full()[0] == a
     array([[ True,  True,  True,  True],
            [ True,  True,  True,  True],
@@ -800,13 +803,13 @@ def WSP2W(wsp, silent_island_warning=False):
 
     Examples
     --------
-    >>> import pysal
+    >>> import libpysal.api as ps
 
     Build a 10x10 scipy.sparse matrix for a rectangular 2x5 region of cells
     (rook contiguity), then construct a PySAL sparse weights object (wsp).
 
-    >>> sp = pysal.weights.lat2SW(2, 5)
-    >>> wsp = WSP(sp)
+    >>> sp = ps.lat2SW(2, 5)
+    >>> wsp = ps.WSP(sp)
     >>> wsp.n
     10
     >>> print wsp.sparse[0].todense()
@@ -814,7 +817,7 @@ def WSP2W(wsp, silent_island_warning=False):
 
     Convert this sparse weights object to a standard PySAL weights object.
 
-    >>> w = pysal.weights.WSP2W(wsp)
+    >>> w = ps.WSP2W(wsp)
     >>> w.n
     10
     >>> print w.full()[0][0]
@@ -877,14 +880,14 @@ def fill_diagonal(w, val=1.0, wsp=False):
 
     Examples
     --------
-    >>> import pysal
+    >>> import libpysal.api as ps
     >>> import numpy as np
 
     Build a basic rook weights matrix, which has zeros on the diagonal, then
     insert ones along the diagonal.
 
-    >>> w = pysal.lat2W(5, 5, id_type='string')
-    >>> w_const = pysal.weights.insert_diagonal(w)
+    >>> w = ps.lat2W(5, 5, id_type='string')
+    >>> w_const = ps.insert_diagonal(w)
     >>> w['id0']
     {'id5': 1.0, 'id1': 1.0}
     >>> w_const['id0']
@@ -893,7 +896,7 @@ def fill_diagonal(w, val=1.0, wsp=False):
     Insert different values along the main diagonal.
 
     >>> diag = np.arange(100, 125)
-    >>> w_var = pysal.weights.insert_diagonal(w, diag)
+    >>> w_var = ps.insert_diagonal(w, diag)
     >>> w_var['id0']
     {'id5': 1.0, 'id0': 100.0, 'id1': 1.0}
 
@@ -942,14 +945,14 @@ def remap_ids(w, old2new, id_order=[]):
 
     Examples
     --------
-    >>> from pysal import lat2W, remap_ids
-    >>> w = lat2W(3,2)
+    >>> import libpysal.api as ps
+    >>> w = ps.lat2W(3,2)
     >>> w.id_order
     [0, 1, 2, 3, 4, 5]
     >>> w.neighbors[0]
     [2, 1]
     >>> old_to_new = {0:'a', 1:'b', 2:'c', 3:'d', 4:'e', 5:'f'}
-    >>> w_new = remap_ids(w, old_to_new)
+    >>> w_new = ps.remap_ids(w, old_to_new)
     >>> w_new.id_order
     ['a', 'b', 'c', 'd', 'e', 'f']
     >>> w_new.neighbors['a']
@@ -994,8 +997,9 @@ def get_ids(shapefile, idVariable):
 
     Examples
     --------
-    >>> from pysal.weights.util import get_ids
-    >>> polyids = get_ids(pysal.examples.get_path("columbus.shp"), "POLYID")
+    >>> from libpysal.weights.util import get_ids
+    >>> import libpysal
+    >>> polyids = get_ids(libpysal.examples.get_path("columbus.shp"), "POLYID")
     >>> polyids[:5]
     [1, 2, 3, 4, 5]
     """
@@ -1066,8 +1070,9 @@ def get_points_array_from_shapefile(shapefile):
     --------
     Point shapefile
 
-    >>> from pysal.weights.util import get_points_array_from_shapefile
-    >>> xy = get_points_array_from_shapefile(pysal.examples.get_path('juvenile.shp'))
+    >>> import libpysal
+    >>> from libpysal.weights.util import get_points_array_from_shapefile
+    >>> xy = get_points_array_from_shapefile(libpysal.examples.get_path('juvenile.shp'))
     >>> xy[:3]
     array([[ 94.,  93.],
            [ 80.,  95.],
@@ -1075,7 +1080,7 @@ def get_points_array_from_shapefile(shapefile):
 
     Polygon shapefile
 
-    >>> xy = get_points_array_from_shapefile(pysal.examples.get_path('columbus.shp'))
+    >>> xy = get_points_array_from_shapefile(libpysal.examples.get_path('columbus.shp'))
     >>> xy[:3]
     array([[  8.82721847,  14.36907602],
            [  8.33265837,  14.03162401],
@@ -1110,7 +1115,7 @@ def min_threshold_distance(data, p=2):
 
     Examples
     --------
-    >>> from pysal.weights.util import min_threshold_distance
+    >>> from libpysal.weights.util import min_threshold_distance
     >>> import numpy as np
     >>> x, y = np.indices((5, 5))
     >>> x.shape = (25, 1)
@@ -1162,13 +1167,13 @@ def lat2SW(nrows=3, ncols=5, criterion="rook", row_st=False):
     Examples
     --------
 
-    >>> from pysal import weights
-    >>> w9 = weights.lat2SW(3,3)
+    >>> import libpysal.api as ps
+    >>> w9 = ps.lat2SW(3,3)
     >>> w9[0,1]
     1
     >>> w9[3,6]
     1
-    >>> w9r = weights.lat2SW(3,3, row_st=True)
+    >>> w9r = ps.lat2SW(3,3, row_st=True)
     >>> w9r[3,6]
     0.33333333333333331
     """
@@ -1246,25 +1251,26 @@ def neighbor_equality(w1, w2):
 
     Examples
     --------
-    >>> from pysal.weights.util import neighbor_equality
-    >>> w1 = pysal.lat2W(3,3)
-    >>> w2 = pysal.lat2W(3,3)
+    >>> from libpysal.weights.util import neighbor_equality
+    >>> import libpysal.api as ps
+    >>> w1 = ps.lat2W(3,3)
+    >>> w2 = ps.lat2W(3,3)
     >>> neighbor_equality(w1, w2)
     True
-    >>> w3 = pysal.lat2W(5,5)
+    >>> w3 = ps.lat2W(5,5)
     >>> neighbor_equality(w1, w3)
     False
     >>> n4 = w1.neighbors.copy()
     >>> n4[0] = [1]
     >>> n4[1] = [4, 2]
-    >>> w4 = pysal.W(n4)
+    >>> w4 = ps.W(n4)
     >>> neighbor_equality(w1, w4)
     False
     >>> n5 = w1.neighbors.copy()
     >>> n5[0]
     [3, 1]
     >>> n5[0] = [1, 3]
-    >>> w5 = pysal.W(n5)
+    >>> w5 = ps.W(n5)
     >>> neighbor_equality(w1, w5)
     True
 

--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -22,26 +22,26 @@ class W(object):
 
     Parameters
     ----------
-    neighbors       : dictionary
-                      key is region ID, value is a list of neighbor IDS
-                      Example:  {'a':['b'],'b':['a','c'],'c':['b']}
-    weights : dictionary
-                      key is region ID, value is a list of edge weights
-                      If not supplied all edge weights are assumed to have a weight of 1.
-                      Example: {'a':[0.5],'b':[0.5,1.5],'c':[1.5]}
-    id_order : list
-                      An ordered list of ids, defines the order of
-                      observations when iterating over W if not set,
-                      lexicographical ordering is used to iterate and the
-                      id_order_set property will return False.  This can be
-                      set after creation by setting the 'id_order' property.
-    silent_island_warning   : boolean
-                            By default PySAL will print a warning if the
-                            dataset contains any disconnected observations or
-                            islands. To silence this warning set this
-                            parameter to True.
-    ids : list
-                      values to use for keys of the neighbors and weights dicts
+    neighbors            : dictionary
+                           Key is region ID, value is a list of neighbor IDS.
+                           Example:  {'a':['b'],'b':['a','c'],'c':['b']}
+    weights              : dictionary
+                           Key is region ID, value is a list of edge weights.
+                           If not supplied all edge weights are assumed to have a weight of 1.
+                           Example: {'a':[0.5],'b':[0.5,1.5],'c':[1.5]}
+    id_order             : list
+                           An ordered list of ids, defines the order of
+                           observations when iterating over W if not set,
+                           lexicographical ordering is used to iterate and the
+                           id_order_set property will return False. This can be
+                           set after creation by setting the 'id_order' property.
+    silent_island_warning: boolean
+                           By default libpysal will print a warning if the
+                           dataset contains any disconnected observations or
+                           islands. To silence this warning set this
+                           parameter to True.
+    ids                  : list
+                           Values to use for keys of the neighbors and weights dicts.
 
     Attributes
     ----------
@@ -107,7 +107,8 @@ class W(object):
 
     Examples
     --------
-    >>> from pysal import W, lat2W
+    >>> from libpysal.api import W, lat2W
+    >>> import libpysal.api as ps
     >>> neighbors = {0: [3, 1], 1: [0, 4, 2], 2: [1, 5], 3: [0, 6, 4], 4: [1, 3, 7, 5], 5: [2, 4, 8], 6: [3, 7], 7: [4, 6, 8], 8: [5, 7]}
     >>> weights = {0: [1, 1], 1: [1, 1, 1], 2: [1, 1], 3: [1, 1, 1], 4: [1, 1, 1, 1], 5: [1, 1, 1], 6: [1, 1], 7: [1, 1, 1], 8: [1, 1]}
     >>> w = W(neighbors, weights)
@@ -116,8 +117,8 @@ class W(object):
 
     Read from external gal file
 
-    >>> import pysal
-    >>> w = pysal.open(pysal.examples.get_path("stl.gal")).read()
+    >>> import libpysal
+    >>> w = libpysal.open(libpysal.examples.get_path("stl.gal")).read()
     >>> w.n
     78
     >>> "%.3f"%w.pct_nonzero
@@ -141,14 +142,15 @@ class W(object):
     2533.667
 
     Cardinality Histogram
-
-    >>> w=pysal.rook_from_shapefile(pysal.examples.get_path("sacramentot2.shp"))
+    >>> import libpysal.api as ps
+    >>> w=ps.rook_from_shapefile(libpysal.examples.get_path("sacramentot2.shp"))
     >>> w.histogram
     [(1, 1), (2, 6), (3, 33), (4, 103), (5, 114), (6, 73), (7, 35), (8, 17), (9, 9), (10, 4), (11, 4), (12, 3), (13, 0), (14, 1)]
 
     Disconnected observations (islands)
 
-    >>> w = pysal.W({1:[0],0:[1],2:[], 3:[]})
+    >>> w = ps.W({1:[0],0:[1],2:[], 3:[]})
+
     WARNING: there are 2 disconnected observations
     Island ids:  [2, 3]
 
@@ -642,14 +644,16 @@ class W(object):
 
         Examples
         --------
-        >>> from pysal import rook_from_shapefile as rfs
-        >>> w = rfs(pysal.examples.get_path("10740.shp"))
+        >>> import libpysal.api as ps
+        >>> import libpysal
+        >>> w = ps.rook_from_shapefile(libpysal.examples.get_path("10740.shp"))
+
         WARNING: there is one disconnected observation (no neighbors)
         Island id:  [163]
         >>> w[163]
         {}
         >>> w[0]
-        {1: 1.0, 4: 1.0, 101: 1.0, 85: 1.0, 5: 1.0}
+        {1: 1.0, 5: 1.0, 4: 1.0, 101: 1.0, 85: 1.0}
         """
         return dict(zip(self.neighbors[key], self.weights[key]))
 
@@ -659,8 +663,8 @@ class W(object):
 
         Examples
         --------
-        >>> import pysal
-        >>> w=pysal.lat2W(3,3)
+        >>> import libpysal.api as ps
+        >>> w=ps.lat2W(3,3)
         >>> for i,wi in enumerate(w):
         ...     print i,wi
         ...
@@ -698,7 +702,7 @@ class W(object):
         Example
         -------
 
-        >>> import pysal as ps
+        >>> import libpysal.api as ps
         >>> w = ps.lat2W(3, 3)
         >>> w.id_order
         [0, 1, 2, 3, 4, 5, 6, 7, 8]
@@ -763,8 +767,8 @@ class W(object):
         Examples
         --------
 
-        >>> import pysal
-        >>> w=pysal.lat2W(3,3)
+        >>> import libpysal.api as ps
+        >>> w=ps.lat2W(3,3)
         >>> for i,wi in enumerate(w):
         ...     print i,wi
         ...
@@ -821,7 +825,7 @@ class W(object):
 
         Examples
         --------
-        >>> from pysal import lat2W
+        >>> from libpysal.api import lat2W
         >>> w=lat2W()
         >>> w.id_order_set
         True
@@ -841,7 +845,7 @@ class W(object):
 
         Examples
         --------
-        >>> from pysal import W
+        >>> from libpysal.api import W
         >>> neighbors={'c': ['b'], 'b': ['c', 'a'], 'a': ['b']}
         >>> weights ={'c': [1.0], 'b': [1.0, 1.0], 'a': [1.0]}
         >>> w=W(neighbors,weights)
@@ -871,7 +875,7 @@ class W(object):
 
         Examples
         --------
-        >>> from pysal import lat2W
+        >>> from libpysal.api import lat2W
         >>> w=lat2W()
         >>> w.weights[0]
         [1.0, 1.0]
@@ -921,7 +925,7 @@ class W(object):
 
         Examples
         --------
-        >>> from pysal import lat2W
+        >>> from libpysal.api import lat2W
         >>> w=lat2W()
         >>> w.weights[0]
         [1.0, 1.0]
@@ -1038,7 +1042,7 @@ class W(object):
         Examples
         --------
 
-        >>> from pysal import lat2W
+        >>> from libpysal.api import lat2W
         >>> w=lat2W(3,3)
         >>> w.asymmetry()
         []
@@ -1114,7 +1118,7 @@ class W(object):
 
         Examples
         --------
-        >>> from pysal import W, full
+        >>> from libpysal.api import W, full
         >>> neighbors = {'first':['second'],'second':['first','third'],'third':['second']}
         >>> weights = {'first':[1],'second':[1,1],'third':[1]}
         >>> w = W(neighbors, weights)
@@ -1151,12 +1155,12 @@ class W(object):
 
         Examples
         --------
-        >>> import pysal as ps
-        >>> from pysal import W
+        >>> import libpysal as ps
+        >>> from libpysal.api import W
         >>> neighbors={'first':['second'],'second':['first','third'],'third':['second']}
         >>> weights={'first':[1],'second':[1,1],'third':[1]}
         >>> w=W(neighbors,weights)
-        >>> wsp=w.towsp()
+        >>> wsp=w.to_WSP()
         >>> isinstance(wsp, ps.weights.weights.WSP)
         True
         >>> wsp.n
@@ -1229,12 +1233,12 @@ class WSP(object):
     From GAL information
 
     >>> import scipy.sparse
-    >>> import pysal
+    >>> import libpysal.api as ps
     >>> rows = [0, 1, 1, 2, 2, 3]
     >>> cols = [1, 0, 2, 1, 3, 3]
     >>> weights =  [1, 0.75, 0.25, 0.9, 0.1, 1]
     >>> sparse = scipy.sparse.csr_matrix((weights, (rows, cols)), shape=(4,4))
-    >>> w = pysal.weights.WSP(sparse)
+    >>> w = ps.WSP(sparse)
     >>> w.s0
     4.0
     >>> w.trcWtW_WW
@@ -1302,7 +1306,7 @@ class WSP(object):
 
         Arguments
         ---------
-        W       :   pysal.weights.W
+        W       :   libpysal.weights.W
                     a pysal weights object with a sparse form and ids
 
         Returns
@@ -1331,12 +1335,12 @@ class WSP(object):
 
         Examples
         --------
-        >>> import pysal
+        >>> import libpysal.api as ps
 
         Build a 10x10 scipy.sparse matrix for a rectangular 2x5 region of cells
-        (rook contiguity), then construct a PySAL sparse weights object (self).
+        (rook contiguity), then construct a libpysal sparse weights object (self).
 
-        >>> sp = pysal.weights.lat2SW(2, 5)
+        >>> sp = ps.lat2SW(2, 5)
         >>> self = WSP(sp)
         >>> self.n
         10
@@ -1345,7 +1349,7 @@ class WSP(object):
 
         Convert this sparse weights object to a standard PySAL weights object.
 
-        >>> w = pysal.weights.WSP2W(self)
+        >>> w = ps.WSP2W(self)
         >>> w.n
         10
         >>> print w.full()[0][0]


### PR DESCRIPTION
This PR is to update doctests in `weights` module to use `libpysal` instead of `pysal`. Now all the doctests in `weights` module are passed. The [doctest](https://github.com/pysal/libpysal/blob/master/libpysal/weights/Wsets.py#L490) involving the mutual dependence issue #26 is commented for now and would be uncommented once the issue is resolved.
