### PR TITLE
add a function to attach the nearest neighbor to island

### DIFF
--- a/libpysal/api.py
+++ b/libpysal/api.py
@@ -14,7 +14,7 @@ from .weights.user import threshold_binaryW_from_shapefile, threshold_continuous
 from .weights.user import threshold_continuousW_from_shapefile, kernelW, kernelW_from_shapefile
 from .weights.user import adaptive_kernelW, adaptive_kernelW_from_shapefile
 from .weights.user import min_threshold_dist_from_shapefile, build_lattice_shapefile
-from .weights.util import lat2W, block_weights, comb, order, higher_order, shimbel, remap_ids, full2W, full, WSP2W, insert_diagonal, get_ids, get_points_array_from_shapefile, min_threshold_distance, lat2SW, w_local_cluster, higher_order_sp, hexLat2W, regime_weights
+from .weights.util import lat2W, block_weights, comb, order, higher_order, shimbel, remap_ids, full2W, full, WSP2W, insert_diagonal, get_ids, get_points_array_from_shapefile, min_threshold_distance, lat2SW, w_local_cluster, higher_order_sp, hexLat2W, regime_weights, attach_islands
 from .weights.spatial_lag import lag_spatial, lag_categorical
 from .weights.Contiguity import Rook, Queen
 from .weights.Distance import KNN, Kernel, DistanceBand

--- a/libpysal/weights/tests/test_util.py
+++ b/libpysal/weights/tests/test_util.py
@@ -209,6 +209,13 @@ class Testutil(unittest.TestCase):
         self.assertEquals(
             mint, util.min_threshold_distance(data))
 
+    def test_attach_islands(self):
+        w = user.rook_from_shapefile(pysal_examples.get_path('10740.shp'))
+        w_knn1 = user.knnW_from_shapefile(pysal_examples.get_path('10740.shp'), k=1)
+        w_attach = util.attach_islands(w, w_knn1)
+        self.assertEquals(w_attach.islands, [])
+        self.assertEquals(w_attach[w.islands[0]], {166: 1.0})
+
 suite = unittest.TestLoader().loadTestsFromTestCase(Testutil)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR is to add the function ```attach_islands``` which attaches the nearest neighbor to each island of a given pysal/libpysal spatial weight object.
