### PR TITLE
fix networkx adapters

### DIFF
--- a/libpysal/weights/tests/test_nx.py
+++ b/libpysal/weights/tests/test_nx.py
@@ -7,7 +7,6 @@ try:
 except ImportError:
     nx = None
 
-@ut.skipIf(nx is None, "Missing networkx")
 class Test_NetworkXConverter(ut.TestCase):
     def setUp(self):
         self.known_nx = nx.random_regular_graph(4,10,seed=8879) 

--- a/libpysal/weights/tests/test_nx.py
+++ b/libpysal/weights/tests/test_nx.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
     nx = None
 
+@ut.skipIf(nx is None, "Missing networkx")
 class Test_NetworkXConverter(ut.TestCase):
     def setUp(self):
         self.known_nx = nx.random_regular_graph(4,10,seed=8879) 

--- a/libpysal/weights/tests/test_nx.py
+++ b/libpysal/weights/tests/test_nx.py
@@ -15,11 +15,11 @@ class Test_NetworkXConverter(ut.TestCase):
         self.known_W = lat2W(5,5)
 
     def test_round_trip(self):
-        W_ = W.from_nx(self.known_nx)
+        W_ = W.from_networkx(self.known_nx)
         np.testing.assert_allclose(W_.sparse.toarray(), self.known_amat)
-        nx2 = W_.to_nx()
+        nx2 = W_.to_networkx()
         np.testing.assert_allclose(nx.to_numpy_matrix(nx2), self.known_amat)
-        nxsquare = self.known_W.to_nx()
+        nxsquare = self.known_W.to_networkx()
         np.testing.assert_allclose(self.known_W.sparse.toarray(), nx.to_numpy_matrix(nxsquare))
-        W_square = W.from_nx(nxsquare)
+        W_square = W.from_networkx(nxsquare)
         np.testing.assert_allclose(self.known_W.sparse.toarray(), W_square.sparse.toarray())

--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -302,7 +302,7 @@ class W(object):
             for n,w in nw.items():
                 tuple_list.append((k,n,w))
         G = nx.Graph()
-        G.add_weighted_edges_from(ebunch = tuple_list)
+        G.add_weighted_edges_from(tuple_list)
         return G
     
     @classmethod

--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -297,13 +297,8 @@ class W(object):
             import networkx as nx
         except ImportError:
             raise ImportError("NetworkX is required to use this function.")
-        tuple_list = []
-        for k,nw in self:
-            for n,w in nw.items():
-                tuple_list.append((k,n,w))
-        G = nx.Graph()
-        G.add_weighted_edges_from(tuple_list)
-        return G
+        G = nx.DiGraph() if len(self.asymmetries)>0 else nx.Graph()
+        return nx.from_scipy_sparse_matrix(self.sparse, create_using=G)
     
     @classmethod
     def from_networkx(cls, graph, weight_col='weight'):
@@ -323,6 +318,12 @@ class W(object):
         a pysal.weights.W object containing the same graph
         as the networkx graph
         """
+        try:
+            import networkx as nx
+        except ImportError:
+            raise ImportError("NetworkX is required to use this function.")
+        sparse_matrix = nx.to_scipy_sparse_matrix(graph)
+        return WSP(sparse_matrix).to_W()
         neighbors = dict()
         weights = dict()
         for focal in graph.nodes():
@@ -1458,7 +1459,7 @@ class WSP(object):
             id_order = range(self.n)
         neighbors, weights = {}, {}
         start = indptr[0]
-        for i in xrange(self.n):
+        for i in range(self.n):
             oid = id_order[i]
             end = indptr[i + 1]
             neighbors[oid] = indices[start:end]

--- a/requirements_plus.txt
+++ b/requirements_plus.txt
@@ -9,3 +9,4 @@ mplleaflet>=0.0.5
 statsmodels>=0.6.1
 numba
 numexpr
+networkx

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [nosetests]
 ignore-files=collection
-exclude-dir=pysal_core/examples
 
 [wheel]
 universal=1


### PR DESCRIPTION
This:
1. removes unnecessary exclude dir from the `setup.cfg`
2. fixes our networkx adapters by making them use sparse machinery round-trip. 

Now, the roundtrip tests pass in `weights/test_nx.py`. 