### PR TITLE
change data type of contiguity W.neighbors value from set to list (consistent with other weights)

### DIFF
--- a/libpysal/weights/Contiguity.py
+++ b/libpysal/weights/Contiguity.py
@@ -359,7 +359,7 @@ def _build(polygons, criterion="rook", ids=None):
     else:
         for key in neighbor_data:
             neighbors[key] = set(neighbor_data[key])
-    return neighbors, ids
+    return dict(zip(neighbors.keys(),map(list, neighbors.values()))), ids
 
 def buildContiguity(polygons, criterion="rook", ids=None):
     """


### PR DESCRIPTION
This PR to resolve the inconsistency of value data type of dictionary `W.neighbors`.  

[`W.neighbors`](https://github.com/pysal/libpysal/blob/master/libpysal/weights/weights.py#L25) is defined to be a dictionary with region ID as key and **list** of neighbor IDs as **value**. However, in constructing contiguity weights, `W.neighbors` has **set** of neighbor IDs as **value** as shown in #30 . **set** is an unordered data type. Though it is suitable for contiguity spatial weight since all the neighbors have equal weights 1.0 , it is not suitable for others whose neighbors have different weights. To keep consistency, type of **value** of dictionary `W.neighbors` of contiguity spatial weight is forced to be **list** here.
