### PR TITLE
close the door on 2 for libpysal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ branches:
 only:
   - master
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
 
@@ -21,7 +20,6 @@ before_install:
   - conda config --add channels conda-forge
   - conda create -y -q -n test-env python=$TRAVIS_PYTHON_VERSION
   - source activate test-env
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -nw libpysal/ > /dev/null; fi
 
 install:
   - conda install --yes pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - ./miniconda.sh -b -p ./miniconda
   - export PATH=`pwd`/miniconda/bin:$PATH
   - conda update --yes conda
-  - conda config --add channels conda-forge
+  - conda config --append channels conda-forge
   - conda create -y -q -n test-env python=$TRAVIS_PYTHON_VERSION
   - source activate test-env
 

--- a/.travis_testing.sh
+++ b/.travis_testing.sh
@@ -1,5 +1,0 @@
-if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then
-    nosetests --with-coverage --cover-package=pysal --exclude-dir=pysal/contrib
-else
-    nosetests --with-coverage --cover-package=pysal; 
-fi

--- a/libpysal/__init__.py
+++ b/libpysal/__init__.py
@@ -20,19 +20,19 @@ io
 weights
     Tools for creating and manipulating weights
 """
-import cg
-import io
-import weights
-import common
-import examples
+from . import cg
+from . import io
+from . import weights
+from . import common
+from . import examples
 
-from io import IOHandlers
+from .io import IOHandlers
 
 if common.pandas is not None:
-    from io import geotable
+    from .io import geotable
 
 # Assign pysal.open to dispatcher
 open = io.FileIO.FileIO
 
-from version import version
+from .version import version
 MISSINGVALUE = common.MISSINGVALUE

--- a/libpysal/cg/kdtree.py
+++ b/libpysal/cg/kdtree.py
@@ -7,7 +7,7 @@ import math
 import scipy.spatial
 import numpy
 from scipy import inf
-import sphere
+from . import sphere
 from .sphere import RADIUS_EARTH_KM
 
 __author__ = "Charles R Schmidt <schmidtc@gmail.com>"

--- a/libpysal/cg/kdtree.py
+++ b/libpysal/cg/kdtree.py
@@ -86,7 +86,7 @@ class Arc_KDTree(temp_KDTree):
         """
         self.radius = radius
         self.circumference = 2 * math.pi * radius
-        temp_KDTree.__init__(self, map(sphere.toXYZ, data), leafsize)
+        temp_KDTree.__init__(self, list(map(sphere.toXYZ, data)), leafsize)
 
     def _toXYZ(self, x):
         if not issubclass(type(x), numpy.ndarray):
@@ -98,7 +98,7 @@ class Arc_KDTree(temp_KDTree):
         elif len(x.shape) == 1:
             x = numpy.array(sphere.toXYZ(x))
         else:
-            x = map(sphere.toXYZ, x)
+            x = list(map(sphere.toXYZ, x))
         return x
 
     def count_neighbors(self, other, r, p=2):
@@ -280,6 +280,6 @@ class Arc_KDTree(temp_KDTree):
         #print D.data
         a2l = lambda x: sphere.linear2arcdist(x, self.radius)
         #print map(a2l,D.data)
-        return scipy.sparse.coo_matrix((map(a2l, D.data), (D.row, D.col))).todok()
+        return scipy.sparse.coo_matrix((list(map(a2l, D.data)), (D.row, D.col))).todok()
 
 

--- a/libpysal/cg/locators.py
+++ b/libpysal/cg/locators.py
@@ -361,7 +361,7 @@ class Grid:
         for i in xrange(lower_left[0], upper_right[0] + 1):
             for j in xrange(lower_left[1], upper_right[1] + 1):
                 if (i, j) in self.hash:
-                    items.extend(map(lambda item: item[1], filter(lambda item: x_range[0] <= item[0][0] <= x_range[1] and y_range[0] <= item[0][1] <= y_range[1], self.hash[(i, j)])))
+                    items.extend([item[1] for item in filter(lambda item: x_range[0] <= item[0][0] <= x_range[1] and y_range[0] <= item[0][1] <= y_range[1], self.hash[(i, j)])])
         return items
 
     def proximity(self, pt, r):
@@ -395,7 +395,7 @@ class Grid:
         for i in xrange(lower_left[0], upper_right[0] + 1):
             for j in xrange(lower_left[1], upper_right[1] + 1):
                 if (i, j) in self.hash:
-                    items.extend(map(lambda item: item[1], filter(lambda item: get_points_dist(pt, item[0]) <= r, self.hash[(i, j)])))
+                    items.extend([item[1] for item in filter(lambda item: get_points_dist(pt, item[0]) <= r, self.hash[(i, j)])])
         return items
 
     def nearest(self, pt):
@@ -435,8 +435,8 @@ class Grid:
         for i in xrange(lower_left[0], upper_right[0] + 1):
             for j in xrange(lower_left[1], upper_right[1] + 1):
                 if (i, j) in self.hash:
-                    items.extend(map(lambda item: (get_points_dist(pt, item[
-                        0]), item[1]), self.hash[(i, j)]))
+                    items.extend([(get_points_dist(pt, item[
+                        0]), item[1]) for item in self.hash[(i, j)]])
         if items == []:
             return None
         return min(items)[1]

--- a/libpysal/cg/locators.py
+++ b/libpysal/cg/locators.py
@@ -358,8 +358,8 @@ class Grid:
         items = []
         lower_left = self.__grid_loc((x_range[0], y_range[0]))
         upper_right = self.__grid_loc((x_range[1], y_range[1]))
-        for i in xrange(lower_left[0], upper_right[0] + 1):
-            for j in xrange(lower_left[1], upper_right[1] + 1):
+        for i in range(lower_left[0], upper_right[0] + 1):
+            for j in range(lower_left[1], upper_right[1] + 1):
                 if (i, j) in self.hash:
                     items.extend([item[1] for item in filter(lambda item: x_range[0] <= item[0][0] <= x_range[1] and y_range[0] <= item[0][1] <= y_range[1], self.hash[(i, j)])])
         return items
@@ -392,8 +392,8 @@ class Grid:
         items = []
         lower_left = self.__grid_loc((pt[0] - r, pt[1] - r))
         upper_right = self.__grid_loc((pt[0] + r, pt[1] + r))
-        for i in xrange(lower_left[0], upper_right[0] + 1):
-            for j in xrange(lower_left[1], upper_right[1] + 1):
+        for i in range(lower_left[0], upper_right[0] + 1):
+            for j in range(lower_left[1], upper_right[1] + 1):
                 if (i, j) in self.hash:
                     items.extend([item[1] for item in filter(lambda item: get_points_dist(pt, item[0]) <= r, self.hash[(i, j)])])
         return items
@@ -432,8 +432,8 @@ class Grid:
             (pt[0] - search_size, pt[1] - search_size))
         upper_right = self.__grid_loc(
             (pt[0] + search_size, pt[1] + search_size))
-        for i in xrange(lower_left[0], upper_right[0] + 1):
-            for j in xrange(lower_left[1], upper_right[1] + 1):
+        for i in range(lower_left[0], upper_right[0] + 1):
+            for j in range(lower_left[1], upper_right[1] + 1):
                 if (i, j) in self.hash:
                     items.extend([(get_points_dist(pt, item[
                         0]), item[1]) for item in self.hash[(i, j)]])

--- a/libpysal/cg/locators.py
+++ b/libpysal/cg/locators.py
@@ -121,7 +121,7 @@ class IntervalTree:
 
         Test tag: <tc>#is#IntervalTree.build</tc>
         """
-        bad_is = filter(lambda i: i[0] > i[1], intervals)
+        bad_is = [i for i in intervals if i[0] > i[1]]
         if bad_is != []:
             raise Exception('Attempt to build IntervalTree with invalid intervals: ' + str(bad_is))
         eps = list(set([i[0] for i in intervals] + [i[1] for i in intervals]))
@@ -361,7 +361,7 @@ class Grid:
         for i in range(lower_left[0], upper_right[0] + 1):
             for j in range(lower_left[1], upper_right[1] + 1):
                 if (i, j) in self.hash:
-                    items.extend([item[1] for item in filter(lambda item: x_range[0] <= item[0][0] <= x_range[1] and y_range[0] <= item[0][1] <= y_range[1], self.hash[(i, j)])])
+                    items.extend([item[1] for item in [item for item in self.hash[(i, j)] if x_range[0] <= item[0][0] <= x_range[1] and y_range[0] <= item[0][1] <= y_range[1]]])
         return items
 
     def proximity(self, pt, r):
@@ -395,7 +395,7 @@ class Grid:
         for i in range(lower_left[0], upper_right[0] + 1):
             for j in range(lower_left[1], upper_right[1] + 1):
                 if (i, j) in self.hash:
-                    items.extend([item[1] for item in filter(lambda item: get_points_dist(pt, item[0]) <= r, self.hash[(i, j)])])
+                    items.extend([item[1] for item in [item for item in self.hash[(i, j)] if get_points_dist(pt, item[0]) <= r]])
         return items
 
     def nearest(self, pt):
@@ -500,7 +500,7 @@ class BruteForcePointLocator:
         >>> len(pts)
         3
         """
-        return filter(lambda p: get_rectangle_point_intersect(region_rect, p) is not None, self._points)
+        return [p for p in self._points if get_rectangle_point_intersect(region_rect, p) is not None]
 
     def proximity(self, origin, r):
         """
@@ -526,7 +526,7 @@ class BruteForcePointLocator:
         >>> str(p)
         '(0.0, 0.0)'
         """
-        return filter(lambda p: get_points_dist(p, origin) <= r, self._points)
+        return [p for p in self._points if get_points_dist(p, origin) <= r]
 
 
 class PointLocator:

--- a/libpysal/cg/ops/__init__.py
+++ b/libpysal/cg/ops/__init__.py
@@ -1,2 +1,2 @@
-import atomic
-import tabular
+from . import atomic
+from . import tabular

--- a/libpysal/cg/ops/atomic.py
+++ b/libpysal/cg/ops/atomic.py
@@ -1,5 +1,5 @@
-import _accessors as _a
-import _shapely as _s
+from . import _accessors as _a
+from . import _shapely as _s
 
 # prefer access to shapely computation
 _all = dict()

--- a/libpysal/cg/ops/atomic.py
+++ b/libpysal/cg/ops/atomic.py
@@ -6,5 +6,5 @@ _all = dict()
 _all.update(_s.__dict__)
 _all.update(_a.__dict__)
 
-globals().update({_k:_v for _k,_v in _all.items() if not _k.startswith('_')})
+globals().update({_k:_v for _k,_v in list(_all.items()) if not _k.startswith('_')})
 _preferred = _a

--- a/libpysal/cg/ops/tests/test_accessors.py
+++ b/libpysal/cg/ops/tests/test_accessors.py
@@ -106,7 +106,7 @@ class Test_Accessors(ut.TestCase):
         holes = to_test.holes(holed_polygons).tolist()
 
         for elist in no_holes:
-            self.assertEquals(elist, [[]])
+            self.assertEqual(elist, [[]])
 
         answers = [[[(-0.002557818613137461,  -0.25599115990199145),
                      ( 0.0012028146993492903, -0.25561239107915107),

--- a/libpysal/cg/ops/tests/test_shapely.py
+++ b/libpysal/cg/ops/tests/test_shapely.py
@@ -35,7 +35,7 @@ class Test_Shapely(ut.TestCase):
                     comp.is_shape(shapely)):
                     comp.equal(tabular, shapely)
                 else:
-                    self.assertEquals(tabular, shapely)
+                    self.assertEqual(tabular, shapely)
         except NotImplementedError as e:
             warn('The shapely/pysal bridge is not implemented: {}'.format(e))
             return True

--- a/libpysal/cg/ops/tests/test_tabular.py
+++ b/libpysal/cg/ops/tests/test_tabular.py
@@ -25,7 +25,7 @@ class Test_Tabular(ut.TestCase):
                 Polygon([(1,2),(2,2),(2,1),(1,1)]),
                 Polygon([(1,1),(2,1),(2,0),(1,0)])]
         regime = [0,0,1,1]
-        ids = range(4)
+        ids = list(range(4))
         data = np.array((regime, ids)).T
         self.exdf = pd.DataFrame(data, columns=['regime', 'ids'])
         self.exdf['geometry'] = grid

--- a/libpysal/cg/ops/tests/test_tabular.py
+++ b/libpysal/cg/ops/tests/test_tabular.py
@@ -39,7 +39,7 @@ class Test_Tabular(ut.TestCase):
         new_df = GIS.tabular.to_df(geodf)
         self.assertIsInstance(new_df, pd.DataFrame)
         for new, old in zip(new_df.geometry, self.columbus.geometry):
-            self.assertEquals(new, old)
+            self.assertEqual(new, old)
 
     def test_spatial_join(self):
         pass

--- a/libpysal/cg/polygonQuadTreeStructure.py
+++ b/libpysal/cg/polygonQuadTreeStructure.py
@@ -636,7 +636,7 @@ def extract_connecting_borders_between_points(cell_min_point, cell_length_x, cel
         border_id_p_end = 3
 
     if border_id_p_begin == -1 or border_id_p_end == -1:
-        print(cell_min_point, cell_min_point[0]+cell_length_x, cell_min_point[1]+cell_length_y, point_begin, point_end, cell_length_x, cell_length_y)
+        print((cell_min_point, cell_min_point[0]+cell_length_x, cell_min_point[1]+cell_length_y, point_begin, point_end, cell_length_x, cell_length_y))
         raise Exception("Error! begin/end point doesn't lie on the cell border!!!")
 
     # Now, move forward from point_begin to point_end

--- a/libpysal/cg/rtree.py
+++ b/libpysal/cg/rtree.py
@@ -621,8 +621,8 @@ def k_means_cluster(root, k, nodes):
         for c in clusters:
             if (len(c) == 0):
                 print("Errorrr....")
-                print("Nodes: %d, centers: %s" % (len(ns),
-                                                  repr(cluster_centers)))
+                print(("Nodes: %d, centers: %s" % (len(ns),
+                                                  repr(cluster_centers))))
 
             assert(len(c) > 0)
 

--- a/libpysal/cg/segmentLocator.py
+++ b/libpysal/cg/segmentLocator.py
@@ -226,7 +226,7 @@ class SegmentGrid(object):
         possibles = set()
 
         if DEBUG:
-            print "in_grid:", self.in_grid(pt)
+            print("in_grid:", self.in_grid(pt))
             i = pylab.matshow(self.mask, origin='lower',
                               extent=self.x_range + self.y_range, fignum=1)
         # Use KD tree to search out the nearest filled bin.
@@ -280,7 +280,7 @@ class SegmentGrid(object):
                 possibles.update(self.hash[t])
 
             if DEBUG:
-                print "possibles", possibles
+                print("possibles", possibles)
         else:
         ### The old way...
         ### previously I was using kd.query_ball_point on, but the performance was terrible.
@@ -311,15 +311,15 @@ def combo_check(bins, segments, qpoints):
         a = G.nearest(pt)
         b = G2.nearest(pt)
         if a != b:
-            print a, b, a == b
+            print(a, b, a == b)
             global DEBUG
             DEBUG = True
             a = G.nearest(pt)
-            print a
+            print(a)
             a = segments[a]
             b = segments[b]
-            print "pt to a (grid)", get_segment_point_dist(a, pt)
-            print "pt to b (brut)", get_segment_point_dist(b, pt)
+            print("pt to a (grid)", get_segment_point_dist(a, pt))
+            print("pt to b (brut)", get_segment_point_dist(b, pt))
             raw_input()
             pylab.clf()
             DEBUG = False
@@ -329,13 +329,13 @@ def brute_check(segments, qpoints):
     t0 = time.time()
     G2 = BruteSegmentLocator(segs)
     t1 = time.time()
-    print "Created Brute in %0.4f seconds" % (t1 - t0)
+    print("Created Brute in %0.4f seconds" % (t1 - t0))
     t2 = time.time()
     q = map(G2.nearest, qpoints)
     t3 = time.time()
-    print "Brute Found %d matches in %0.4f seconds" % (len(qpoints), t3 - t2)
-    print "Total Brute Time:", t3 - t0
-    print
+    print("Brute Found %d matches in %0.4f seconds" % (len(qpoints), t3 - t2))
+    print("Total Brute Time:", t3 - t0)
+    print()
     return q
 
 
@@ -345,8 +345,8 @@ def grid_check(bins, segments, qpoints, visualize=False):
     t1 = time.time()
     G.grid.kd
     t2 = time.time()
-    print "Created Grid in %0.4f seconds" % (t1 - t0)
-    print "Created KDTree in %0.4f seconds" % (t2 - t1)
+    print("Created Grid in %0.4f seconds" % (t1 - t0))
+    print("Created KDTree in %0.4f seconds" % (t2 - t1))
     if visualize:
         i = pylab.matshow(G.grid.mask, origin='lower',
                           extent=G.grid.x_range + G.grid.y_range)
@@ -354,10 +354,10 @@ def grid_check(bins, segments, qpoints, visualize=False):
     t2 = time.time()
     q = map(G.nearest, qpoints)
     t3 = time.time()
-    print "Grid Found %d matches in %0.4f seconds" % (len(qpoints), t3 - t2)
-    print "Total Grid Time:", t3 - t0
+    print("Grid Found %d matches in %0.4f seconds" % (len(qpoints), t3 - t2))
+    print("Total Grid Time:", t3 - t0)
     qps = len(qpoints) / (t3 - t2)
-    print "q/s:", qps
+    print("q/s:", qps)
     #print
     return qps
 
@@ -377,7 +377,7 @@ def binSizeTest():
         segs = random_segments(n)
         qpts = random_points(q)
         for col, bins in enumerate(binSizes):
-            print "N, Bins:", n, bins
+            print("N, Bins:", n, bins)
             qps = test_grid(bins, segs, qpts)
             results[row, col] = qps
     return results
@@ -394,8 +394,8 @@ if __name__ == '__main__':
     t1 = time.time()
     qpts = random_points(q)
     t2 = time.time()
-    print "segments:", t1 - t0
-    print "points:", t2 - t1
+    print("segments:", t1 - t0)
+    print("points:", t2 - t1)
     #test_brute(segs,qpts)
     #test_grid(50, segs, qpts)
 

--- a/libpysal/cg/segmentLocator.py
+++ b/libpysal/cg/segmentLocator.py
@@ -115,7 +115,7 @@ class SegmentGrid(object):
     @property
     def hashKeys(self):
         if self._hashKeys is None:
-            self._hashKeys = numpy.array(self.hash.keys(),dtype=float)
+            self._hashKeys = numpy.array(list(self.hash.keys()),dtype=float)
         return self._hashKeys
 
     @property
@@ -331,7 +331,7 @@ def brute_check(segments, qpoints):
     t1 = time.time()
     print("Created Brute in %0.4f seconds" % (t1 - t0))
     t2 = time.time()
-    q = map(G2.nearest, qpoints)
+    q = list(map(G2.nearest, qpoints))
     t3 = time.time()
     print("Brute Found %d matches in %0.4f seconds" % (len(qpoints), t3 - t2))
     print("Total Brute Time:", t3 - t0)
@@ -352,7 +352,7 @@ def grid_check(bins, segments, qpoints, visualize=False):
                           extent=G.grid.x_range + G.grid.y_range)
 
     t2 = time.time()
-    q = map(G.nearest, qpoints)
+    q = list(map(G.nearest, qpoints))
     t3 = time.time()
     print("Grid Found %d matches in %0.4f seconds" % (len(qpoints), t3 - t2))
     print("Total Grid Time:", t3 - t0)

--- a/libpysal/cg/segmentLocator.py
+++ b/libpysal/cg/segmentLocator.py
@@ -320,7 +320,7 @@ def combo_check(bins, segments, qpoints):
             b = segments[b]
             print("pt to a (grid)", get_segment_point_dist(a, pt))
             print("pt to b (brut)", get_segment_point_dist(b, pt))
-            raw_input()
+            input()
             pylab.clf()
             DEBUG = False
 

--- a/libpysal/cg/segmentLocator.py
+++ b/libpysal/cg/segmentLocator.py
@@ -19,7 +19,7 @@ class BruteSegmentLocator(object):
     def nearest(self, pt):
         d = self.data
         distances = [get_segment_point_dist(
-            d[i], pt)[0] for i in xrange(self.n)]
+            d[i], pt)[0] for i in range(self.n)]
         return numpy.argmin(distances)
 
 
@@ -188,13 +188,13 @@ class SegmentGrid(object):
         res = self.res
         line = segment.line
         tiny = res / 1000.
-        for i in xrange(1 + min(i, I), max(i, I)):
+        for i in range(1 + min(i, I), max(i, I)):
             #print 'i',i
             x = self.x_range[0] + (i * res)
             y = line.y(x)
             self.bin_loc((x - tiny, y), id)
             self.bin_loc((x + tiny, y), id)
-        for j in xrange(1 + min(j, J), max(j, J)):
+        for j in range(1 + min(j, J), max(j, J)):
             #print 'j',j
             y = self.y_range[0] + (j * res)
             x = line.x(y)
@@ -293,7 +293,7 @@ class SegmentGrid(object):
 
 def random_segments(n):
     segs = []
-    for i in xrange(n):
+    for i in range(n):
         a, b, c, d = [random.random() for x in [1, 2, 3, 4]]
         seg = LineSegment(Point((a, b)), Point((c, d)))
         segs.append(seg)
@@ -301,7 +301,7 @@ def random_segments(n):
 
 
 def random_points(n):
-    return [Point((random.random(), random.random())) for x in xrange(n)]
+    return [Point((random.random(), random.random())) for x in range(n)]
 
 
 def combo_check(bins, segments, qpoints):
@@ -370,8 +370,8 @@ def binSizeTest():
     minB = 250
     maxB = 2000
     stepB = 250
-    sizes = range(minN, maxN, stepN)
-    binSizes = range(minB, maxB, stepB)
+    sizes = list(range(minN, maxN, stepN))
+    binSizes = list(range(minB, maxB, stepB))
     results = numpy.zeros((len(sizes), len(binSizes)))
     for row, n in enumerate(sizes):
         segs = random_segments(n)

--- a/libpysal/cg/shapely_ext.py
+++ b/libpysal/cg/shapely_ext.py
@@ -5,79 +5,79 @@ __all__ = ["to_wkb", "to_wkt", "area", "distance", "length", "boundary", "bounds
 
 
 def to_wkb(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     return o.to_wkb()
 
 def to_wkt(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     return o.to_wkt()
 
 # Real-valued properties and methods
 # ----------------------------------
 def area(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     return o.area
 
 def distance(shape, other):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     return o.distance(o2)
 
 def length(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     return o.length
 
 # Topological properties
 # ----------------------
 def boundary(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     res = o.boundary
     return asShape(res)
 
 def bounds(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     return o.bounds
 
 def centroid(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     res = o.centroid
     return asShape(res)
 
 def representative_point(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     res = o.representative_point()
     return asShape(res)
 
 def convex_hull(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     res = o.convex_hull
     return asShape(res)
 
 def envelope(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     res = o.envelope
     return asShape(res)
 
 def buffer(shape, radius, resolution=16):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     res = o.buffer(radius, resolution)
     return asShape(res)
 
 def simplify(shape, tolerance, preserve_topology=True):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     res = o.simplify(tolerance, preserve_topology)
     return asShape(res)
@@ -85,32 +85,32 @@ def simplify(shape, tolerance, preserve_topology=True):
 # Binary operations
 # -----------------
 def difference(shape, other):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     res = o.difference(o2)
     return asShape(res)
 
 def intersection(shape, other):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     res = o.intersection(o2)
     return asShape(res)
 
 def symmetric_difference(shape, other):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     res = o.symmetric_difference(o2)
     return asShape(res)
 
 def union(shape, other):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     res = o.union(o2)
@@ -119,7 +119,7 @@ def union(shape, other):
 def cascaded_union(shapes):
     o = []
     for shape in shapes:
-        if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+        if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
         o.append(geom.asShape(shape))
     res = shops.cascaded_union(o)
     return asShape(res)
@@ -127,10 +127,10 @@ def cascaded_union(shapes):
 def unary_union(shapes):
     # seems to be the same as cascade_union except that it handles multipart polygons
     if shapely_version < '1.2.16':
-        raise Exception, "shapely 1.2.16 or higher needed for unary_union; upgrade shapely or try cascade_union instead"
+        raise Exception("shapely 1.2.16 or higher needed for unary_union; upgrade shapely or try cascade_union instead")
     o = []
     for shape in shapes:
-        if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+        if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
         o.append(geom.asShape(shape))
     res = shops.unary_union(o)
     return asShape(res)
@@ -138,105 +138,105 @@ def unary_union(shapes):
 # Unary predicates
 # ----------------
 def has_z(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     return o.has_z
 
 def is_empty(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     return o.is_empty
 
 def is_ring(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     return o.is_ring
 
 def is_simple(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     return o.is_simple
 
 def is_valid(shape):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     return o.is_valid
 
 # Binary predicates
 # -----------------
 def relate(shape, other):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     return o.relate(o2)
 
 def contains(shape, other):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     return o.contains(o2)
 
 def crosses(shape, other):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     return o.crosses(o2)
 
 def disjoint(shape, other):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     return o.disjoint(o2)
 
 def equals(shape, other):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     return o.equals(o2)
 
 def intersects(shape, other):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     return o.intersects(o2)
 
 def overlaps(shape, other):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     return o.overlaps(o2)
 
 def touches(shape, other):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     return o.touches(o2)
 
 def within(shape, other):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     return o.within(o2)
 
 def equals_exact(shape, other, tolerance):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     return o.equals_exact(o2, tolerance)
 
 def almost_equals(shape, other, decimal=6):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     return o.almost_equals(o2, decimal)
@@ -245,14 +245,14 @@ def almost_equals(shape, other, decimal=6):
 # ------------------
 
 def project(shape, other, normalized=False):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
-    if not hasattr(other,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
+    if not hasattr(other,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     o2 = geom.asShape(other)
     return o.project(o2, normalized)
 
 def interpolate(shape, distance, normalized=False):
-    if not hasattr(shape,'__geo_interface__'): raise TypeError, "%r does not appear to be a shape"%shape
+    if not hasattr(shape,'__geo_interface__'): raise TypeError("%r does not appear to be a shape"%shape)
     o = geom.asShape(shape)
     res = o.interpolate(distance, normalized)
     return asShape(res)

--- a/libpysal/cg/shapes.py
+++ b/libpysal/cg/shapes.py
@@ -1994,6 +1994,6 @@ class Rectangle(Geometry):
 
 _geoJSON_type_to_Pysal_type = {'point': Point, 'linestring': Chain, 'multilinestring': Chain,
                                'polygon': Polygon, 'multipolygon': Polygon}
-import standalone  # moving this to top breaks unit tests !
+from . import standalone  # moving this to top breaks unit tests !
 from .polygonQuadTreeStructure import QuadTreeStructureSingleRing
 

--- a/libpysal/cg/shapes.py
+++ b/libpysal/cg/shapes.py
@@ -1842,7 +1842,7 @@ class Rectangle(Geometry):
         self.right = float(right)
         self.upper = float(upper)
 
-    def __nonzero__(self):
+    def __bool__(self):
         """
         ___nonzero__ is used "to implement truth value testing and the built-in operation bool()" -- http://docs.python.org/reference/datamodel.html
 

--- a/libpysal/cg/shapes.py
+++ b/libpysal/cg/shapes.py
@@ -1153,7 +1153,7 @@ class Chain(Geometry):
             return math.hypot(v1[0] - v2[0], v1[1] - v2[1])
 
         def part_perimeter(part):
-            return sum([dist(part[i], part[i + 1]) for i in xrange(len(part) - 1)])
+            return sum([dist(part[i], part[i + 1]) for i in range(len(part) - 1)])
 
         if self._len is None:
             self._len = sum([part_perimeter(part) for part in self._vertices])
@@ -1173,7 +1173,7 @@ class Chain(Geometry):
         --------
         """
         def part_perimeter(part):
-            return sum([arcdist(part[i], part[i + 1]) * 1000. for i in xrange(len(part) - 1)])
+            return sum([arcdist(part[i], part[i + 1]) * 1000. for i in range(len(part) - 1)])
         if self._arclen is None:
             self._arclen = sum(
                 [part_perimeter(part) for part in self._vertices])
@@ -1247,7 +1247,7 @@ class Ring(Geometry):
             dist = self.dist
             v = self.vertices
             self._perimeter = sum([dist(v[i], v[i + 1])
-                                   for i in xrange(-1, len(self) - 1)])
+                                   for i in range(-1, len(self) - 1)])
         return self._perimeter
 
     @property
@@ -1300,7 +1300,7 @@ class Ring(Geometry):
             N = len(self)
 
             A = 0.0
-            for i in xrange(N - 1):
+            for i in range(N - 1):
                 A += (x[i] + x[i + 1]) * \
                     (y[i] - y[i + 1])
             A = A * 0.5
@@ -1334,7 +1334,7 @@ class Ring(Geometry):
             N = len(self)
             cx = 0
             cy = 0
-            for i in xrange(N - 1):
+            for i in range(N - 1):
                 f = (x[i] * y[i + 1] - x[i + 1] * y[i])
                 cx += (x[i] + x[i + 1]) * f
                 cy += (y[i] + y[i + 1]) * f
@@ -1371,10 +1371,10 @@ class Ring(Geometry):
                 return False
 
             rn = len(self.vertices)
-            xs = [ self.vertices[i][0] - point[0] for i in xrange(rn) ]
-            ys = [ self.vertices[i][1] - point[1] for i in xrange(rn) ]
+            xs = [ self.vertices[i][0] - point[0] for i in range(rn) ]
+            ys = [ self.vertices[i][1] - point[1] for i in range(rn) ]
             w = 0
-            for i in xrange(len(self.vertices) - 1):
+            for i in range(len(self.vertices) - 1):
                 yi = ys[i]
                 yj = ys[i+1]
                 xi = xs[i]
@@ -1620,7 +1620,7 @@ class Polygon(Geometry):
             return math.hypot(v1[0] - v2[0], v1[1] - v2[1])
 
         def part_perimeter(part):
-            return sum([dist(part[i], part[i + 1]) for i in xrange(-1, len(part) - 1)])
+            return sum([dist(part[i], part[i + 1]) for i in range(-1, len(part) - 1)])
 
         if self._perimeter is None:
             self._perimeter = (sum([part_perimeter(part) for part in self._vertices]) +
@@ -1692,7 +1692,7 @@ class Polygon(Geometry):
         """
         def part_area(part_verts):
             area = 0
-            for i in xrange(-1, len(part_verts) - 1):
+            for i in range(-1, len(part_verts) - 1):
                 area += (part_verts[i][0] + part_verts[i + 1][0]) * \
                     (part_verts[i][1] - part_verts[i + 1][1])
             area = area * 0.5

--- a/libpysal/cg/shapes.py
+++ b/libpysal/cg/shapes.py
@@ -1031,7 +1031,7 @@ class Chain(Geometry):
         if geo['type'].lower() == 'linestring':
             verts = [Point(pt) for pt in geo['coordinates']]
         elif geo['type'].lower() == 'multilinestring':
-            verts = [map(Point, part) for part in geo['coordinates']]
+            verts = [list(map(Point, part)) for part in geo['coordinates']]
         else:
             raise TypeError('%r is not a Chain'%geo)
         return cls(verts)
@@ -1459,14 +1459,14 @@ class Polygon(Geometry):
                 return part[::-1]
 
         if isinstance(vertices[0], list):
-            self._part_rings = map(Ring, vertices)
+            self._part_rings = list(map(Ring, vertices))
             self._vertices = [clockwise(part) for part in vertices]
         else:
             self._part_rings = [Ring(vertices)]
             self._vertices = [clockwise(vertices)]
         if holes is not None and holes != []:
             if isinstance(holes[0], list):
-                self._hole_rings = map(Ring, holes)
+                self._hole_rings = list(map(Ring, holes))
                 self._holes = [clockwise(hole) for hole in holes]
             else:
                 self._hole_rings = [Ring(holes)]

--- a/libpysal/cg/sphere.py
+++ b/libpysal/cg/sphere.py
@@ -137,8 +137,8 @@ def brute_knn(pts, k, mode='arc'):
     """
     n = len(pts)
     full = numpy.zeros((n, n))
-    for i in xrange(n):
-        for j in xrange(i + 1, n):
+    for i in range(n):
+        for j in range(i + 1, n):
             if mode == 'arc':
                 lng0, lat0 = pts[i]
                 lng1, lat1 = pts[j]
@@ -148,7 +148,7 @@ def brute_knn(pts, k, mode='arc'):
             full[i, j] = dist
             full[j, i] = dist
     w = {}
-    for i in xrange(n):
+    for i in range(n):
         w[i] = full[i].argsort()[1:k + 1].tolist()
     return w
 
@@ -178,12 +178,12 @@ def fast_knn(pts, k, return_dist=False):
     d, w = kd.query(pts, k + 1)
     w = w[:, 1:]
     wn = {}
-    for i in xrange(len(pts)):
+    for i in range(len(pts)):
         wn[i] = w[i].tolist()
     if return_dist:
         d = d[:, 1:]
         wd = {}
-        for i in xrange(len(pts)):
+        for i in range(len(pts)):
             wd[i] = [linear2arcdist(x,
                                     radius=RADIUS_EARTH_MILES) for x in d[i].tolist()]
         return wn, wd
@@ -195,7 +195,7 @@ def fast_threshold(pts, dist, radius=RADIUS_EARTH_KM):
     kd = scipy.spatial.KDTree(pts)
     r = kd.query_ball_tree(kd, d)
     wd = {}
-    for i in xrange(len(pts)):
+    for i in range(len(pts)):
         l = r[i]
         l.remove(i)
         wd[i] = l

--- a/libpysal/cg/sphere.py
+++ b/libpysal/cg/sphere.py
@@ -109,7 +109,7 @@ def toXYZ(pt):
     -------
     x, y, z
     """
-    phi, theta = map(math.radians, pt)
+    phi, theta = list(map(math.radians, pt))
     phi, theta = phi + pi, theta + (pi / 2)
     x = 1 * sin(theta) * cos(phi)
     y = 1 * sin(theta) * sin(phi)

--- a/libpysal/cg/standalone.py
+++ b/libpysal/cg/standalone.py
@@ -89,7 +89,7 @@ def get_bounding_box(items):
         else:  # Point
             return o[1]
 
-    return Rectangle(min(map(left, items)), min(map(lower, items)), max(map(right, items)), max(map(upper, items)))
+    return Rectangle(min(list(map(left, items))), min(list(map(lower, items))), max(list(map(right, items))), max(list(map(upper, items))))
 
 
 def get_angle_between(ray1, ray2):

--- a/libpysal/cg/standalone.py
+++ b/libpysal/cg/standalone.py
@@ -280,23 +280,21 @@ def get_polygon_point_intersect(poly, pt):
     >>> get_polygon_point_intersect(poly, pt2)
     """
     def pt_lies_on_part_boundary(pt, vertices):
-        return filter(
-            lambda i: get_segment_point_dist(LineSegment(
-                vertices[i], vertices[i + 1]), pt)[0] == 0,
-            range(-1, len(vertices) - 1)) != []
+        return [i for i in range(-1, len(vertices) - 1) if get_segment_point_dist(LineSegment(
+                vertices[i], vertices[i + 1]), pt)[0] == 0] != []
 
     ret = None
     if get_rectangle_point_intersect(poly.bounding_box, pt) is None:  # Weed out points that aren't even close
         return None
-    elif filter(lambda verts: pt_lies_on_part_boundary(pt, verts), poly._vertices) != []:
+    elif [verts for verts in poly._vertices if pt_lies_on_part_boundary(pt, verts)] != []:
         ret = pt
-    elif filter(lambda verts: _point_in_vertices(pt, verts), poly._vertices) != []:
+    elif [verts for verts in poly._vertices if _point_in_vertices(pt, verts)] != []:
         ret = pt
     if poly._holes != [[]]:
-        if filter(lambda verts: pt_lies_on_part_boundary(pt, verts), poly.holes) != []:
+        if [verts for verts in poly.holes if pt_lies_on_part_boundary(pt, verts)] != []:
             # pt lies on boundary of hole.
             pass
-        if filter(lambda verts: _point_in_vertices(pt, verts), poly.holes) != []:
+        if [verts for verts in poly.holes if _point_in_vertices(pt, verts)] != []:
             # pt lines inside a hole.
             ret = None
         #raise NotImplementedError, 'Cannot compute containment for polygon with holes'

--- a/libpysal/cg/standalone.py
+++ b/libpysal/cg/standalone.py
@@ -283,7 +283,7 @@ def get_polygon_point_intersect(poly, pt):
         return filter(
             lambda i: get_segment_point_dist(LineSegment(
                 vertices[i], vertices[i + 1]), pt)[0] == 0,
-            xrange(-1, len(vertices) - 1)) != []
+            range(-1, len(vertices) - 1)) != []
 
     ret = None
     if get_rectangle_point_intersect(poly.bounding_box, pt) is None:  # Weed out points that aren't even close
@@ -451,7 +451,7 @@ def get_polygon_point_dist(poly, pt):
     part_prox = []
     for vertices in poly._vertices:
         part_prox.append(min([get_segment_point_dist(LineSegment(vertices[i], vertices[i + 1]), pt)[0]
-                              for i in xrange(-1, len(vertices) - 1)]))
+                              for i in range(-1, len(vertices) - 1)]))
     return min(part_prox)
 
 
@@ -723,7 +723,7 @@ def _point_in_vertices(pt, vertices):
         pt = (pt[0], pt[1] + -1e-14 + random.random(
         ) * 2e-14)  # Perturb the location very slightly
     inters = 0
-    for i in xrange(-1, len(vertices) - 1):
+    for i in range(-1, len(vertices) - 1):
         v1 = vertices[i]
         v2 = vertices[i + 1]
         if neg_ray_intersect(v1, v2, pt):

--- a/libpysal/cg/tests/test_geoJSON.py
+++ b/libpysal/cg/tests/test_geoJSON.py
@@ -18,9 +18,9 @@ class test_MultiPloygon(unittest.TestCase):
         for poly in multipolygons:
             json = poly.__geo_interface__
             shape = asShape(json)
-            self.assertEquals(json['type'],'MultiPolygon')
-            self.assertEquals(str(shape.holes), str(poly.holes))
-            self.assertEquals(str(shape.parts), str(poly.parts))
+            self.assertEqual(json['type'],'MultiPolygon')
+            self.assertEqual(str(shape.holes), str(poly.holes))
+            self.assertEqual(str(shape.parts), str(poly.parts))
 class test_MultiLineString(unittest.TestCase):
     def test_multipart_chain(self):
         vertices = [[Point((0, 0)), Point((1, 0)), Point((1, 5))],
@@ -34,19 +34,19 @@ class test_MultiLineString(unittest.TestCase):
         chain2 = Chain(vertices)
 
         json = chain0.__geo_interface__
-        self.assertEquals(json['type'], 'LineString')
-        self.assertEquals(len(json['coordinates']), 3)
+        self.assertEqual(json['type'], 'LineString')
+        self.assertEqual(len(json['coordinates']), 3)
 
         json = chain1.__geo_interface__
-        self.assertEquals(json['type'], 'LineString')
-        self.assertEquals(len(json['coordinates']), 3)
+        self.assertEqual(json['type'], 'LineString')
+        self.assertEqual(len(json['coordinates']), 3)
 
         json = chain2.__geo_interface__
-        self.assertEquals(json['type'], 'MultiLineString')
-        self.assertEquals(len(json['coordinates']), 2)
+        self.assertEqual(json['type'], 'MultiLineString')
+        self.assertEqual(len(json['coordinates']), 2)
 
         chain3 = asShape(json)
-        self.assertEquals(chain2.parts, chain3.parts)
+        self.assertEqual(chain2.parts, chain3.parts)
 
 
 if __name__ == '__main__':

--- a/libpysal/cg/tests/test_segmentLocator.py
+++ b/libpysal/cg/tests/test_segmentLocator.py
@@ -15,25 +15,25 @@ class SegmentGrid_Tester(unittest.TestCase):
         self.grid.add(LineSegment(Point((10.0, 0.0)), Point((0.0, 0.0))), 3)
 
     def test_nearest_1(self):
-        self.assertEquals([0, 1, 2, 3], self.grid.nearest(Point((
+        self.assertEqual([0, 1, 2, 3], self.grid.nearest(Point((
             5.0, 5.0))))  # Center
-        self.assertEquals(
+        self.assertEqual(
             [0], self.grid.nearest(Point((0.0, 5.0))))  # Left Edge
-        self.assertEquals(
+        self.assertEqual(
             [1], self.grid.nearest(Point((5.0, 10.0))))  # Top Edge
-        self.assertEquals(
+        self.assertEqual(
             [2], self.grid.nearest(Point((10.0, 5.0))))  # Right Edge
-        self.assertEquals(
+        self.assertEqual(
             [3], self.grid.nearest(Point((5.0, 0.0))))  # Bottom Edge
 
     def test_nearest_2(self):
-        self.assertEquals([0, 1, 3], self.grid.nearest(Point((-
+        self.assertEqual([0, 1, 3], self.grid.nearest(Point((-
                                                               100000.0, 5.0))))  # Left Edge
-        self.assertEquals([1, 2, 3], self.grid.nearest(Point((
+        self.assertEqual([1, 2, 3], self.grid.nearest(Point((
             100000.0, 5.0))))  # Right Edge
-        self.assertEquals([0, 2, 3], self.grid.nearest(Point((5.0,
+        self.assertEqual([0, 2, 3], self.grid.nearest(Point((5.0,
                                                               -100000.0))))  # Bottom Edge
-        self.assertEquals([0, 1, 2], self.grid.nearest(Point((5.0,
+        self.assertEqual([0, 1, 2], self.grid.nearest(Point((5.0,
                                                               100000.0))))  # Top Edge
 
 

--- a/libpysal/cg/tests/test_shapes.py
+++ b/libpysal/cg/tests/test_shapes.py
@@ -22,7 +22,7 @@ class test_Point(unittest.TestCase):
         """
         for l in [(-5, 10), (0, -6.0), (float(1e300), -1e300)]:
             p = Point(l)
-            self.assertEquals(str(p), str((float(l[0]), float(
+            self.assertEqual(str(p), str((float(l[0]), float(
                 l[1]))))  # Recast to floats like point does
 
 
@@ -126,23 +126,23 @@ class test_LineSegment(unittest.TestCase):
         """
         ls = LineSegment(Point((0, 0)), Point((10, 0)))
         swap = ls.get_swap()
-        self.assertEquals(ls.p1, swap.p2)
-        self.assertEquals(ls.p2, swap.p1)
+        self.assertEqual(ls.p1, swap.p2)
+        self.assertEqual(ls.p2, swap.p1)
 
         ls = LineSegment(Point((-5, 0)), Point((5, 0)))
         swap = ls.get_swap()
-        self.assertEquals(ls.p1, swap.p2)
-        self.assertEquals(ls.p2, swap.p1)
+        self.assertEqual(ls.p1, swap.p2)
+        self.assertEqual(ls.p2, swap.p1)
 
         ls = LineSegment(Point((0, 0)), Point((0, 0)))
         swap = ls.get_swap()
-        self.assertEquals(ls.p1, swap.p2)
-        self.assertEquals(ls.p2, swap.p1)
+        self.assertEqual(ls.p1, swap.p2)
+        self.assertEqual(ls.p2, swap.p1)
 
         ls = LineSegment(Point((5, 5)), Point((5, 5)))
         swap = ls.get_swap()
-        self.assertEquals(ls.p1, swap.p2)
-        self.assertEquals(ls.p2, swap.p1)
+        self.assertEqual(ls.p1, swap.p2)
+        self.assertEqual(ls.p2, swap.p1)
 
     def test_bounding_box(self):
         """
@@ -151,22 +151,22 @@ class test_LineSegment(unittest.TestCase):
         Test tag: <tc>#tests#LineSegment.bounding_box</tc>
         """
         ls = LineSegment(Point((0, 0)), Point((0, 10)))
-        self.assertEquals(ls.bounding_box.left, 0)
-        self.assertEquals(ls.bounding_box.lower, 0)
-        self.assertEquals(ls.bounding_box.right, 0)
-        self.assertEquals(ls.bounding_box.upper, 10)
+        self.assertEqual(ls.bounding_box.left, 0)
+        self.assertEqual(ls.bounding_box.lower, 0)
+        self.assertEqual(ls.bounding_box.right, 0)
+        self.assertEqual(ls.bounding_box.upper, 10)
 
         ls = LineSegment(Point((0, 0)), Point((-3, -4)))
-        self.assertEquals(ls.bounding_box.left, -3)
-        self.assertEquals(ls.bounding_box.lower, -4)
-        self.assertEquals(ls.bounding_box.right, 0)
-        self.assertEquals(ls.bounding_box.upper, 0)
+        self.assertEqual(ls.bounding_box.left, -3)
+        self.assertEqual(ls.bounding_box.lower, -4)
+        self.assertEqual(ls.bounding_box.right, 0)
+        self.assertEqual(ls.bounding_box.upper, 0)
 
         ls = LineSegment(Point((-5, 0)), Point((3, 0)))
-        self.assertEquals(ls.bounding_box.left, -5)
-        self.assertEquals(ls.bounding_box.lower, 0)
-        self.assertEquals(ls.bounding_box.right, 3)
-        self.assertEquals(ls.bounding_box.upper, 0)
+        self.assertEqual(ls.bounding_box.left, -5)
+        self.assertEqual(ls.bounding_box.lower, 0)
+        self.assertEqual(ls.bounding_box.right, 3)
+        self.assertEqual(ls.bounding_box.upper, 0)
 
     def test_len1(self):
         """
@@ -175,10 +175,10 @@ class test_LineSegment(unittest.TestCase):
         Test tag: <tc>#tests#LineSegment.len</tc>
         """
         ls = LineSegment(Point((0, 0)), Point((0, 0)))
-        self.assertEquals(ls.len, 0)
+        self.assertEqual(ls.len, 0)
 
         ls = LineSegment(Point((0, 0)), Point((-3, 0)))
-        self.assertEquals(ls.len, 3)
+        self.assertEqual(ls.len, 3)
 
     def test_line1(self):
         """
@@ -188,19 +188,19 @@ class test_LineSegment(unittest.TestCase):
         """
         import math
         ls = LineSegment(Point((0, 0)), Point((1, 0)))
-        self.assertEquals(ls.line.m, 0)
-        self.assertEquals(ls.line.b, 0)
+        self.assertEqual(ls.line.m, 0)
+        self.assertEqual(ls.line.b, 0)
 
         ls = LineSegment(Point((0, 0)), Point((0, 1)))
-        self.assertEquals(ls.line.m, float('inf'))
+        self.assertEqual(ls.line.m, float('inf'))
         self.assertTrue(math.isnan(ls.line.b))
 
         ls = LineSegment(Point((0, 0)), Point((0, -1)))
-        self.assertEquals(ls.line.m, float('inf'))
+        self.assertEqual(ls.line.m, float('inf'))
         self.assertTrue(math.isnan(ls.line.b))
 
         ls = LineSegment(Point((0, 0)), Point((0, 0)))
-        self.assertEquals(ls.line, None)
+        self.assertEqual(ls.line, None)
 
         ls = LineSegment(Point((5,0)), Point((10,0)))
         ls1 = LineSegment(Point((5,0)), Point((10,1)))
@@ -232,19 +232,19 @@ class test_Line(unittest.TestCase):
         Test tag: <tc>#tests#Line.y</tc>
         """
         l = Line(0, 0)
-        self.assertEquals(l.y(0), 0)
-        self.assertEquals(l.y(-1e600), 0)
-        self.assertEquals(l.y(1e600), 0)
+        self.assertEqual(l.y(0), 0)
+        self.assertEqual(l.y(-1e600), 0)
+        self.assertEqual(l.y(1e600), 0)
 
         l = Line(1, 1)
-        self.assertEquals(l.y(2), 3)
-        self.assertEquals(l.y(-1e600), -1e600)
-        self.assertEquals(l.y(1e600), 1e600)
+        self.assertEqual(l.y(2), 3)
+        self.assertEqual(l.y(-1e600), -1e600)
+        self.assertEqual(l.y(1e600), 1e600)
 
         l = Line(-1, 1)
-        self.assertEquals(l.y(2), -1)
-        self.assertEquals(l.y(-1e600), 1e600)
-        self.assertEquals(l.y(1e600), -1e600)
+        self.assertEqual(l.y(2), -1)
+        self.assertEqual(l.y(-1e600), 1e600)
+        self.assertEqual(l.y(1e600), -1e600)
 
     def test_x1(self):
         """
@@ -262,14 +262,14 @@ class test_Line(unittest.TestCase):
             l.x(1e600)
 
         l = Line(1, 1)
-        self.assertEquals(l.x(3), 2)
-        self.assertEquals(l.x(-1e600), -1e600)
-        self.assertEquals(l.x(1e600), 1e600)
+        self.assertEqual(l.x(3), 2)
+        self.assertEqual(l.x(-1e600), -1e600)
+        self.assertEqual(l.x(1e600), 1e600)
 
         l = Line(-1, 1)
-        self.assertEquals(l.x(2), -1)
-        self.assertEquals(l.x(-1e600), 1e600)
-        self.assertEquals(l.x(1e600), -1e600)
+        self.assertEqual(l.x(2), -1)
+        self.assertEqual(l.x(-1e600), 1e600)
+        self.assertEqual(l.x(1e600), -1e600)
 
 
 class test_Ray(unittest.TestCase):
@@ -303,11 +303,11 @@ class test_Chain(unittest.TestCase):
         """
         vertices = [Point((0, 0)), Point((1, 1)), Point((2, 5)),
                     Point((0, 0)), Point((1, 1)), Point((2, 5))]
-        self.assertEquals(Chain(vertices).vertices, vertices)
+        self.assertEqual(Chain(vertices).vertices, vertices)
 
         vertices = [[Point((0, 0)), Point((1, 1)), Point((2, 5))],
                     [Point((0, 0)), Point((1, 1)), Point((2, 5))]]
-        self.assertEquals(Chain(vertices).vertices, vertices[0] + vertices[1])
+        self.assertEqual(Chain(vertices).vertices, vertices[0] + vertices[1])
 
     def test_parts1(self):
         """
@@ -317,11 +317,11 @@ class test_Chain(unittest.TestCase):
         """
         vertices = [Point((0, 0)), Point((1, 1)), Point((2, 5)),
                     Point((0, 0)), Point((1, 1)), Point((2, 5))]
-        self.assertEquals(Chain(vertices).parts, [vertices])
+        self.assertEqual(Chain(vertices).parts, [vertices])
 
         vertices = [[Point((0, 0)), Point((1, 1)), Point((2, 5))],
                     [Point((0, 0)), Point((1, 1)), Point((2, 5))]]
-        self.assertEquals(Chain(vertices).parts, vertices)
+        self.assertEqual(Chain(vertices).parts, vertices)
 
     def test_bounding_box1(self):
         """
@@ -332,10 +332,10 @@ class test_Chain(unittest.TestCase):
         vertices = [[Point((0, 0)), Point((1, 1)), Point((2, 6))],
                     [Point((-5, -5)), Point((0, 0)), Point((2, 5))]]
         bb = Chain(vertices).bounding_box
-        self.assertEquals(bb.left, -5)
-        self.assertEquals(bb.lower, -5)
-        self.assertEquals(bb.right, 2)
-        self.assertEquals(bb.upper, 6)
+        self.assertEqual(bb.left, -5)
+        self.assertEqual(bb.lower, -5)
+        self.assertEqual(bb.right, 2)
+        self.assertEqual(bb.upper, 6)
 
     def test_len1(self):
         """
@@ -345,7 +345,7 @@ class test_Chain(unittest.TestCase):
         """
         vertices = [[Point((0, 0)), Point((1, 0)), Point((1, 5))],
                     [Point((-5, -5)), Point((-5, 0)), Point((0, 0)), Point((0, 0))]]
-        self.assertEquals(Chain(vertices).len, 6 + 10)
+        self.assertEqual(Chain(vertices).len, 6 + 10)
 
 
 class test_Polygon(unittest.TestCase):
@@ -402,7 +402,7 @@ class test_Polygon(unittest.TestCase):
         p = Polygon(
             [[Point((0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))],
                      [Point((30, 30)), Point((40, 30)), Point((40, 40)), Point((30, 40))]])
-        self.assertEquals(p.area, 200)
+        self.assertEqual(p.area, 200)
 
     def test_area2(self):
         """
@@ -413,14 +413,14 @@ class test_Polygon(unittest.TestCase):
         p = Polygon(
             [Point((0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))],
                     holes=[Point((2, 2)), Point((4, 2)), Point((4, 4)), Point((2, 4))])
-        self.assertEquals(p.area, 100 - 4)
+        self.assertEqual(p.area, 100 - 4)
 
         p = Polygon(
             [Point((0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))],
                     holes=[[Point(
                         (2, 2)), Point((4, 2)), Point((4, 4)), Point((2, 4))],
                         [Point((6, 6)), Point((6, 8)), Point((8, 8)), Point((8, 6))]])
-        self.assertEquals(p.area, 100 - (4 + 4))
+        self.assertEqual(p.area, 100 - (4 + 4))
 
         p = Polygon(
             [[Point((0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))],
@@ -431,7 +431,7 @@ class test_Polygon(unittest.TestCase):
                     holes=[[Point(
                         (2, 2)), Point((4, 2)), Point((4, 4)), Point((2, 4))],
                         [Point((36, 36)), Point((36, 38)), Point((38, 38)), Point((38, 36))]])
-        self.assertEquals(p.area, 200 - (4 + 4))
+        self.assertEqual(p.area, 200 - (4 + 4))
 
     def test_area4(self):
         """
@@ -441,11 +441,11 @@ class test_Polygon(unittest.TestCase):
         """
         p = Polygon([Point(
             (0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))])
-        self.assertEquals(p.area, 100)
+        self.assertEqual(p.area, 100)
 
         p = Polygon([Point(
             (0, 0)), Point((0, 10)), Point((10, 10)), Point((10, 0))])
-        self.assertEquals(p.area, 100)
+        self.assertEqual(p.area, 100)
 
     def test_bounding_box1(self):
         """
@@ -457,10 +457,10 @@ class test_Polygon(unittest.TestCase):
             [[Point((0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))],
                      [Point((30, 30)), Point((40, 30)), Point((40, 40)), Point((30, 40))]])
         bb = p.bounding_box
-        self.assertEquals(bb.left, 0)
-        self.assertEquals(bb.lower, 0)
-        self.assertEquals(bb.right, 40)
-        self.assertEquals(bb.upper, 40)
+        self.assertEqual(bb.left, 0)
+        self.assertEqual(bb.lower, 0)
+        self.assertEqual(bb.right, 40)
+        self.assertEqual(bb.upper, 40)
 
     def test_centroid1(self):
         """
@@ -472,8 +472,8 @@ class test_Polygon(unittest.TestCase):
             [[Point((0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))],
                      [Point((30, 30)), Point((40, 30)), Point((40, 40)), Point((30, 40))]])
         c = p.centroid
-        self.assertEquals(c[0], 20)
-        self.assertEquals(c[1], 20)
+        self.assertEqual(c[0], 20)
+        self.assertEqual(c[1], 20)
 
     def test_centroid2(self):
         """
@@ -485,8 +485,8 @@ class test_Polygon(unittest.TestCase):
             [[Point((0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))],
                      [Point((30, 30)), Point((35, 30)), Point((35, 35)), Point((30, 35))]])
         c = p.centroid
-        self.assertEquals(c[0], 10.5)
-        self.assertEquals(c[1], 10.5)
+        self.assertEqual(c[0], 10.5)
+        self.assertEqual(c[1], 10.5)
 
     def test_holes1(self):
         """
@@ -497,7 +497,7 @@ class test_Polygon(unittest.TestCase):
         p = Polygon(
             [Point((0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))],
                     holes=[Point((2, 2)), Point((4, 2)), Point((4, 4)), Point((2, 4))])
-        self.assertEquals(len(p.holes), 1)
+        self.assertEqual(len(p.holes), 1)
         e_holes = [Point((2, 2)), Point((2, 4)), Point((4, 4)), Point((4, 2))]
         self.assertTrue(p.holes[0] in [e_holes, [e_holes[-1]] + e_holes[:3],
                                        e_holes[-2:] + e_holes[:2], e_holes[-3:] + [e_holes[0]]])
@@ -514,7 +514,7 @@ class test_Polygon(unittest.TestCase):
                         (2, 2)), Point((4, 2)), Point((4, 4)), Point((2, 4))],
                         [Point((6, 6)), Point((6, 8)), Point((8, 8)), Point((8, 6))]])
         holes = p.holes
-        self.assertEquals(len(holes), 2)
+        self.assertEqual(len(holes), 2)
 
     def test_parts1(self):
         """
@@ -525,7 +525,7 @@ class test_Polygon(unittest.TestCase):
         p = Polygon(
             [[Point((0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))],
                      [Point((30, 30)), Point((40, 30)), Point((30, 40))]])
-        self.assertEquals(len(p.parts), 2)
+        self.assertEqual(len(p.parts), 2)
 
         part1 = [Point(
             (0, 0)), Point((0, 10)), Point((10, 10)), Point((10, 0))]
@@ -552,7 +552,7 @@ class test_Polygon(unittest.TestCase):
         p = Polygon(
             [[Point((0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))],
                      [Point((30, 30)), Point((40, 30)), Point((40, 40)), Point((30, 40))]])
-        self.assertEquals(p.perimeter, 80)
+        self.assertEqual(p.perimeter, 80)
 
     def test_perimeter2(self):
         """
@@ -569,7 +569,7 @@ class test_Polygon(unittest.TestCase):
                     holes=[[Point(
                         (2, 2)), Point((4, 2)), Point((4, 4)), Point((2, 4))],
                         [Point((6, 6)), Point((6, 8)), Point((8, 8)), Point((8, 6))]])
-        self.assertEquals(p.perimeter, 80 + 16)
+        self.assertEqual(p.perimeter, 80 + 16)
 
     def test_vertices1(self):
         """
@@ -579,7 +579,7 @@ class test_Polygon(unittest.TestCase):
         """
         p = Polygon([Point(
             (0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))])
-        self.assertEquals(len(p.vertices), 4)
+        self.assertEqual(len(p.vertices), 4)
         e_verts = [Point(
             (0, 0)), Point((0, 10)), Point((10, 10)), Point((10, 0))]
         self.assertTrue(p.vertices in [e_verts, e_verts[-1:] + e_verts[:3],
@@ -594,14 +594,14 @@ class test_Polygon(unittest.TestCase):
         p = Polygon(
             [[Point((0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))],
                      [Point((30, 30)), Point((40, 30)), Point((40, 40)), Point((30, 40))]])
-        self.assertEquals(len(p.vertices), 8)
+        self.assertEqual(len(p.vertices), 8)
 
     def test_contains_point(self):
         p = Polygon([Point((0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))], [Point((1, 2)), Point((2, 2)), Point((2, 1)), Point((1, 1))])
-        self.assertEquals(p.contains_point((0, 0)), 0)
-        self.assertEquals(p.contains_point((1, 1)), 0)
-        self.assertEquals(p.contains_point((5, 5)), 1)
-        self.assertEquals(p.contains_point((10, 10)), 0)
+        self.assertEqual(p.contains_point((0, 0)), 0)
+        self.assertEqual(p.contains_point((1, 1)), 0)
+        self.assertEqual(p.contains_point((5, 5)), 1)
+        self.assertEqual(p.contains_point((10, 10)), 0)
 
 
 class test_Rectangle(unittest.TestCase):
@@ -634,24 +634,24 @@ class test_Rectangle(unittest.TestCase):
         """
         r = Rectangle(5, 5, 5, 10)  # Zero width
         r.set_centroid(Point((0, 0)))
-        self.assertEquals(r.left, 0)
-        self.assertEquals(r.lower, -2.5)
-        self.assertEquals(r.right, 0)
-        self.assertEquals(r.upper, 2.5)
+        self.assertEqual(r.left, 0)
+        self.assertEqual(r.lower, -2.5)
+        self.assertEqual(r.right, 0)
+        self.assertEqual(r.upper, 2.5)
 
         r = Rectangle(10, 5, 20, 5)  # Zero height
         r.set_centroid(Point((40, 40)))
-        self.assertEquals(r.left, 35)
-        self.assertEquals(r.lower, 40)
-        self.assertEquals(r.right, 45)
-        self.assertEquals(r.upper, 40)
+        self.assertEqual(r.left, 35)
+        self.assertEqual(r.lower, 40)
+        self.assertEqual(r.right, 45)
+        self.assertEqual(r.upper, 40)
 
         r = Rectangle(0, 0, 0, 0)  # Zero width and height
         r.set_centroid(Point((-4, -4)))
-        self.assertEquals(r.left, -4)
-        self.assertEquals(r.lower, -4)
-        self.assertEquals(r.right, -4)
-        self.assertEquals(r.upper, -4)
+        self.assertEqual(r.left, -4)
+        self.assertEqual(r.lower, -4)
+        self.assertEqual(r.right, -4)
+        self.assertEqual(r.upper, -4)
 
     def test_set_scale1(self):
         """
@@ -662,16 +662,16 @@ class test_Rectangle(unittest.TestCase):
         r = Rectangle(2, 2, 4, 4)
 
         r.set_scale(0.5)
-        self.assertEquals(r.left, 2.5)
-        self.assertEquals(r.lower, 2.5)
-        self.assertEquals(r.right, 3.5)
-        self.assertEquals(r.upper, 3.5)
+        self.assertEqual(r.left, 2.5)
+        self.assertEqual(r.lower, 2.5)
+        self.assertEqual(r.right, 3.5)
+        self.assertEqual(r.upper, 3.5)
 
         r.set_scale(2)
-        self.assertEquals(r.left, 2)
-        self.assertEquals(r.lower, 2)
-        self.assertEquals(r.right, 4)
-        self.assertEquals(r.upper, 4)
+        self.assertEqual(r.left, 2)
+        self.assertEqual(r.lower, 2)
+        self.assertEqual(r.right, 4)
+        self.assertEqual(r.upper, 4)
 
     def test_set_scale2(self):
         """
@@ -681,31 +681,31 @@ class test_Rectangle(unittest.TestCase):
         """
         r = Rectangle(5, 5, 5, 10)  # Zero width
         r.set_scale(2)
-        self.assertEquals(r.left, 5)
-        self.assertEquals(r.lower, 2.5)
-        self.assertEquals(r.right, 5)
-        self.assertEquals(r.upper, 12.5)
+        self.assertEqual(r.left, 5)
+        self.assertEqual(r.lower, 2.5)
+        self.assertEqual(r.right, 5)
+        self.assertEqual(r.upper, 12.5)
 
         r = Rectangle(10, 5, 20, 5)  # Zero height
         r.set_scale(2)
-        self.assertEquals(r.left, 5)
-        self.assertEquals(r.lower, 5)
-        self.assertEquals(r.right, 25)
-        self.assertEquals(r.upper, 5)
+        self.assertEqual(r.left, 5)
+        self.assertEqual(r.lower, 5)
+        self.assertEqual(r.right, 25)
+        self.assertEqual(r.upper, 5)
 
         r = Rectangle(0, 0, 0, 0)  # Zero width and height
         r.set_scale(100)
-        self.assertEquals(r.left, 0)
-        self.assertEquals(r.lower, 0)
-        self.assertEquals(r.right, 0)
-        self.assertEquals(r.upper, 0)
+        self.assertEqual(r.left, 0)
+        self.assertEqual(r.lower, 0)
+        self.assertEqual(r.right, 0)
+        self.assertEqual(r.upper, 0)
 
         r = Rectangle(0, 0, 0, 0)  # Zero width and height
         r.set_scale(0.01)
-        self.assertEquals(r.left, 0)
-        self.assertEquals(r.lower, 0)
-        self.assertEquals(r.right, 0)
-        self.assertEquals(r.upper, 0)
+        self.assertEqual(r.left, 0)
+        self.assertEqual(r.lower, 0)
+        self.assertEqual(r.right, 0)
+        self.assertEqual(r.upper, 0)
 
     def test_area1(self):
         """
@@ -714,13 +714,13 @@ class test_Rectangle(unittest.TestCase):
         Test tag: <tc>#tests#Rectangle.area</tc>
         """
         r = Rectangle(5, 5, 5, 10)  # Zero width
-        self.assertEquals(r.area, 0)
+        self.assertEqual(r.area, 0)
 
         r = Rectangle(10, 5, 20, 5)  # Zero height
-        self.assertEquals(r.area, 0)
+        self.assertEqual(r.area, 0)
 
         r = Rectangle(0, 0, 0, 0)  # Zero width and height
-        self.assertEquals(r.area, 0)
+        self.assertEqual(r.area, 0)
 
     def test_height1(self):
         """
@@ -729,7 +729,7 @@ class test_Rectangle(unittest.TestCase):
         Test tag: <tc>#tests#Rectangle.height</tc>
         """
         r = Rectangle(10, 5, 20, 5)  # Zero height
-        self.assertEquals(r.height, 0)
+        self.assertEqual(r.height, 0)
 
     def test_width1(self):
         """
@@ -738,7 +738,7 @@ class test_Rectangle(unittest.TestCase):
         Test tag: <tc>#tests#Rectangle.width</tc>
         """
         r = Rectangle(5, 5, 5, 10)  # Zero width
-        self.assertEquals(r.width, 0)
+        self.assertEqual(r.width, 0)
 
 
 #suite = unittest.TestSuite()

--- a/libpysal/cg/tests/test_sphere.py
+++ b/libpysal/cg/tests/test_sphere.py
@@ -20,22 +20,22 @@ class Sphere(unittest.TestCase):
 
     def test_arcdist(self):
         d = sphere.arcdist(self.pt0, self.pt1, sphere.RADIUS_EARTH_MILES)
-        self.assertEquals(d, math.pi * sphere.RADIUS_EARTH_MILES)
+        self.assertEqual(d, math.pi * sphere.RADIUS_EARTH_MILES)
 
     def test_arcdist2linear(self):
         d = sphere.arcdist(self.pt0, self.pt1, sphere.RADIUS_EARTH_MILES)
         ld = sphere.arcdist2linear(d, sphere.RADIUS_EARTH_MILES)
-        self.assertEquals(ld, 2.0)
+        self.assertEqual(ld, 2.0)
 
     def test_radangle(self):
         p0 = (-87.893517, 41.981417)
         p1 = (-87.519295, 41.657498)
-        self.assertAlmostEquals(sphere.radangle(p0,p1), 0.007460167953189258)
+        self.assertAlmostEqual(sphere.radangle(p0,p1), 0.007460167953189258)
 
     def test_linear2arcdist(self):
         d = sphere.arcdist(self.pt0, self.pt1, sphere.RADIUS_EARTH_MILES)
         ad = sphere.linear2arcdist(2.0, radius=sphere.RADIUS_EARTH_MILES)
-        self.assertEquals(d, ad)
+        self.assertEqual(d, ad)
 
     def test_harcdist(self):
         d1 = sphere.harcdist(self.p0, self.p1,

--- a/libpysal/cg/tests/test_sphere.py
+++ b/libpysal/cg/tests/test_sphere.py
@@ -105,7 +105,7 @@ class Sphere(unittest.TestCase):
               [70, 74, 73, 69]}
 
         pts = [shape.centroid for shape in self.shapes]
-        pts = map(sphere.toXYZ, pts)
+        pts = list(map(sphere.toXYZ, pts))
         self.assertAlmostEqual(sphere.brute_knn(pts, 4, 'xyz'), w2)
 
 if __name__ == '__main__':

--- a/libpysal/cg/tests/test_voronoi.py
+++ b/libpysal/cg/tests/test_voronoi.py
@@ -13,7 +13,7 @@ class Voronoi(unittest.TestCase):
 
     def test_voronoi(self):
         regions, vertices = voronoi(self.points)
-        self.assertEquals(regions, [[1, 3, 2],
+        self.assertEqual(regions, [[1, 3, 2],
                                     [4, 5, 1, 0],
                                     [0, 1, 7, 6],
                                     [9, 0, 8]])

--- a/libpysal/common.py
+++ b/libpysal/common.py
@@ -10,7 +10,7 @@ except:
 try:
     import scipy as sp
     import scipy.stats as stats
-    from cg.kdtree import KDTree
+    from .cg.kdtree import KDTree
     from scipy.spatial.distance import pdist, cdist
 except:
     print('scipy 0.7+ is required')
@@ -127,8 +127,8 @@ def requires(*args, **kwargs):
             def passer(*args,**kwargs):
                 if v:
                     missing = [arg for i, arg in enumerate(wanted) if not available[i]]
-                    print('missing dependencies: {d}'.format(d=missing))
-                    print('not running {}'.format(function.__name__))
+                    print(('missing dependencies: {d}'.format(d=missing)))
+                    print(('not running {}'.format(function.__name__)))
                 else:
                     pass
             return passer 

--- a/libpysal/examples/__init__.py
+++ b/libpysal/examples/__init__.py
@@ -1,5 +1,5 @@
 import os
-import _version
+from . import _version
 
 base = os.path.abspath(os.path.dirname(_version.__file__))
 __all__ = ['get_path', 'available', 'explain']

--- a/libpysal/io/FileIO.py
+++ b/libpysal/io/FileIO.py
@@ -111,9 +111,9 @@ class FileIO(object):  # should be a type?
     @classmethod
     def check(cls):
         """ Prints the contents of the registry """
-        print "PySAL File I/O understands the following file extensions:"
+        print("PySAL File I/O understands the following file extensions:")
         for key, val in cls.__registry.iteritems():
-            print "Ext: '.%s', Modes: %r" % (key, val.keys())
+            print("Ext: '.%s', Modes: %r" % (key, val.keys()))
 
     @classmethod
     def open(cls, *args, **kwargs):

--- a/libpysal/io/FileIO.py
+++ b/libpysal/io/FileIO.py
@@ -246,7 +246,7 @@ class FileIO(object):  # should be a type?
         else:
             return row
 
-    def next(self):
+    def __next__(self):
         """A FileIO object is its own iterator, see StringIO"""
         self._complain_ifclosed(self.closed)
         r = self.__read()

--- a/libpysal/io/FileIO.py
+++ b/libpysal/io/FileIO.py
@@ -112,7 +112,7 @@ class FileIO(object):  # should be a type?
     def check(cls):
         """ Prints the contents of the registry """
         print("PySAL File I/O understands the following file extensions:")
-        for key, val in cls.__registry.items():
+        for key, val in list(cls.__registry.items()):
             print("Ext: '.%s', Modes: %r" % (key, list(val.keys())))
 
     @classmethod
@@ -190,7 +190,7 @@ class FileIO(object):  # should be a type?
         elif isinstance(ids, dict):
             self.__ids = ids
             self.__rIds = {}
-            for id, n in ids.items():
+            for id, n in list(ids.items()):
                 self.__rIds[n] = id
         elif not ids:
             self.__ids = None

--- a/libpysal/io/FileIO.py
+++ b/libpysal/io/FileIO.py
@@ -34,7 +34,7 @@ class FileIO_MetaCls(type):
         return cls
 
 
-class FileIO(object):  # should be a type?
+class FileIO(object, metaclass=FileIO_MetaCls):  # should be a type?
     """
     How this works:
     FileIO.open(\*args) == FileIO(\*args)
@@ -51,7 +51,6 @@ class FileIO(object):  # should be a type?
     ....for now we'll just return an instance of W on mode='r'
     .... on mode='w', .write will expect an instance of W
     """
-    __metaclass__ = FileIO_MetaCls
     __registry = {}  # {'shp':{'r':[OGRshpReader,pysalShpReader]}}
 
     def __new__(cls, dataPath='', mode='r', dataFormat=None):

--- a/libpysal/io/FileIO.py
+++ b/libpysal/io/FileIO.py
@@ -112,8 +112,8 @@ class FileIO(object):  # should be a type?
     def check(cls):
         """ Prints the contents of the registry """
         print("PySAL File I/O understands the following file extensions:")
-        for key, val in cls.__registry.iteritems():
-            print("Ext: '.%s', Modes: %r" % (key, val.keys()))
+        for key, val in cls.__registry.items():
+            print("Ext: '.%s', Modes: %r" % (key, list(val.keys())))
 
     @classmethod
     def open(cls, *args, **kwargs):
@@ -128,7 +128,7 @@ class FileIO(object):  # should be a type?
             if not self.p.ids:
                 return "keys: range(0,n)"
             else:
-                return "keys: " + self.p.ids.keys().__repr__()
+                return "keys: " + list(self.p.ids.keys()).__repr__()
 
         def __getitem__(self, key):
             if type(key) == list:
@@ -190,7 +190,7 @@ class FileIO(object):  # should be a type?
         elif isinstance(ids, dict):
             self.__ids = ids
             self.__rIds = {}
-            for id, n in ids.iteritems():
+            for id, n in ids.items():
                 self.__rIds[n] = id
         elif not ids:
             self.__ids = None

--- a/libpysal/io/IOHandlers/__init__.py
+++ b/libpysal/io/IOHandlers/__init__.py
@@ -1,23 +1,23 @@
 import warnings
 warnings.filterwarnings(
     action='ignore', message=".*__builtin__.file size changed.*")
-import gwt
-import gal
-import dat
-import pyShpIO
-import wkt
-import geoda_txt
-import csvWrapper
-import pyDbfIO
-import arcgis_dbf
-import arcgis_swm
-import arcgis_txt
-import dat
-import geobugs_txt
-import mat
-import mtx
-import stata_txt
-import wk1
+from . import gwt
+from . import gal
+from . import dat
+from . import pyShpIO
+from . import wkt
+from . import geoda_txt
+from . import csvWrapper
+from . import pyDbfIO
+from . import arcgis_dbf
+from . import arcgis_swm
+from . import arcgis_txt
+from . import dat
+from . import geobugs_txt
+from . import mat
+from . import mtx
+from . import stata_txt
+from . import wk1
 
 try:
     from . import db

--- a/libpysal/io/IOHandlers/arcgis_dbf.py
+++ b/libpysal/io/IOHandlers/arcgis_dbf.py
@@ -212,7 +212,7 @@ class ArcGISDbfIO(FileIO.FileIO):
             self.file.field_spec = [id_spec, id_spec, ('N', 13, 6)]
 
             for id in obj.id_order:
-                neighbors = zip(obj.neighbors[id], obj.weights[id])
+                neighbors = list(zip(obj.neighbors[id], obj.weights[id]))
                 for neighbor, weight in neighbors:
                     self.file.write([id, neighbor, weight])
                     self.pos = self.file.pos

--- a/libpysal/io/IOHandlers/arcgis_dbf.py
+++ b/libpysal/io/IOHandlers/arcgis_dbf.py
@@ -62,7 +62,7 @@ class ArcGISDbfIO(FileIO.FileIO):
         self.file = FileIO.FileIO(self.dataPath, self.mode)
 
     def _set_varName(self, val):
-        if issubclass(type(val), basestring):
+        if issubclass(type(val), str):
             self._varName = val
 
     def _get_varName(self):

--- a/libpysal/io/IOHandlers/arcgis_swm.py
+++ b/libpysal/io/IOHandlers/arcgis_swm.py
@@ -114,7 +114,7 @@ class ArcGISSwmIO(FileIO.FileIO):
 
         neighbors = {}
         weights = {}
-        for i in xrange(no_obs):
+        for i in range(no_obs):
             origin, no_nghs = tuple(unpack('<2l', self.file.read(8)))
             neighbors[origin] = []
             weights[origin] = []

--- a/libpysal/io/IOHandlers/arcgis_swm.py
+++ b/libpysal/io/IOHandlers/arcgis_swm.py
@@ -56,7 +56,7 @@ class ArcGISSwmIO(FileIO.FileIO):
         self.file = open(self.dataPath, self.mode + 'b')
 
     def _set_varName(self, val):
-        if issubclass(type(val), basestring):
+        if issubclass(type(val), str):
             self._varName = val
 
     def _get_varName(self):

--- a/libpysal/io/IOHandlers/arcgis_txt.py
+++ b/libpysal/io/IOHandlers/arcgis_txt.py
@@ -1,5 +1,5 @@
 import os.path
-import gwt
+from . import gwt
 from ...weights import W
 from ...weights.util import remap_ids
 from .. import FileIO

--- a/libpysal/io/IOHandlers/dat.py
+++ b/libpysal/io/IOHandlers/dat.py
@@ -1,5 +1,5 @@
 import os.path
-import gwt
+from . import gwt
 from ...weights import W
 from warnings import warn
 

--- a/libpysal/io/IOHandlers/db.py
+++ b/libpysal/io/IOHandlers/db.py
@@ -77,7 +77,7 @@ class SQLConnection(FileIO.FileIO):
     @property
     def tables(self):
         if not hasattr(self, '_tables'):
-            self._tables = self.metadata.tables.keys()
+            self._tables = list(self.metadata.tables.keys())
         return self._tables
 
     @property

--- a/libpysal/io/IOHandlers/db.py
+++ b/libpysal/io/IOHandlers/db.py
@@ -48,7 +48,7 @@ class SQLConnection(FileIO.FileIO):
     def seek(self):
         pass
 
-    def next(self):
+    def __next__(self):
         pass
 
     def close(self):

--- a/libpysal/io/IOHandlers/gal.py
+++ b/libpysal/io/IOHandlers/gal.py
@@ -103,7 +103,7 @@ class GalIO(FileIO.FileIO):
                 id, n_neighbors = self.file.readline().strip().split()
                 id = typ(id)
                 n_neighbors = int(n_neighbors)
-                neighbors_i = map(typ, self.file.readline().strip().split())
+                neighbors_i = list(map(typ, self.file.readline().strip().split()))
                 nn = len(neighbors_i)
                 extend([id] * nn)
                 counter += nn
@@ -137,7 +137,7 @@ class GalIO(FileIO.FileIO):
                 id, n_neighbors = self.file.readline().strip().split()
                 id = typ(id)
                 n_neighbors = int(n_neighbors)
-                neighbors_i = map(typ, self.file.readline().strip().split())
+                neighbors_i = list(map(typ, self.file.readline().strip().split()))
                 neighbors[id] = neighbors_i
                 ids.append(id)
             self.pos += 1

--- a/libpysal/io/IOHandlers/gal.py
+++ b/libpysal/io/IOHandlers/gal.py
@@ -99,7 +99,7 @@ class GalIO(FileIO.FileIO):
             append = col.append
             counter = 0
             typ = self.data_type
-            for i in xrange(n):
+            for i in range(n):
                 id, n_neighbors = self.file.readline().strip().split()
                 id = typ(id)
                 n_neighbors = int(n_neighbors)

--- a/libpysal/io/IOHandlers/geobugs_txt.py
+++ b/libpysal/io/IOHandlers/geobugs_txt.py
@@ -129,12 +129,12 @@ class GeoBUGSTextIO(FileIO.FileIO):
             part_text = fbody[start:end]
 
             part_length, start, end = len(part_text), 0, -1
-            for c in xrange(part_length):
+            for c in range(part_length):
                 if part_text[c].isdigit():
                     start = c
                     break
 
-            for c in xrange(part_length - 1, 0, -1):
+            for c in range(part_length - 1, 0, -1):
                 if part_text[c].isdigit():
                     end = c + 1
                     break
@@ -156,7 +156,7 @@ class GeoBUGSTextIO(FileIO.FileIO):
         neighbors = {}
         weights = {}
         pos = 0
-        for i in xrange(no_obs):
+        for i in range(no_obs):
             neighbors[i + 1] = []
             weights[i + 1] = []
             no_nghs = cardinalities[i]

--- a/libpysal/io/IOHandlers/gwt.py
+++ b/libpysal/io/IOHandlers/gwt.py
@@ -78,7 +78,7 @@ class GwtIO(FileIO.FileIO):
         """
         data = [row.strip().split() for row in self.file.readlines()]
         ids = filter(unique_filter(), [x[0] for x in data])
-        ids = map(id_type, ids)
+        ids = list(map(id_type, ids))
         WN = {}
         for id in ids:  # note: fromkeys is no good here, all keys end up sharing the say dict value
             WN[id] = {}
@@ -89,8 +89,8 @@ class GwtIO(FileIO.FileIO):
         weights = {}
         neighbors = {}
         for i in WN:
-            weights[i] = WN[i].values()
-            neighbors[i] = WN[i].keys()
+            weights[i] = list(WN[i].values())
+            neighbors[i] = list(WN[i].keys())
         if ret_ids:
             return weights, neighbors, ids
         else:
@@ -174,7 +174,7 @@ class GwtIO(FileIO.FileIO):
         write function by Myunghwa Hwang.
         """
         for id in obj.id_order:
-            neighbors = zip(obj.neighbors[id], obj.weights[id])
+            neighbors = list(zip(obj.neighbors[id], obj.weights[id]))
             str_id = "_".join(str(id).split())
             for neighbor, weight in neighbors:
                 neighbor = "_".join(str(neighbor).split())
@@ -262,7 +262,7 @@ class GwtIO(FileIO.FileIO):
     @staticmethod
     def __zero_offset(neighbors, weights, original_ids=None):
         if not original_ids:
-            original_ids = neighbors.keys()
+            original_ids = list(neighbors.keys())
         old_weights = weights
         new_weights = {}
         new_ids = {}

--- a/libpysal/io/IOHandlers/gwt.py
+++ b/libpysal/io/IOHandlers/gwt.py
@@ -43,7 +43,7 @@ class GwtIO(FileIO.FileIO):
         self.file = open(self.dataPath, self.mode)
 
     def _set_varName(self, val):
-        if issubclass(type(val), basestring):
+        if issubclass(type(val), str):
             self._varName = val
 
     def _get_varName(self):
@@ -51,7 +51,7 @@ class GwtIO(FileIO.FileIO):
     varName = property(fget=_get_varName, fset=_set_varName)
 
     def _set_shpName(self, val):
-        if issubclass(type(val), basestring):
+        if issubclass(type(val), str):
             self._shpName = val
 
     def _get_shpName(self):

--- a/libpysal/io/IOHandlers/gwt.py
+++ b/libpysal/io/IOHandlers/gwt.py
@@ -77,7 +77,7 @@ class GwtIO(FileIO.FileIO):
         _read function by Myunghwa Hwang.
         """
         data = [row.strip().split() for row in self.file.readlines()]
-        ids = filter(unique_filter(), [x[0] for x in data])
+        ids = list(filter(unique_filter(), [x[0] for x in data]))
         ids = list(map(id_type, ids))
         WN = {}
         for id in ids:  # note: fromkeys is no good here, all keys end up sharing the say dict value

--- a/libpysal/io/IOHandlers/mat.py
+++ b/libpysal/io/IOHandlers/mat.py
@@ -46,7 +46,7 @@ class MatIO(FileIO.FileIO):
         self.file = open(self.dataPath, self.mode + 'b')
 
     def _set_varName(self, val):
-        if issubclass(type(val), basestring):
+        if issubclass(type(val), str):
             self._varName = val
 
     def _get_varName(self):

--- a/libpysal/io/IOHandlers/mtx.py
+++ b/libpysal/io/IOHandlers/mtx.py
@@ -128,7 +128,7 @@ class MtxIO(FileIO.FileIO):
         if self.pos > 0:
             raise StopIteration
         mtx = sio.mmread(self.file)
-        ids = range(1, mtx.shape[0] + 1)  # matrix market indexes start at one
+        ids = list(range(1, mtx.shape[0] + 1))  # matrix market indexes start at one
         wsp = WSP(mtx, ids)
         if self._sparse:
             w = wsp

--- a/libpysal/io/IOHandlers/pyDbfIO.py
+++ b/libpysal/io/IOHandlers/pyDbfIO.py
@@ -243,7 +243,7 @@ class DBF(Tables.DataTable):
             try:
                 assert len(value) == size
             except:
-                print value, len(value), size
+                print(value, len(value), size)
                 raise
             self.f.write(value.encode())
             self.pos += 1
@@ -305,13 +305,13 @@ if __name__ == '__main__':
     newDB = pysal.open('copy.dbf', 'w')
     newDB.header = f.header
     newDB.field_spec = f.field_spec
-    print f.header
+    print(f.header)
     for row in f:
-        print row
+        print(row)
         newDB.write(row)
     newDB.close()
     copy = pysal.open('copy.dbf', 'r')
     f.seek(0)
-    print "HEADER: ", copy.header == f.header
-    print "SPEC: ", copy.field_spec == f.field_spec
-    print "DATA: ", list(copy) == list(f)
+    print("HEADER: ", copy.header == f.header)
+    print("SPEC: ", copy.field_spec == f.field_spec)
+    print("DATA: ", list(copy) == list(f))

--- a/libpysal/io/IOHandlers/pyDbfIO.py
+++ b/libpysal/io/IOHandlers/pyDbfIO.py
@@ -164,7 +164,7 @@ class DBF(Tables.DataTable):
         if rec[0] != ' ':
             return self.read_record(i + 1)
         result = []
-        for (name, typ, size, deci), value in itertools.izip(self.field_info, rec):
+        for (name, typ, size, deci), value in zip(self.field_info, rec):
             if name == 'DeletionFlag':
                 continue
             if typ == 'N':
@@ -222,7 +222,7 @@ class DBF(Tables.DataTable):
             raise TypeError("Rows must contains %d fields" % len(self.header))
         self.numrec += 1
         self.f.write(' '.encode())                        # deletion flag
-        for (typ, size, deci), value in itertools.izip(self.field_spec, obj):
+        for (typ, size, deci), value in zip(self.field_spec, obj):
             if value is None:
                 if typ == 'C':
                     value = ' ' * size
@@ -286,7 +286,7 @@ class DBF(Tables.DataTable):
                           lenheader, lenrecord)
         self.f.write(hdr)
         # field specs
-        for name, (typ, size, deci) in itertools.izip(self.header, self.field_spec):
+        for name, (typ, size, deci) in zip(self.header, self.field_spec):
             typ = typ.encode()
             name = name.ljust(11, '\x00')
             name = name.encode()

--- a/libpysal/io/IOHandlers/pyDbfIO.py
+++ b/libpysal/io/IOHandlers/pyDbfIO.py
@@ -65,7 +65,7 @@ class DBF(Tables.DataTable):
             fmt = 's' #each record is a string
             self._col_index = {}
             idx = 0
-            for fieldno in xrange(numfields):
+            for fieldno in range(numfields):
                 name, typ, size, deci = struct.unpack(
                     '<11sc4xBB14x', f.read(32)) #again, check struct for fmt def.
                 name = name.decode() #forces to unicode in 2, to str in 3
@@ -117,7 +117,7 @@ class DBF(Tables.DataTable):
         f = self.f
         f.seek(self.header_size + offset)
         col = [0] * self.n_records
-        for i in xrange(self.n_records):
+        for i in range(self.n_records):
             value = f.read(size)
             value = value.decode()
             f.seek(gap, 1)

--- a/libpysal/io/IOHandlers/pyDbfIO.py
+++ b/libpysal/io/IOHandlers/pyDbfIO.py
@@ -150,7 +150,7 @@ class DBF(Tables.DataTable):
                     value = MISSINGVALUE
                 else:
                     value = float(value)
-            if isinstance(value, str) or isinstance(value, unicode):
+            if isinstance(value, str) or isinstance(value, str):
                 value = value.rstrip()
             col[i] = value
         self.seek(prevPos)
@@ -197,7 +197,7 @@ class DBF(Tables.DataTable):
                     value = MISSINGVALUE
                 else:
                     value = float(value)
-            if isinstance(value, str) or isinstance(value, unicode):
+            if isinstance(value, str) or isinstance(value, str):
                 value = value.rstrip()
             result.append(value)
         return result

--- a/libpysal/io/IOHandlers/pyShpIO.py
+++ b/libpysal/io/IOHandlers/pyShpIO.py
@@ -169,7 +169,7 @@ class PurePyShpWrapper(FileIO.FileIO):
                 if self.dataObj.type() == 'POLYGON' and not cg.is_clockwise(vertices):
                     ### SHAPEFILE WARNING: Polygon %d topology has been fixed. (ccw -> cw)
                     warn("SHAPEFILE WARNING: Polygon %d topology has been fixed. (ccw -> cw)" % (self.pos), RuntimeWarning)
-                    print "SHAPEFILE WARNING: Polygon %d topology has been fixed. (ccw -> cw)" % (self.pos)
+                    print("SHAPEFILE WARNING: Polygon %d topology has been fixed. (ccw -> cw)" % (self.pos))
 
                 shp = self.type(vertices)
             else:

--- a/libpysal/io/IOHandlers/pyShpIO.py
+++ b/libpysal/io/IOHandlers/pyShpIO.py
@@ -153,7 +153,7 @@ class PurePyShpWrapper(FileIO.FileIO):
                 partsIndex = list(rec['Parts Index'])
                 partsIndex.append(None)
                 parts = [rec['Vertices'][partsIndex[i]:partsIndex[
-                    i + 1]] for i in xrange(rec['NumParts'])]
+                    i + 1]] for i in range(rec['NumParts'])]
                 if self.dataObj.type() == 'POLYGON':
                     is_cw = [cg.is_clockwise(part) for part in parts]
                     vertices = [part for part, cw in zip(parts, is_cw) if cw]

--- a/libpysal/io/IOHandlers/template.py
+++ b/libpysal/io/IOHandlers/template.py
@@ -136,9 +136,9 @@ if __name__ == '__main__':
     f = pysal.open('test.bar', 'r')
     s = ''.join(f.read())
     f.close()
-    print s
+    print(s)
 
     f = open('test.foo', 'r')
     s2 = f.read()
     f.close()
-    print s == s2
+    print(s == s2)

--- a/libpysal/io/IOHandlers/template.py
+++ b/libpysal/io/IOHandlers/template.py
@@ -46,7 +46,7 @@ class TemplateWriter(FileIO):
                     return True
                 else:
                     return False
-            result = filter(foobar, obj)  # e.g.   'foobara' == filter(foobar,'my little foobar example')
+            result = list(filter(foobar, obj))  # e.g.   'foobara' == filter(foobar,'my little foobar example')
 
             #do the actual writing...
             self.fileObj.write(result + '\n')
@@ -83,7 +83,7 @@ class TemplateReaderWriter(FileIO):
                 return True
             else:
                 return False
-        return filter(foobar, st)  # e.g.   'foobara' == filter(foobar,'my little foobar example')
+        return list(filter(foobar, st))  # e.g.   'foobara' == filter(foobar,'my little foobar example')
 
     def _read(self):
         """ the _read method should return only ONE object and raise StopIteration at the EOF."""

--- a/libpysal/io/IOHandlers/template.py
+++ b/libpysal/io/IOHandlers/template.py
@@ -38,7 +38,7 @@ class TemplateWriter(FileIO):
 
         # it's up to the writer to understand the object, you should check that object is of the type you expect and raise a TypeError is its now.
         # we will support writing string objects in this example, all string are derived from basestring...
-        if issubclass(type(obj), basestring):
+        if issubclass(type(obj), str):
 
             #Non-essential ...
             def foobar(c):
@@ -98,7 +98,7 @@ class TemplateReaderWriter(FileIO):
     def write(self, obj):
         """ .write method of the 'foobar' template, receives an obj """
         self._complain_ifclosed(self.closed)
-        if issubclass(type(obj), basestring):
+        if issubclass(type(obj), str):
             result = self._filter(obj)
             self.fileObj.write(result + '\n')
             self.pos += 1

--- a/libpysal/io/IOHandlers/tests/test_arcgis_dbf.py
+++ b/libpysal/io/IOHandlers/tests/test_arcgis_dbf.py
@@ -15,7 +15,7 @@ class test_ArcGISDbfIO(unittest.TestCase):
     def test_close(self):
         f = self.obj
         f.close()
-        self.failUnlessRaises(ValueError, f.read)
+        self.assertRaises(ValueError, f.read)
 
     def test_read(self):
         with warnings.catch_warnings(record=True) as warn:
@@ -30,7 +30,7 @@ class test_ArcGISDbfIO(unittest.TestCase):
 
     def test_seek(self):
         self.test_read()
-        self.failUnlessRaises(StopIteration, self.obj.read)
+        self.assertRaises(StopIteration, self.obj.read)
         self.obj.seek(0)
         self.test_read()
 

--- a/libpysal/io/IOHandlers/tests/test_arcgis_dbf.py
+++ b/libpysal/io/IOHandlers/tests/test_arcgis_dbf.py
@@ -26,7 +26,7 @@ class test_ArcGISDbfIO(unittest.TestCase):
                 assert "Missing Value Found, setting value to pysal.MISSINGVALUE" in str(warn[0].message)
         self.assertEqual(88, w.n)
         self.assertEqual(5.25, w.mean_neighbors)
-        self.assertEqual([1.0, 1.0, 1.0, 1.0], w[1].values())
+        self.assertEqual([1.0, 1.0, 1.0, 1.0], list(w[1].values()))
 
     def test_seek(self):
         self.test_read()

--- a/libpysal/io/IOHandlers/tests/test_arcgis_swm.py
+++ b/libpysal/io/IOHandlers/tests/test_arcgis_swm.py
@@ -20,7 +20,7 @@ class test_ArcGISSwmIO(unittest.TestCase):
         w = self.obj.read()
         self.assertEqual(88, w.n)
         self.assertEqual(5.25, w.mean_neighbors)
-        self.assertEqual([1.0, 1.0, 1.0, 1.0], w[1].values())
+        self.assertEqual([1.0, 1.0, 1.0, 1.0], list(w[1].values()))
 
     def test_seek(self):
         self.test_read()

--- a/libpysal/io/IOHandlers/tests/test_arcgis_swm.py
+++ b/libpysal/io/IOHandlers/tests/test_arcgis_swm.py
@@ -14,7 +14,7 @@ class test_ArcGISSwmIO(unittest.TestCase):
     def test_close(self):
         f = self.obj
         f.close()
-        self.failUnlessRaises(ValueError, f.read)
+        self.assertRaises(ValueError, f.read)
 
     def test_read(self):
         w = self.obj.read()
@@ -24,7 +24,7 @@ class test_ArcGISSwmIO(unittest.TestCase):
 
     def test_seek(self):
         self.test_read()
-        self.failUnlessRaises(StopIteration, self.obj.read)
+        self.assertRaises(StopIteration, self.obj.read)
         self.obj.seek(0)
         self.test_read()
 

--- a/libpysal/io/IOHandlers/tests/test_arcgis_txt.py
+++ b/libpysal/io/IOHandlers/tests/test_arcgis_txt.py
@@ -26,7 +26,7 @@ class test_ArcGISTextIO(unittest.TestCase):
                 assert "DBF relating to ArcGIS TEXT was not found, proceeding with unordered string ids." in str(warn[0].message)
         self.assertEqual(3, w.n)
         self.assertEqual(2.0, w.mean_neighbors)
-        self.assertEqual([0.1, 0.05], w[2].values())
+        self.assertEqual([0.1, 0.05], list(w[2].values()))
 
     def test_seek(self):
         self.test_read()

--- a/libpysal/io/IOHandlers/tests/test_arcgis_txt.py
+++ b/libpysal/io/IOHandlers/tests/test_arcgis_txt.py
@@ -15,7 +15,7 @@ class test_ArcGISTextIO(unittest.TestCase):
     def test_close(self):
         f = self.obj
         f.close()
-        self.failUnlessRaises(ValueError, f.read)
+        self.assertRaises(ValueError, f.read)
 
     def test_read(self):
         with warnings.catch_warnings(record=True) as warn:
@@ -30,7 +30,7 @@ class test_ArcGISTextIO(unittest.TestCase):
 
     def test_seek(self):
         self.test_read()
-        self.failUnlessRaises(StopIteration, self.obj.read)
+        self.assertRaises(StopIteration, self.obj.read)
         self.obj.seek(0)
         self.test_read()
 

--- a/libpysal/io/IOHandlers/tests/test_csvWrapper.py
+++ b/libpysal/io/IOHandlers/tests/test_csvWrapper.py
@@ -14,56 +14,56 @@ class test_csvWrapper(unittest.TestCase):
         self.obj = csvWrapper.csvWrapper(test_file, 'r')
 
     def test_len(self):
-        self.assertEquals(len(self.obj), 78)
+        self.assertEqual(len(self.obj), 78)
 
     def test_tell(self):
-        self.assertEquals(self.obj.tell(), 0)
+        self.assertEqual(self.obj.tell(), 0)
         self.obj.read(1)
-        self.assertEquals(self.obj.tell(), 1)
+        self.assertEqual(self.obj.tell(), 1)
         self.obj.read(50)
-        self.assertEquals(self.obj.tell(), 51)
+        self.assertEqual(self.obj.tell(), 51)
         self.obj.read()
-        self.assertEquals(self.obj.tell(), 78)
+        self.assertEqual(self.obj.tell(), 78)
 
     def test_seek(self):
         self.obj.seek(0)
-        self.assertEquals(self.obj.tell(), 0)
+        self.assertEqual(self.obj.tell(), 0)
         self.obj.seek(55)
-        self.assertEquals(self.obj.tell(), 55)
+        self.assertEqual(self.obj.tell(), 55)
         self.obj.read(1)
-        self.assertEquals(self.obj.tell(), 56)
+        self.assertEqual(self.obj.tell(), 56)
 
     def test_read(self):
         self.obj.seek(0)
         objs = self.obj.read()
-        self.assertEquals(len(objs), 78)
+        self.assertEqual(len(objs), 78)
         self.obj.seek(0)
         objsB = list(self.obj)
-        self.assertEquals(len(objsB), 78)
+        self.assertEqual(len(objsB), 78)
         for rowA, rowB in zip(objs, objsB):
-            self.assertEquals(rowA, rowB)
+            self.assertEqual(rowA, rowB)
 
     def test_casting(self):
         self.obj.cast('WKT', WKTParser())
         verts = [(-89.585220336914062, 39.978794097900391), (-89.581146240234375, 40.094867706298828), (-89.603988647460938, 40.095306396484375), (-89.60589599609375, 40.136119842529297), (-89.6103515625, 40.3251953125), (-89.269027709960938, 40.329566955566406), (-89.268562316894531, 40.285579681396484), (-89.154655456542969, 40.285774230957031), (-89.152763366699219, 40.054969787597656), (-89.151618957519531, 39.919403076171875), (-89.224777221679688, 39.918678283691406), (-89.411857604980469, 39.918041229248047), (-89.412437438964844, 39.931644439697266), (-89.495201110839844, 39.933486938476562), (-89.4927978515625, 39.980186462402344), (-89.585220336914062, 39.978794097900391)]
         if PY3:
             for i, pt in enumerate(self.obj.__next__()[0].vertices):
-                self.assertEquals(pt[:], verts[i])
+                self.assertEqual(pt[:], verts[i])
         else:
             for i, pt in enumerate(self.obj.next()[0].vertices):
-                self.assertEquals(pt[:], verts[i])
+                self.assertEqual(pt[:], verts[i])
 
     def test_by_col(self):
         for field in self.obj.header:
-            self.assertEquals(len(self.obj.by_col[field]), 78)
+            self.assertEqual(len(self.obj.by_col[field]), 78)
 
     def test_slicing(self):
         chunk = self.obj[50:55, 1:3]
-        self.assertEquals(chunk[0], ['Jefferson', 'Missouri'])
-        self.assertEquals(chunk[1], ['Jefferson', 'Illinois'])
-        self.assertEquals(chunk[2], ['Miller', 'Missouri'])
-        self.assertEquals(chunk[3], ['Maries', 'Missouri'])
-        self.assertEquals(chunk[4], ['White', 'Illinois'])
+        self.assertEqual(chunk[0], ['Jefferson', 'Missouri'])
+        self.assertEqual(chunk[1], ['Jefferson', 'Illinois'])
+        self.assertEqual(chunk[2], ['Miller', 'Missouri'])
+        self.assertEqual(chunk[3], ['Maries', 'Missouri'])
+        self.assertEqual(chunk[4], ['White', 'Illinois'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/libpysal/io/IOHandlers/tests/test_dat.py
+++ b/libpysal/io/IOHandlers/tests/test_dat.py
@@ -14,7 +14,7 @@ class test_DatIO(unittest.TestCase):
     def test_close(self):
         f = self.obj
         f.close()
-        self.failUnlessRaises(ValueError, f.read)
+        self.assertRaises(ValueError, f.read)
 
     def test_read(self):
         w = self.obj.read()
@@ -24,7 +24,7 @@ class test_DatIO(unittest.TestCase):
 
     def test_seek(self):
         self.test_read()
-        self.failUnlessRaises(StopIteration, self.obj.read)
+        self.assertRaises(StopIteration, self.obj.read)
         self.obj.seek(0)
         self.test_read()
 

--- a/libpysal/io/IOHandlers/tests/test_dat.py
+++ b/libpysal/io/IOHandlers/tests/test_dat.py
@@ -20,7 +20,7 @@ class test_DatIO(unittest.TestCase):
         w = self.obj.read()
         self.assertEqual(49, w.n)
         self.assertEqual(4.7346938775510203, w.mean_neighbors)
-        self.assertEqual([0.5, 0.5], w[5.0].values())
+        self.assertEqual([0.5, 0.5], list(w[5.0].values()))
 
     def test_seek(self):
         self.test_read()

--- a/libpysal/io/IOHandlers/tests/test_db.py
+++ b/libpysal/io/IOHandlers/tests/test_db.py
@@ -45,7 +45,7 @@ class Test_sqlite_reader(ut.TestCase):
 
     def test_deserialize(self):
         db = psopen('sqlite:///test.db')
-        self.assertEqual(db.tables, [u'newhaven'])
+        self.assertEqual(db.tables, ['newhaven'])
 
         gj = db._get_gjson('newhaven')
         self.assertFalse(True)

--- a/libpysal/io/IOHandlers/tests/test_gal.py
+++ b/libpysal/io/IOHandlers/tests/test_gal.py
@@ -18,7 +18,7 @@ class test_GalIO(unittest.TestCase):
     def test_close(self):
         f = self.obj
         f.close()
-        self.failUnlessRaises(ValueError, f.read)
+        self.assertRaises(ValueError, f.read)
 
     def test_read(self):
         # reading a GAL returns a W
@@ -30,7 +30,7 @@ class test_GalIO(unittest.TestCase):
 
     def test_seek(self):
         self.test_read()
-        self.failUnlessRaises(StopIteration, self.obj.read)
+        self.assertRaises(StopIteration, self.obj.read)
         self.obj.seek(0)
         self.test_read()
 

--- a/libpysal/io/IOHandlers/tests/test_geobugs_txt.py
+++ b/libpysal/io/IOHandlers/tests/test_geobugs_txt.py
@@ -19,7 +19,7 @@ class test_GeoBUGSTextIO(unittest.TestCase):
         for obj in [self.obj_scot, self.obj_col]:
             f = obj
             f.close()
-            self.failUnlessRaises(ValueError, f.read)
+            self.assertRaises(ValueError, f.read)
 
     def test_read(self):
         w_scot = self.obj_scot.read()
@@ -34,8 +34,8 @@ class test_GeoBUGSTextIO(unittest.TestCase):
 
     def test_seek(self):
         self.test_read()
-        self.failUnlessRaises(StopIteration, self.obj_scot.read)
-        self.failUnlessRaises(StopIteration, self.obj_col.read)
+        self.assertRaises(StopIteration, self.obj_scot.read)
+        self.assertRaises(StopIteration, self.obj_col.read)
         self.obj_scot.seek(0)
         self.obj_col.seek(0)
         self.test_read()

--- a/libpysal/io/IOHandlers/tests/test_geobugs_txt.py
+++ b/libpysal/io/IOHandlers/tests/test_geobugs_txt.py
@@ -25,12 +25,12 @@ class test_GeoBUGSTextIO(unittest.TestCase):
         w_scot = self.obj_scot.read()
         self.assertEqual(56, w_scot.n)
         self.assertEqual(4.1785714285714288, w_scot.mean_neighbors)
-        self.assertEqual([1.0, 1.0, 1.0], w_scot[1].values())
+        self.assertEqual([1.0, 1.0, 1.0], list(w_scot[1].values()))
 
         w_col = self.obj_col.read()
         self.assertEqual(49, w_col.n)
         self.assertEqual(4.6938775510204085, w_col.mean_neighbors)
-        self.assertEqual([0.5, 0.5], w_col[1].values())
+        self.assertEqual([0.5, 0.5], list(w_col[1].values()))
 
     def test_seek(self):
         self.test_read()

--- a/libpysal/io/IOHandlers/tests/test_geoda_txt.py
+++ b/libpysal/io/IOHandlers/tests/test_geoda_txt.py
@@ -20,7 +20,7 @@ class test_GeoDaTxtReader(unittest.TestCase):
     def test_close(self):
         f = self.obj
         f.close()
-        self.failUnlessRaises(ValueError, f.read)
+        self.assertRaises(ValueError, f.read)
 
 if __name__ == '__main__':
     unittest.main()

--- a/libpysal/io/IOHandlers/tests/test_gwt.py
+++ b/libpysal/io/IOHandlers/tests/test_gwt.py
@@ -15,7 +15,7 @@ class test_GwtIO(unittest.TestCase):
     def test_close(self):
         f = self.obj
         f.close()
-        self.failUnlessRaises(ValueError, f.read)
+        self.assertRaises(ValueError, f.read)
 
     def test_read(self):
         w = self.obj.read()
@@ -26,7 +26,7 @@ class test_GwtIO(unittest.TestCase):
 
     def test_seek(self):
         self.test_read()
-        self.failUnlessRaises(StopIteration, self.obj.read)
+        self.assertRaises(StopIteration, self.obj.read)
         self.obj.seek(0)
         self.test_read()
 

--- a/libpysal/io/IOHandlers/tests/test_gwt.py
+++ b/libpysal/io/IOHandlers/tests/test_gwt.py
@@ -22,7 +22,7 @@ class test_GwtIO(unittest.TestCase):
         self.assertEqual(168, w.n)
         self.assertEqual(16.678571428571427, w.mean_neighbors)
         w.transform = 'B'
-        self.assertEqual([1.0], w[1].values())
+        self.assertEqual([1.0], list(w[1].values()))
 
     def test_seek(self):
         self.test_read()

--- a/libpysal/io/IOHandlers/tests/test_mat.py
+++ b/libpysal/io/IOHandlers/tests/test_mat.py
@@ -15,7 +15,7 @@ class test_MatIO(unittest.TestCase):
     def test_close(self):
         f = self.obj
         f.close()
-        self.failUnlessRaises(ValueError, f.read)
+        self.assertRaises(ValueError, f.read)
 
     def test_read(self):
         w = self.obj.read()
@@ -25,7 +25,7 @@ class test_MatIO(unittest.TestCase):
 
     def test_seek(self):
         self.test_read()
-        self.failUnlessRaises(StopIteration, self.obj.read)
+        self.assertRaises(StopIteration, self.obj.read)
         self.obj.seek(0)
         self.test_read()
 

--- a/libpysal/io/IOHandlers/tests/test_mat.py
+++ b/libpysal/io/IOHandlers/tests/test_mat.py
@@ -21,7 +21,7 @@ class test_MatIO(unittest.TestCase):
         w = self.obj.read()
         self.assertEqual(46, w.n)
         self.assertEqual(4.0869565217391308, w.mean_neighbors)
-        self.assertEqual([1.0, 1.0, 1.0, 1.0], w[1].values())
+        self.assertEqual([1.0, 1.0, 1.0, 1.0], list(w[1].values()))
 
     def test_seek(self):
         self.test_read()

--- a/libpysal/io/IOHandlers/tests/test_mtx.py
+++ b/libpysal/io/IOHandlers/tests/test_mtx.py
@@ -23,7 +23,7 @@ class test_MtxIO(unittest.TestCase):
         self.assertEqual(49, w.n)
         self.assertEqual(4.7346938775510203, w.mean_neighbors)
         self.assertEqual([0.33329999999999999, 0.33329999999999999,
-                          0.33329999999999999], w[1].values())
+                          0.33329999999999999], list(w[1].values()))
         s0 = w.s0
         self.obj.seek(0)
         wsp = self.obj.read(sparse=True)

--- a/libpysal/io/IOHandlers/tests/test_mtx.py
+++ b/libpysal/io/IOHandlers/tests/test_mtx.py
@@ -16,7 +16,7 @@ class test_MtxIO(unittest.TestCase):
     def test_close(self):
         f = self.obj
         f.close()
-        self.failUnlessRaises(ValueError, f.read)
+        self.assertRaises(ValueError, f.read)
 
     def test_read(self):
         w = self.obj.read()
@@ -32,7 +32,7 @@ class test_MtxIO(unittest.TestCase):
 
     def test_seek(self):
         self.test_read()
-        self.failUnlessRaises(StopIteration, self.obj.read)
+        self.assertRaises(StopIteration, self.obj.read)
         self.obj.seek(0)
         self.test_read()
 

--- a/libpysal/io/IOHandlers/tests/test_pyShpIO.py
+++ b/libpysal/io/IOHandlers/tests/test_pyShpIO.py
@@ -18,36 +18,36 @@ class test_PurePyShpWrapper(unittest.TestCase):
         self.shxcopy = shpcopy.replace('.shp', '.shx')
 
     def test_len(self):
-        self.assertEquals(len(self.shpObj), 195)
+        self.assertEqual(len(self.shpObj), 195)
 
     def test_tell(self):
-        self.assertEquals(self.shpObj.tell(), 0)
+        self.assertEqual(self.shpObj.tell(), 0)
         self.shpObj.read(1)
-        self.assertEquals(self.shpObj.tell(), 1)
+        self.assertEqual(self.shpObj.tell(), 1)
         self.shpObj.read(50)
-        self.assertEquals(self.shpObj.tell(), 51)
+        self.assertEqual(self.shpObj.tell(), 51)
         self.shpObj.read()
-        self.assertEquals(self.shpObj.tell(), 195)
+        self.assertEqual(self.shpObj.tell(), 195)
 
     def test_seek(self):
         self.shpObj.seek(0)
-        self.assertEquals(self.shpObj.tell(), 0)
+        self.assertEqual(self.shpObj.tell(), 0)
         self.shpObj.seek(55)
-        self.assertEquals(self.shpObj.tell(), 55)
+        self.assertEqual(self.shpObj.tell(), 55)
         self.shpObj.read(1)
-        self.assertEquals(self.shpObj.tell(), 56)
+        self.assertEqual(self.shpObj.tell(), 56)
 
     def test_read(self):
         self.shpObj.seek(0)
         objs = self.shpObj.read()
-        self.assertEquals(len(objs), 195)
+        self.assertEqual(len(objs), 195)
 
         self.shpObj.seek(0)
         objsB = list(self.shpObj)
-        self.assertEquals(len(objsB), 195)
+        self.assertEqual(len(objsB), 195)
 
         for shpA, shpB in zip(objs, objsB):
-            self.assertEquals(shpA.vertices, shpB.vertices)
+            self.assertEqual(shpA.vertices, shpB.vertices)
 
     def test_random_access(self):
         self.shpObj.seek(57)
@@ -56,9 +56,9 @@ class test_PurePyShpWrapper(unittest.TestCase):
         shp32 = self.shpObj.read(1)[0]
 
         self.shpObj.seek(57)
-        self.assertEquals(self.shpObj.read(1)[0].vertices, shp57.vertices)
+        self.assertEqual(self.shpObj.read(1)[0].vertices, shp57.vertices)
         self.shpObj.seek(32)
-        self.assertEquals(self.shpObj.read(1)[0].vertices, shp32.vertices)
+        self.assertEqual(self.shpObj.read(1)[0].vertices, shp32.vertices)
 
     def test_write(self):
         out = PurePyShpWrapper(self.shpcopy, 'w')
@@ -69,13 +69,13 @@ class test_PurePyShpWrapper(unittest.TestCase):
 
         orig = open(self.test_file, 'rb')
         copy = open(self.shpcopy, 'rb')
-        self.assertEquals(orig.read(), copy.read())
+        self.assertEqual(orig.read(), copy.read())
         orig.close()
         copy.close()
 
         oshx = open(self.test_file.replace('.shp', '.shx'), 'rb')
         cshx = open(self.shxcopy, 'rb')
-        self.assertEquals(oshx.read(), cshx.read())
+        self.assertEqual(oshx.read(), cshx.read())
         oshx.close()
         cshx.close()
 

--- a/libpysal/io/IOHandlers/tests/test_stata_txt.py
+++ b/libpysal/io/IOHandlers/tests/test_stata_txt.py
@@ -25,13 +25,13 @@ class test_StataTextIO(unittest.TestCase):
         w_sparse = self.obj_sparse.read()
         self.assertEqual(56, w_sparse.n)
         self.assertEqual(4.0, w_sparse.mean_neighbors)
-        self.assertEqual([1.0, 1.0, 1.0, 1.0, 1.0], w_sparse[1].values())
+        self.assertEqual([1.0, 1.0, 1.0, 1.0, 1.0], list(w_sparse[1].values()))
 
         w_full = self.obj_full.read()
         self.assertEqual(56, w_full.n)
         self.assertEqual(4.0, w_full.mean_neighbors)
         self.assertEqual(
-            [0.125, 0.125, 0.125, 0.125, 0.125], w_full[1].values())
+            [0.125, 0.125, 0.125, 0.125, 0.125], list(w_full[1].values()))
 
     def test_seek(self):
         self.test_read()

--- a/libpysal/io/IOHandlers/tests/test_stata_txt.py
+++ b/libpysal/io/IOHandlers/tests/test_stata_txt.py
@@ -19,7 +19,7 @@ class test_StataTextIO(unittest.TestCase):
         for obj in [self.obj_sparse, self.obj_full]:
             f = obj
             f.close()
-            self.failUnlessRaises(ValueError, f.read)
+            self.assertRaises(ValueError, f.read)
 
     def test_read(self):
         w_sparse = self.obj_sparse.read()
@@ -35,8 +35,8 @@ class test_StataTextIO(unittest.TestCase):
 
     def test_seek(self):
         self.test_read()
-        self.failUnlessRaises(StopIteration, self.obj_sparse.read)
-        self.failUnlessRaises(StopIteration, self.obj_full.read)
+        self.assertRaises(StopIteration, self.obj_sparse.read)
+        self.assertRaises(StopIteration, self.obj_full.read)
         self.obj_sparse.seek(0)
         self.obj_full.seek(0)
         self.test_read()

--- a/libpysal/io/IOHandlers/tests/test_wk1.py
+++ b/libpysal/io/IOHandlers/tests/test_wk1.py
@@ -20,7 +20,7 @@ class test_Wk1IO(unittest.TestCase):
         w = self.obj.read()
         self.assertEqual(46, w.n)
         self.assertEqual(4.0869565217391308, w.mean_neighbors)
-        self.assertEqual([1.0, 1.0, 1.0, 1.0], w[1].values())
+        self.assertEqual([1.0, 1.0, 1.0, 1.0], list(w[1].values()))
 
     def test_seek(self):
         self.test_read()

--- a/libpysal/io/IOHandlers/tests/test_wk1.py
+++ b/libpysal/io/IOHandlers/tests/test_wk1.py
@@ -14,7 +14,7 @@ class test_Wk1IO(unittest.TestCase):
     def test_close(self):
         f = self.obj
         f.close()
-        self.failUnlessRaises(ValueError, f.read)
+        self.assertRaises(ValueError, f.read)
 
     def test_read(self):
         w = self.obj.read()
@@ -24,7 +24,7 @@ class test_Wk1IO(unittest.TestCase):
 
     def test_seek(self):
         self.test_read()
-        self.failUnlessRaises(StopIteration, self.obj.read)
+        self.assertRaises(StopIteration, self.obj.read)
         self.obj.seek(0)
         self.test_read()
 

--- a/libpysal/io/IOHandlers/tests/test_wkt.py
+++ b/libpysal/io/IOHandlers/tests/test_wkt.py
@@ -12,7 +12,7 @@ class test_WKTReader(unittest.TestCase):
     def test_close(self):
         f = self.obj
         f.close()
-        self.failUnlessRaises(ValueError, f.read)
+        self.assertRaises(ValueError, f.read)
         # w_kt_reader = WKTReader(*args, **kwargs)
         # self.assertEqual(expected, w_kt_reader.close())
 

--- a/libpysal/io/IOHandlers/wk1.py
+++ b/libpysal/io/IOHandlers/wk1.py
@@ -146,7 +146,7 @@ class Wk1IO(FileIO.FileIO):
         self.file = open(self.dataPath, self.mode + 'b')
 
     def _set_varName(self, val):
-        if issubclass(type(val), basestring):
+        if issubclass(type(val), str):
             self._varName = val
 
     def _get_varName(self):

--- a/libpysal/io/Tables.py
+++ b/libpysal/io/Tables.py
@@ -1,5 +1,5 @@
 __all__ = ['DataTable']
-import FileIO
+from . import FileIO
 from ..common import requires
 from warnings import warn
 import numpy as np
@@ -206,7 +206,7 @@ class DataTable(FileIO.FileIO):
             if read_shp is True or self.dataPath.endswith('.dbf'):
                 read_shp = self.dataPath[:-3] + 'shp'
             try:
-                from geotable.shp import shp2series
+                from .geotable.shp import shp2series
                 df['geometry'] = shp2series(self.dataPath[:-3] + 'shp')
             except IOError as e:
                 warn('Encountered the following error in attempting to read'

--- a/libpysal/io/Tables.py
+++ b/libpysal/io/Tables.py
@@ -181,10 +181,10 @@ class DataTable(FileIO.FileIO):
         if isinstance(rows, slice):
             row_start, row_stop, row_step = rows.indices(len(self))
             self.seek(row_start)
-            data = [self.next() for i in range(row_start, row_stop, row_step)]
+            data = [next(self) for i in range(row_start, row_stop, row_step)]
         else:
             self.seek(slice(rows).indices(len(self))[1])
-            data = [self.next()]
+            data = [next(self)]
         if cols is not None:
             if isinstance(cols, slice):
                 col_start, col_stop, col_step = cols.indices(len(data[0]))

--- a/libpysal/io/Tables.py
+++ b/libpysal/io/Tables.py
@@ -167,7 +167,7 @@ class DataTable(FileIO.FileIO):
             #>>> assert index in range(0, len(table))
         """
         prevPos = self.tell()
-        if issubclass(type(key), basestring):
+        if issubclass(type(key), str):
             raise TypeError("index should be int or slice")
         if issubclass(type(key), int) or isinstance(key, slice):
             rows = key

--- a/libpysal/io/__init__.py
+++ b/libpysal/io/__init__.py
@@ -1,2 +1,2 @@
-import FileIO
-import geotable as gt
+from . import FileIO
+from . import geotable as gt

--- a/libpysal/io/geotable/__init__.py
+++ b/libpysal/io/geotable/__init__.py
@@ -1,2 +1,2 @@
-from file import read_files, write_files
+from .file import read_files, write_files
 

--- a/libpysal/io/geotable/config.py
+++ b/libpysal/io/geotable/config.py
@@ -15,12 +15,12 @@ def set_preference(pkg):
     """
     if pkg.lower() == 'shapely':
         ops.atomic.__dict__.update({k:v for k,v in
-                                    ops.atomic._s.__dict__.items() 
+                                    list(ops.atomic._s.__dict__.items()) 
                                     if not k.startswith('_')})
         ops.atomic._preferred = ops.atomic._s
     elif pkg.lower().startswith('att'):
         ops.atomic.__dict__.update({k:v for k,v in
-                                    ops.atomic._a.__dict__.items() 
+                                    list(ops.atomic._a.__dict__.items()) 
                                     if not k.startswith('_')})
         ops.atomic._preferred = ops.atomic._a
     else:

--- a/libpysal/io/geotable/config.py
+++ b/libpysal/io/geotable/config.py
@@ -55,9 +55,9 @@ def get_provider(fn=None):
     if fn is None:
         return ops.atomic._preferred
     try:
-        fprovenance = fn.func.func_name
+        fprovenance = fn.func.__name__
     except AttributeError:
-        fprovenance = fn.func_name
+        fprovenance = fn.__name__
     if fprovenance == 'get_attr':
         return ops._accessors
     else:

--- a/libpysal/io/geotable/dbf.py
+++ b/libpysal/io/geotable/dbf.py
@@ -101,7 +101,7 @@ def df2dbf(df, dbf_path, my_specs=None):
     db = ps_open(dbf_path, 'w')
     db.header = list(df.columns)
     db.field_spec = specs
-    for i, row in df.T.items():
+    for i, row in list(df.T.items()):
         db.write(row)
     db.close()
     return dbf_path

--- a/libpysal/io/geotable/dbf.py
+++ b/libpysal/io/geotable/dbf.py
@@ -101,7 +101,7 @@ def df2dbf(df, dbf_path, my_specs=None):
     db = ps_open(dbf_path, 'w')
     db.header = list(df.columns)
     db.field_spec = specs
-    for i, row in df.T.iteritems():
+    for i, row in df.T.items():
         db.write(row)
     db.close()
     return dbf_path

--- a/libpysal/io/geotable/file.py
+++ b/libpysal/io/geotable/file.py
@@ -2,8 +2,8 @@ from ...weights.Contiguity import Rook, Queen
 from ..FileIO import FileIO as ps_open
 from .utils import insert_metadata
 import os
-from shp import shp2series, series2shp
-from dbf import dbf2df, df2dbf
+from .shp import shp2series, series2shp
+from .dbf import dbf2df, df2dbf
 
 
 def read_files(filepath, **kwargs):

--- a/libpysal/io/geotable/wrappers.py
+++ b/libpysal/io/geotable/wrappers.py
@@ -35,4 +35,4 @@ _readers = {'read_shapefile':read_files,
             'read_fiona':fiona}
 _writers = {'to_shapefile':write_files}
 
-_pandas_readers = {k:v for k,v in pd.io.api.__dict__.items() if k.startswith('read_')}
+_pandas_readers = {k:v for k,v in list(pd.io.api.__dict__.items()) if k.startswith('read_')}

--- a/libpysal/io/util/__init__.py
+++ b/libpysal/io/util/__init__.py
@@ -1,2 +1,2 @@
-from wkt import *
-from shapefile import *
+from .wkt import *
+from .shapefile import *

--- a/libpysal/io/util/shapefile.py
+++ b/libpysal/io/util/shapefile.py
@@ -27,6 +27,7 @@ if PY3:
     izip = zip
 else:
     from cStringIO import StringIO
+    from itertools import izip
     
 
 if sys.byteorder == 'little':

--- a/libpysal/io/util/shapefile.py
+++ b/libpysal/io/util/shapefile.py
@@ -467,7 +467,7 @@ class shx_file:
         fmt = '>%di' % (2 * numRecords)
         size = calcsize(fmt)
         dat = unpack(fmt, self.fileObj.read(size))
-        self.index = [(dat[i] * 2, dat[i + 1] * 2) for i in xrange(
+        self.index = [(dat[i] * 2, dat[i + 1] * 2) for i in range(
             0, len(dat), 2)]
 
     def _create_shx_file(self):

--- a/libpysal/io/util/shapefile.py
+++ b/libpysal/io/util/shapefile.py
@@ -16,7 +16,7 @@ __author__ = "Charles R Schmidt <schmidtc@gmail.com>"
 
 from struct import calcsize, unpack, pack
 
-from itertools import izip, islice
+from itertools import islice
 import array
 import sys
 
@@ -24,8 +24,10 @@ PY3 = int(sys.version[0]) > 2
 
 if PY3:
     import io
+    izip = zip
 else:
     from cStringIO import StringIO
+    from itertools import izip
 
 if sys.byteorder == 'little':
     SYS_BYTE_ORDER = '<'
@@ -634,7 +636,7 @@ class PolyLine:
         #record['Vertices'] = [(record['Vertices'][i],record['Vertices'][i+1]) for i in xrange(0,record['NumPoints']*2,2)]
         verts = record['Vertices']
         #Next line is equivalent to: zip(verts[::2],verts[1::2])
-        record['Vertices'] = list(izip(
+        record['Vertices'] = list(zip(
             islice(verts, 0, None, 2), islice(verts, 1, None, 2)))
         if not record['Parts Index']:
             record['Parts Index'] = [0]
@@ -683,7 +685,7 @@ class PolyLineZ(object):
                          ('Marray', ('d', record['NumPoints']), '<'),)
         _unpackDict2(record, contentStruct, dat)
         verts = record['Vertices']
-        record['Vertices'] = list(izip(
+        record['Vertices'] = list(zip(
             islice(verts, 0, None, 2), islice(verts, 1, None, 2)))
         if not record['Parts Index']:
             record['Parts Index'] = [0]

--- a/libpysal/io/util/shapefile.py
+++ b/libpysal/io/util/shapefile.py
@@ -323,7 +323,7 @@ class shp_file:
     def type(self):
         return self.shape.String_Type
 
-    def next(self):
+    def __next__(self):
         """returns the next Shape in the shapeFile
 
         Example:

--- a/libpysal/io/util/shapefile.py
+++ b/libpysal/io/util/shapefile.py
@@ -27,7 +27,7 @@ if PY3:
     izip = zip
 else:
     from cStringIO import StringIO
-    from itertools import izip
+    
 
 if sys.byteorder == 'little':
     SYS_BYTE_ORDER = '<'

--- a/libpysal/io/util/tests/test_shapefile.py
+++ b/libpysal/io/util/tests/test_shapefile.py
@@ -108,10 +108,10 @@ class test_shp_file(unittest.TestCase):
         points = [pt for pt in shp]
         expected = {'Y': -0.25904661905760773, 'X': -
                     0.00068176617532103578, 'Shape Type': 1}
-        self.assertEqual(expected, shp.next())
+        self.assertEqual(expected, next(shp))
         expected = {'Y': -0.25630328607387354, 'X':
                     0.11697145363360706, 'Shape Type': 1}
-        self.assertEqual(expected, shp.next())
+        self.assertEqual(expected, next(shp))
 
     def test_type(self):
         shp = shp_file(pysal_examples.get_path('Point.shp'))

--- a/libpysal/io/util/tests/test_shapefile.py
+++ b/libpysal/io/util/tests/test_shapefile.py
@@ -77,7 +77,7 @@ class test_shp_file(unittest.TestCase):
         shp.close()
 
         for a, b in zip(points, shp_file('test_point')):
-            self.assertEquals(a, b)
+            self.assertEqual(a, b)
         os.remove('test_point.shp')
         os.remove('test_point.shx')
 
@@ -203,7 +203,7 @@ class TestPolyLine(unittest.TestCase):
 
 class TestMultiPoint(unittest.TestCase):
     def test___init__(self):
-        self.failUnlessRaises(NotImplementedError, MultiPoint)
+        self.assertRaises(NotImplementedError, MultiPoint)
 
 
 class TestPointZ(unittest.TestCase):
@@ -220,7 +220,7 @@ class TestPointZ(unittest.TestCase):
 
 class TestPolyLineZ(unittest.TestCase):
     def test___init__(self):
-        self.failUnlessRaises(NotImplementedError, PolyLineZ)
+        self.assertRaises(NotImplementedError, PolyLineZ)
 
 
 class TestPolyLineZ(unittest.TestCase):
@@ -263,37 +263,37 @@ class TestPolygonZ(unittest.TestCase):
 
 class TestMultiPointZ(unittest.TestCase):
     def test___init__(self):
-        self.failUnlessRaises(NotImplementedError, MultiPointZ)
+        self.assertRaises(NotImplementedError, MultiPointZ)
         # multi_point_z = MultiPointZ()
 
 
 class TestPointM(unittest.TestCase):
     def test___init__(self):
-        self.failUnlessRaises(NotImplementedError, PointM)
+        self.assertRaises(NotImplementedError, PointM)
         # point_m = PointM()
 
 
 class TestPolyLineM(unittest.TestCase):
     def test___init__(self):
-        self.failUnlessRaises(NotImplementedError, PolyLineM)
+        self.assertRaises(NotImplementedError, PolyLineM)
         # poly_line_m = PolyLineM()
 
 
 class TestPolygonM(unittest.TestCase):
     def test___init__(self):
-        self.failUnlessRaises(NotImplementedError, PolygonM)
+        self.assertRaises(NotImplementedError, PolygonM)
         # polygon_m = PolygonM()
 
 
 class TestMultiPointM(unittest.TestCase):
     def test___init__(self):
-        self.failUnlessRaises(NotImplementedError, MultiPointM)
+        self.assertRaises(NotImplementedError, MultiPointM)
         # multi_point_m = MultiPointM()
 
 
 class TestMultiPatch(unittest.TestCase):
     def test___init__(self):
-        self.failUnlessRaises(NotImplementedError, MultiPatch)
+        self.assertRaises(NotImplementedError, MultiPatch)
         # multi_patch = MultiPatch()
 
 
@@ -308,7 +308,7 @@ class _TestPoints(unittest.TestCase):
 
         shp = list(shp_file('test_point'))
         for a, b in zip(points, shp):
-            self.assertEquals(a, b)
+            self.assertEqual(a, b)
         os.remove('test_point.shp')
         os.remove('test_point.shx')
 
@@ -338,7 +338,7 @@ class _TestPolyLines(unittest.TestCase):
         shp.close()
         shp = list(shp_file('test_line'))
         for a, b in zip(shapes, shp):
-            self.assertEquals(a, b)
+            self.assertEqual(a, b)
         os.remove('test_line.shp')
         os.remove('test_line.shx')
 
@@ -369,7 +369,7 @@ class _TestPolygons(unittest.TestCase):
         shp.close()
         shp = list(shp_file('test_poly'))
         for a, b in zip(shapes, shp):
-            self.assertEquals(a, b)
+            self.assertEqual(a, b)
         os.remove('test_poly.shp')
         os.remove('test_poly.shx')
 

--- a/libpysal/io/util/tests/test_weight_converter.py
+++ b/libpysal/io/util/tests/test_weight_converter.py
@@ -20,8 +20,8 @@ class test_WeightConverter(unittest.TestCase):
         dataformats = ['arcgis_dbf', 'arcgis_text', None, None, None, None, None,
                        'geobugs_text', 'stata_text', 'stata_text', None, None]
         ns = [88, 3, 88, 49, 49, 100, 168, 56, 56, 56, 46, 46]
-        self.dataformats = dict(zip(self.test_files, dataformats))
-        self.ns = dict(zip(self.test_files, ns))
+        self.dataformats = dict(list(zip(self.test_files, dataformats)))
+        self.ns = dict(list(zip(self.test_files, ns)))
         self.fileformats = [('dbf', 'arcgis_dbf'), ('txt', 'arcgis_text'), ('swm', None),
                             ('dat', None), ('mtx', None), ('gal', None), ('',
                                                                           'geobugs_text'),

--- a/libpysal/io/util/tests/test_wkt.py
+++ b/libpysal/io/util/tests/test_wkt.py
@@ -20,34 +20,34 @@ class test_WKTParser(unittest.TestCase):
 
     def test_Point(self):
         pt = self.parser(self.wktPOINT)
-        self.assert_(issubclass(type(pt), Point))
-        self.assertEquals(pt[:], (6.0, 10.0))
+        self.assertTrue(issubclass(type(pt), Point))
+        self.assertEqual(pt[:], (6.0, 10.0))
 
     def test_LineString(self):
         line = self.parser(self.wktLINESTRING)
-        self.assert_(issubclass(type(line), Chain))
+        self.assertTrue(issubclass(type(line), Chain))
         parts = [[pt[:] for pt in part] for part in line.parts]
-        self.assertEquals(parts, [[(3.0, 4.0), (10.0, 50.0), (20.0, 25.0)]])
-        self.assertEquals(line.len, 73.455384532199886)
+        self.assertEqual(parts, [[(3.0, 4.0), (10.0, 50.0), (20.0, 25.0)]])
+        self.assertEqual(line.len, 73.455384532199886)
 
     def test_Polygon(self):
         poly = self.parser(self.wktPOLYGON)
-        self.assert_(issubclass(type(poly), Polygon))
+        self.assertTrue(issubclass(type(poly), Polygon))
         parts = [[pt[:] for pt in part] for part in poly.parts]
-        self.assertEquals(parts, [[(1.0, 1.0), (1.0, 5.0), (5.0, 5.0), (5.0,
+        self.assertEqual(parts, [[(1.0, 1.0), (1.0, 5.0), (5.0, 5.0), (5.0,
                                                                         1.0), (1.0, 1.0)], [(2.0, 2.0), (2.0, 3.0), (3.0, 3.0), (3.0, 2.0),
                                                                                             (2.0, 2.0)]])
-        self.assertEquals(
+        self.assertEqual(
             poly.centroid, (2.9705882352941178, 2.9705882352941178))
-        self.assertEquals(poly.area, 17.0)
+        self.assertEqual(poly.area, 17.0)
 
     def test_fromWKT(self):
         for wkt in self.unsupported:
-            self.failUnlessRaises(
+            self.assertRaises(
                 NotImplementedError, self.parser.fromWKT, wkt)
         for wkt in self.empty:
-            self.assertEquals(self.parser.fromWKT(wkt), None)
-        self.assertEquals(self.parser.__call__, self.parser.fromWKT)
+            self.assertEqual(self.parser.fromWKT(wkt), None)
+        self.assertEqual(self.parser.__call__, self.parser.fromWKT)
 
 if __name__ == '__main__':
     unittest.main()

--- a/libpysal/io/util/wkb.py
+++ b/libpysal/io/util/wkb.py
@@ -203,10 +203,10 @@ if __name__ == '__main__':
         import shapely.wkt, shapely.geometry
         from pysal.contrib.shapely_ext import to_wkb
     except ImportError:
-        print "shapely is used to test this module."
+        print("shapely is used to test this module.")
         raise
     for example in wktExamples:
-        print example
+        print(example)
         shape0= shapely.wkt.loads(example)
         shape1 = loads(shape0.to_wkb())
         if example.startswith('MULTIPOINT'):
@@ -220,11 +220,11 @@ if __name__ == '__main__':
             shape2 = shapely.geometry.asShape(shape1)
 
 
-        print shape1
+        print(shape1)
         if shape2:
             assert shape0.equals(shape2)
-            print shape0.equals(shape2)
+            print(shape0.equals(shape2))
         else:
-            print "Skip"
+            print("Skip")
 
-        print ""
+        print("")

--- a/libpysal/io/util/wkb.py
+++ b/libpysal/io/util/wkb.py
@@ -55,12 +55,12 @@ def load_ring_little(dat):
     """
     npts = struct.unpack('<I', dat.read(4))[0]
     xy = struct.unpack('<%dd'%(npts*2), dat.read(npts*2*8))
-    return [cg.Point(xy[i:i+2]) for i in xrange(0,npts*2,2)]
+    return [cg.Point(xy[i:i+2]) for i in range(0,npts*2,2)]
     
 def load_ring_big(dat):
     npts = struct.unpack('>I', dat.read(4))[0]
     xy = struct.unpack('>%dd'%(npts*2), dat.read(npts*2*8))
-    return [cg.Point(xy[i:i+2]) for i in xrange(0,npts*2,2)]
+    return [cg.Point(xy[i:i+2]) for i in range(0,npts*2,2)]
     
 
 def loads(s):
@@ -109,7 +109,7 @@ def loads(s):
         """
         n = struct.unpack(endian+'I', dat.read(4))[0]
         xy = struct.unpack(endian+'%dd'%(n*2), dat.read(n*2*8))
-        return cg.Chain([cg.Point(xy[i:i+2]) for i in xrange(0,n*2,2)])
+        return cg.Chain([cg.Point(xy[i:i+2]) for i in range(0,n*2,2)])
     elif typ == 3:
         """
         WKBPolygon  {
@@ -124,7 +124,7 @@ def loads(s):
         """
         nrings = struct.unpack(endian+'I', dat.read(4))[0]
         load_ring = load_ring_little if endian == '<' else load_ring_big
-        rings = [load_ring(dat) for _ in xrange(nrings)]
+        rings = [load_ring(dat) for _ in range(nrings)]
         return cg.Polygon(rings[0], rings[1:])
     elif typ == 4:
         """
@@ -136,7 +136,7 @@ def loads(s):
         }
         """
         npts = struct.unpack(endian+'I', dat.read(4))[0]
-        return [loads(dat) for _ in xrange(npts)]
+        return [loads(dat) for _ in range(npts)]
     elif typ == 5:
         """
         WKBMultiLineString  {
@@ -147,7 +147,7 @@ def loads(s):
         }
         """
         nparts = struct.unpack(endian+'I', dat.read(4))[0]
-        chains = [loads(dat) for _ in xrange(nparts)]
+        chains = [loads(dat) for _ in range(nparts)]
         return cg.Chain(sum([c.parts for c in chains],[]))
     elif typ == 6:
         """
@@ -160,7 +160,7 @@ def loads(s):
 
         """
         npolys = struct.unpack(endian+'I', dat.read(4))[0]
-        polys = [loads(dat) for _ in xrange(npolys)]
+        polys = [loads(dat) for _ in range(npolys)]
         parts = sum([p.parts for p in polys], [])
         holes = sum([p.holes for p in polys if p.holes[0]], [])
         # MULTIPOLYGON EMPTY, isn't well supported by pysal shape types.
@@ -177,7 +177,7 @@ def loads(s):
         }
         """
         ngeoms = struct.unpack(endian+'I', dat.read(4))[0]
-        return [loads(dat) for _ in xrange(ngeoms)]
+        return [loads(dat) for _ in range(ngeoms)]
         
     raise TypeError('Type (%d) is unknown or unsupported.'%typ)
 

--- a/libpysal/io/util/wkb.py
+++ b/libpysal/io/util/wkb.py
@@ -212,7 +212,7 @@ if __name__ == '__main__':
         if example.startswith('MULTIPOINT'):
             shape2 = shapely.geometry.asMultiPoint(shape1)
         elif example.startswith('GEOMETRYCOLLECTION'):
-            shape2 = shapely.geometry.collection.GeometryCollection(map(shapely.geometry.asShape,shape1))
+            shape2 = shapely.geometry.collection.GeometryCollection(list(map(shapely.geometry.asShape,shape1)))
         elif example == 'MULTIPOLYGON EMPTY':
             #Skip Test
             shape2 = None

--- a/libpysal/io/util/wkt.py
+++ b/libpysal/io/util/wkt.py
@@ -75,7 +75,7 @@ class WKTParser:
 
     def LineString(self, geoStr):
         points = geoStr.strip().split(',')
-        points = map(self.Point, points)
+        points = list(map(self.Point, points))
         return cg.Chain(points)
 
     def Polygon(self, geoStr):

--- a/libpysal/test_NameSpace.py
+++ b/libpysal/test_NameSpace.py
@@ -39,7 +39,7 @@ class TestNameSpace(unittest.TestCase):
             self.assertTrue(item in current_namespace)
         for item in current_namespace:
             if item not in namespace_v1_0 and not item.startswith('__'):
-                print item, "added to name space"
+                print(item, "added to name space")
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestNameSpace)

--- a/libpysal/weights/Contiguity.py
+++ b/libpysal/weights/Contiguity.py
@@ -359,7 +359,7 @@ def _build(polygons, criterion="rook", ids=None):
     else:
         for key in neighbor_data:
             neighbors[key] = set(neighbor_data[key])
-    return dict(zip(neighbors.keys(),map(list, neighbors.values()))), ids
+    return dict(list(zip(list(neighbors.keys()),list(map(list, list(neighbors.values())))))), ids
 
 def buildContiguity(polygons, criterion="rook", ids=None):
     """

--- a/libpysal/weights/Distance.py
+++ b/libpysal/weights/Distance.py
@@ -657,7 +657,7 @@ class Kernel(W):
             c = c ** (-0.5)
             self.kernel = [c * np.exp(-(zi ** 2) / 2.) for zi in zs]
         else:
-            print('Unsupported kernel function', self.function)
+            print(('Unsupported kernel function', self.function))
 
 
 class DistanceBand(W):

--- a/libpysal/weights/Distance.py
+++ b/libpysal/weights/Distance.py
@@ -640,7 +640,7 @@ class Kernel(W):
             if not isinstance(di, np.ndarray):
                 di = np.asarray([di] * len(nids))
                 ni = np.asarray([ni] * len(nids))
-            zi = np.array([dict(zip(ni, di))[nid] for nid in nids]) / bw[i]
+            zi = np.array([dict(list(zip(ni, di)))[nid] for nid in nids]) / bw[i]
             z.append(zi)
         zs = z
         # functions follow Anselin and Rey (2010) table 5.4
@@ -886,9 +886,9 @@ class DistanceBand(W):
             self.dmat.eliminate_zeros()
             tempW = WSP2W(WSP(self.dmat, id_order=ids), silent_island_warning=self.silent)
             neighbors = tempW.neighbors
-            weight_keys = tempW.weights.keys()
-            weight_vals = tempW.weights.values()
-            weights = dict(zip(weight_keys, map(list, weight_vals)))
+            weight_keys = list(tempW.weights.keys())
+            weight_vals = list(tempW.weights.values())
+            weights = dict(list(zip(weight_keys, list(map(list, weight_vals)))))
             return neighbors, weights
         else:
             weighted = self.dmat.power(self.alpha)
@@ -896,9 +896,9 @@ class DistanceBand(W):
             weighted.eliminate_zeros()
             tempW = WSP2W(WSP(weighted, id_order=ids), silent_island_warning=self.silent)
             neighbors = tempW.neighbors
-            weight_keys = tempW.weights.keys()
-            weight_vals = tempW.weights.values()
-            weights = dict(zip(weight_keys, map(list, weight_vals)))
+            weight_keys = list(tempW.weights.keys())
+            weight_vals = list(tempW.weights.values())
+            weights = dict(list(zip(weight_keys, list(map(list, weight_vals)))))
             return neighbors, weights
 
     def _spdistance_matrix(self, x,y, threshold=None):

--- a/libpysal/weights/Wsets.py
+++ b/libpysal/weights/Wsets.py
@@ -63,7 +63,7 @@ def w_union(w1, w2, silent_island_warning=False):
     >>>
 
     """
-    neighbors = dict(w1.neighbors.items())
+    neighbors = dict(list(w1.neighbors.items()))
     for i in w2.neighbors:
         if i in neighbors:
             add_neigh = set(neighbors[i]).union(set(w2.neighbors[i]))
@@ -129,7 +129,7 @@ def w_intersection(w1, w2, w_shape='w1', silent_island_warning=False):
     """
 
     if w_shape == 'w1':
-        neigh_keys = w1.neighbors.keys()
+        neigh_keys = list(w1.neighbors.keys())
     elif w_shape == 'all':
         neigh_keys = set(w1.neighbors.keys()).union(set(w2.neighbors.keys()))
     elif w_shape == 'min':
@@ -214,7 +214,7 @@ def w_difference(w1, w2, w_shape='w1', constrained=True, silent_island_warning=F
     """
 
     if w_shape == 'w1':
-        neigh_keys = w1.neighbors.keys()
+        neigh_keys = list(w1.neighbors.keys())
     elif w_shape == 'all':
         neigh_keys = set(w1.neighbors.keys()).union(set(w2.neighbors.keys()))
     elif w_shape == 'min':

--- a/libpysal/weights/__init__.py
+++ b/libpysal/weights/__init__.py
@@ -1,1 +1,1 @@
-from weights import W
+from .weights import W

--- a/libpysal/weights/_contW_lists.py
+++ b/libpysal/weights/_contW_lists.py
@@ -82,7 +82,7 @@ class ContiguityWeightsLists:
                 items[vertex].add(offsets[i])
 
             shared_vertices = []
-            for item, location in items.items():
+            for item, location in list(items.items()):
                 if len(location) > 1:
                     shared_vertices.append(location)
 
@@ -107,7 +107,7 @@ class ContiguityWeightsLists:
                 items[item].add(offsets[i])
 
             shared_vertices = []
-            for item, location in items.items():
+            for item, location in list(items.items()):
                 if len(location) > 1:
                     shared_vertices.append(location)
 

--- a/libpysal/weights/_contW_lists.py
+++ b/libpysal/weights/_contW_lists.py
@@ -24,9 +24,9 @@ def _get_boundary_points(pgon):
     if pgon.type.lower() == 'polygon':
         bounds = pgon.boundary
         if bounds.type.lower() == 'linestring':
-            return list(map(tuple, zip(*bounds.coords.xy)))
+            return list(map(tuple, list(zip(*bounds.coords.xy))))
         elif bounds.type.lower() == 'multilinestring':
-            return list(it.chain(*(zip(*bound.coords.xy)
+            return list(it.chain(*(list(zip(*bound.coords.xy))
                                      for bound in bounds)))
         else:
             raise TypeError('Input Polygon has unrecognized boundary type: {}'
@@ -82,7 +82,7 @@ class ContiguityWeightsLists:
                 items[vertex].add(offsets[i])
 
             shared_vertices = []
-            for item, location in items.iteritems():
+            for item, location in items.items():
                 if len(location) > 1:
                     shared_vertices.append(location)
 
@@ -107,7 +107,7 @@ class ContiguityWeightsLists:
                 items[item].add(offsets[i])
 
             shared_vertices = []
-            for item, location in items.iteritems():
+            for item, location in items.items():
                 if len(location) > 1:
                     shared_vertices.append(location)
 

--- a/libpysal/weights/adjtools.py
+++ b/libpysal/weights/adjtools.py
@@ -80,9 +80,9 @@ def _adjlist_mvapply(X, W=None, alist=None, func=None, skip_verify=False):
                           left_on='neighbor', right_on='id', 
                           suffixes=('_focal','_neighbor'))
     alist_atts.drop(['id_focal', 'id_neighbor'], axis=1, inplace=True)
-    alist_atts[func.__name__] = map(func, 
-                                    zip(alist_atts.filter(like='_focal').values,
-                                        alist_atts.filter(like='_neighbor').values))
+    alist_atts[func.__name__] = list(map(func, 
+                                    list(zip(alist_atts.filter(like='_focal').values,
+                                        alist_atts.filter(like='_neighbor').values))))
     return alist_atts
 
 def _get_W_and_alist(W, alist, skip_verify=False):

--- a/libpysal/weights/adjtools.py
+++ b/libpysal/weights/adjtools.py
@@ -70,7 +70,7 @@ def _adjlist_mvapply(X, W=None, alist=None, func=None, skip_verify=False):
     try:
         names = X.columns.tolist()
     except AttributeError:
-        names = list(map(str, range(X.shape[1])))
+        names = list(map(str, list(range(X.shape[1]))))
     ids = np.asarray(W.id_order)[:,None]
     table = pd.DataFrame(ids, columns=['id'])
     table = pd.concat((table, pd.DataFrame(X, columns=names)), axis=1)

--- a/libpysal/weights/spatial_lag.py
+++ b/libpysal/weights/spatial_lag.py
@@ -168,7 +168,7 @@ def lag_categorical(w, y, ties='tryself'):
     for focal_name,neighbors in w:
         focal_idx = w.id2i[focal_name]
         neighborhood_tally = np.zeros(labels.shape)
-        for neighb_name, weight in neighbors.items():
+        for neighb_name, weight in list(neighbors.items()):
             neighb_idx = w.id2i[neighb_name]
             neighb_label = normalized_labels[neighb_idx]
             neighborhood_tally[neighb_label] += weight

--- a/libpysal/weights/spintW.py
+++ b/libpysal/weights/spintW.py
@@ -215,7 +215,7 @@ def vecW(origin_x, origin_y, dest_x, dest_y, threshold, p=2, alpha=-1.0,
     [1, 2]
 
     """
-    data = zip(origin_x, origin_y, dest_x, dest_y)
+    data = list(zip(origin_x, origin_y, dest_x, dest_y))
     W = DistanceBand(data, threshold=threshold, p=p, binary=binary, alpha=alpha,
             ids=ids, build_sp=False, silent=silent)
     return W

--- a/libpysal/weights/tests/test_Contiguity.py
+++ b/libpysal/weights/tests/test_Contiguity.py
@@ -24,7 +24,7 @@ class Contiguity_Mixin(object):
     idVariable = None # id variable from file or column
 
     def setUp(self):
-        self.__dict__.update({k:v for k,v in Contiguity_Mixin.__dict__.items()
+        self.__dict__.update({k:v for k,v in list(Contiguity_Mixin.__dict__.items())
             if not k.startswith('_')})
     
     def runTest(self):
@@ -97,7 +97,7 @@ class Test_Queen(ut.TestCase, Contiguity_Mixin):
         self.cls = c.Queen
         self.idVariable = 'POLYID'
         self.known_name = 5
-        self.known_namedw = {k+1:v for k,v in self.known_w.items()}
+        self.known_namedw = {k+1:v for k,v in list(self.known_w.items())}
 
 class Test_Rook(ut.TestCase, Contiguity_Mixin):
     def setUp(self):
@@ -109,7 +109,7 @@ class Test_Rook(ut.TestCase, Contiguity_Mixin):
         self.cls = c.Rook
         self.idVariable = 'POLYID'
         self.known_name = 5
-        self.known_namedw = {k+1:v for k,v in self.known_w.items()}
+        self.known_namedw = {k+1:v for k,v in list(self.known_w.items())}
 
 q = ut.TestLoader().loadTestsFromTestCase(Test_Queen)
 r = ut.TestLoader().loadTestsFromTestCase(Test_Rook)

--- a/libpysal/weights/tests/test_Distance.py
+++ b/libpysal/weights/tests/test_Distance.py
@@ -170,8 +170,8 @@ class Test_DistanceBand(ut.TestCase, Distance_Mixin):
                      radius=cg.sphere.RADIUS_EARTH_KM)
         npoints = self.arc_points.shape[0]
         full = np.matrix([[arc(self.arc_points[i], self.arc_points[j])
-                          for j in xrange(npoints)] 
-                          for i in xrange(npoints)])
+                          for j in range(npoints)] 
+                          for i in range(npoints)])
         maxdist = full.max()
         w = d.DistanceBand(kdt, maxdist, binary=False, alpha=1.0)
         np.testing.assert_allclose(w.sparse.todense(), full)

--- a/libpysal/weights/tests/test_Distance.py
+++ b/libpysal/weights/tests/test_Distance.py
@@ -128,17 +128,17 @@ class Test_DistanceBand(ut.TestCase, Distance_Mixin):
     def test_init(self):
         w = d.DistanceBand(self.grid_kdt, 1)
         for k,v in w:
-            self.assertEquals(v, self.grid_rook_w[k])
+            self.assertEqual(v, self.grid_rook_w[k])
 
     def test_from_shapefile(self):
         w = d.DistanceBand.from_shapefile(self.grid_path, 1)
         for k,v in w:
-            self.assertEquals(v, self.grid_rook_w[k])
+            self.assertEqual(v, self.grid_rook_w[k])
 
     def test_from_array(self):
         w = d.DistanceBand.from_array(self.grid_points, 1)
         for k,v in w:
-            self.assertEquals(v, self.grid_rook_w[k])
+            self.assertEqual(v, self.grid_rook_w[k])
 
     @ut.skipIf(PANDAS_EXTINCT, 'Missing pandas')
     def test_from_dataframe(self):
@@ -148,7 +148,7 @@ class Test_DistanceBand(ut.TestCase, Distance_Mixin):
         df = pd.DataFrame({'obs':random_data, 'geometry':geom_series})
         w = d.DistanceBand.from_dataframe(df, 1)
         for k,v in w:
-            self.assertEquals(v, self.grid_rook_w[k])
+            self.assertEqual(v, self.grid_rook_w[k])
 
     ##########################
     # Function/User tests    #
@@ -162,7 +162,7 @@ class Test_DistanceBand(ut.TestCase, Distance_Mixin):
         self.grid_f.seek(0)
         grid_dbw = d.DistanceBand(grid_integers, 1)
         for k,v in grid_dbw:
-            self.assertEquals(v, self.grid_rook_w[k])
+            self.assertEqual(v, self.grid_rook_w[k])
 
     def test_arcdist(self):
         arc = cg.sphere.arcdist

--- a/libpysal/weights/tests/test_Distance.py
+++ b/libpysal/weights/tests/test_Distance.py
@@ -38,7 +38,7 @@ class Distance_Mixin(object):
     known_name = known_wi
     
     def setUp(self):
-        self.__dict__.update({k:v for k,v in Distance_Mixin.__dict__.items()
+        self.__dict__.update({k:v for k,v in list(Distance_Mixin.__dict__.items())
             if not k.startswith('_')})
     
     def test_init(self):
@@ -241,28 +241,28 @@ class Test_Kernel(ut.TestCase, Distance_Mixin):
 
     def test_init(self):
         w = d.Kernel(self.euclidean_kdt)
-        for k,v in w[self.known_wi0].items():
+        for k,v in list(w[self.known_wi0].items()):
             np.testing.assert_allclose(v, self.known_w0[k], rtol=RTOL)
 
     def test_from_shapefile(self):
         w = d.Kernel.from_shapefile(self.polygon_path, idVariable='POLYID')
-        for k,v in w[self.known_wi5].items():
+        for k,v in list(w[self.known_wi5].items()):
             np.testing.assert_allclose((k,v), (k,self.known_w5[k]), rtol=RTOL)
         
         w = d.Kernel.from_shapefile(self.polygon_path, fixed=False)
-        for k,v in w[self.known_wi6].items():
+        for k,v in list(w[self.known_wi6].items()):
             np.testing.assert_allclose((k,v), (k,self.known_w6[k]), rtol=RTOL)
 
     def test_from_array(self):
         w = d.Kernel.from_array(self.points)
-        for k,v in w[self.known_wi0].items():
+        for k,v in list(w[self.known_wi0].items()):
             np.testing.assert_allclose(v, self.known_w0[k], rtol=RTOL)
     
     @ut.skipIf(PANDAS_EXTINCT, 'Missing pandas')
     def test_from_dataframe(self):
         df = pdio.read_files(self.polygon_path)
         w = d.Kernel.from_dataframe(df)
-        for k,v in w[self.known_wi5-1].items():
+        for k,v in list(w[self.known_wi5-1].items()):
             np.testing.assert_allclose(v, self.known_w5[k+1], rtol=RTOL)
     
     ##########################
@@ -271,12 +271,12 @@ class Test_Kernel(ut.TestCase, Distance_Mixin):
 
     def test_fixed_bandwidth(self):
         w = d.Kernel(self.points, bandwidth=15.0)
-        for k,v in w[self.known_wi1].items():
+        for k,v in list(w[self.known_wi1].items()):
             np.testing.assert_allclose((k,v), (k, self.known_w1[k]))
         np.testing.assert_allclose(np.ones((w.n,1))*15, w.bandwidth)
 
         w = d.Kernel(self.points, bandwidth=self.known_w2_bws)
-        for k,v in w[self.known_wi2].items():
+        for k,v in list(w[self.known_wi2].items()):
             np.testing.assert_allclose((k,v), (k, self.known_w2[k]), rtol=RTOL)
         for i in range(w.n):
             np.testing.assert_allclose(w.bandwidth[i], self.known_w2_bws[i], rtol=RTOL)
@@ -289,7 +289,7 @@ class Test_Kernel(ut.TestCase, Distance_Mixin):
         np.testing.assert_allclose(bws, self.known_w3_abws, rtol=RTOL)
 
         w = d.Kernel(self.points, fixed=False, function='gaussian')
-        for k,v in w[self.known_wi4].items():
+        for k,v in list(w[self.known_wi4].items()):
             np.testing.assert_allclose((k,v), (k, self.known_w4[k]), rtol=RTOL)
         bws = w.bandwidth.tolist()
         np.testing.assert_allclose(bws, self.known_w4_abws, rtol=RTOL)

--- a/libpysal/weights/tests/test_Wsets.py
+++ b/libpysal/weights/tests/test_Wsets.py
@@ -51,7 +51,7 @@ class TestWsets(unittest.TestCase):
     def test_w_subset(self):
         """Unit test"""
         w1 = lat2W(6, 4)
-        ids = range(16)
+        ids = list(range(16))
         w2 = Wsets.w_subset(w1, ids)
         self.assertEqual(w1[0], w2[0])
         self.assertEqual(set(w1.neighbors[15]), set([11, 14, 19]))

--- a/libpysal/weights/tests/test__contW_lists.py
+++ b/libpysal/weights/tests/test__contW_lists.py
@@ -23,7 +23,7 @@ class TestContiguityWeights(unittest.TestCase):
         shpObj.close()
 
     def test_w_type(self):
-        self.assert_(isinstance(self.binningW, ContiguityWeightsLists))
+        self.assertTrue(isinstance(self.binningW, ContiguityWeightsLists))
 
     def test_QUEEN(self):
         self.assertEqual(QUEEN, 1)
@@ -32,8 +32,8 @@ class TestContiguityWeights(unittest.TestCase):
         self.assertEqual(ROOK, 2)
 
     def test_ContiguityWeightsLists(self):
-        self.assert_(hasattr(self.binningW, 'w'))
-        self.assert_(issubclass(dict, type(self.binningW.w)))
+        self.assertTrue(hasattr(self.binningW, 'w'))
+        self.assertTrue(issubclass(dict, type(self.binningW.w)))
         self.assertEqual(len(self.binningW.w), 136)
 
     def test_nested_polygons(self):

--- a/libpysal/weights/tests/test__contW_lists.py
+++ b/libpysal/weights/tests/test__contW_lists.py
@@ -45,7 +45,7 @@ class TestContiguityWeights(unittest.TestCase):
             pysal_examples.get_path('virginia.shp'), QUEEN, 'POLY_ID')
         # compare output.
         for key in geodaW.neighbors:
-            geoda_neighbors = map(int, geodaW.neighbors[key])
+            geoda_neighbors = list(map(int, geodaW.neighbors[key]))
             pysalb_neighbors = pysalWb.neighbors[int(key)]
             geoda_neighbors.sort()
             pysalb_neighbors.sort()
@@ -60,7 +60,7 @@ class TestContiguityWeights(unittest.TestCase):
             pysal_examples.get_path('rook31.shp'), ROOK, 'POLY_ID')
         # compare output.
         for key in geodaW.neighbors:
-            geoda_neighbors = map(int, geodaW.neighbors[key])
+            geoda_neighbors = list(map(int, geodaW.neighbors[key]))
             pysalb_neighbors = pysalWb.neighbors[int(key)]
             geoda_neighbors.sort()
             pysalb_neighbors.sort()
@@ -75,7 +75,7 @@ class TestContiguityWeights(unittest.TestCase):
             'stl_hom.shp'), ROOK, 'POLY_ID_OG')
         # compare output.
         for key in geodaW.neighbors:
-            geoda_neighbors = map(int, geodaW.neighbors[key])
+            geoda_neighbors = list(map(int, geodaW.neighbors[key]))
             pysalb_neighbors = pysalWb.neighbors[int(key)]
             geoda_neighbors.sort()
             pysalb_neighbors.sort()
@@ -90,7 +90,7 @@ class TestContiguityWeights(unittest.TestCase):
             'sacramentot2.shp'), ROOK, 'POLYID')
         # compare output.
         for key in geodaW.neighbors:
-            geoda_neighbors = map(int, geodaW.neighbors[key])
+            geoda_neighbors = list(map(int, geodaW.neighbors[key]))
             pysalb_neighbors = pysalWb.neighbors[int(key)]
             geoda_neighbors.sort()
             pysalb_neighbors.sort()
@@ -105,7 +105,7 @@ class TestContiguityWeights(unittest.TestCase):
             pysal_examples.get_path('virginia.shp'), ROOK, 'POLY_ID')
         # compare output.
         for key in geodaW.neighbors:
-            geoda_neighbors = map(int, geodaW.neighbors[key])
+            geoda_neighbors = list(map(int, geodaW.neighbors[key]))
             pysalb_neighbors = pysalWb.neighbors[int(key)]
             geoda_neighbors.sort()
             pysalb_neighbors.sort()

--- a/libpysal/weights/tests/test_adjlist.py
+++ b/libpysal/weights/tests/test_adjlist.py
@@ -52,7 +52,7 @@ class Test_Adjlist(ut.TestCase):
     def test_mvapply(self):
         df = ps.geotable.read_files(ps.get_path('columbus.dbf')).head()
         W = ps.Queen.from_dataframe(df)
-        ssq = lambda (x,y): np.sum((x-y)**2).item()
+        ssq = lambda x_y: np.sum((x_y[0]-x_y[1])**2).item()
         ssq.__name__ = 'sum_of_squares'
         alist = adj.adjlist_apply(df[['HOVAL', 'CRIME', 'INC']], W=W, 
                                   func=ssq)

--- a/libpysal/weights/tests/test_adjlist.py
+++ b/libpysal/weights/tests/test_adjlist.py
@@ -78,7 +78,7 @@ class Test_Adjlist(ut.TestCase):
         atts = ['HOVAL', 'CRIME', 'INC'] 
         df = ps.geotable.read_files(ps.get_path('columbus.dbf')).head()
         W = ps.Queen.from_dataframe(df)
-        hoval, crime, inc = map(self.apply_and_compare_columbus, atts) 
+        hoval, crime, inc = list(map(self.apply_and_compare_columbus, atts)) 
         mapped = adj.adjlist_map(df[atts], W=W)
         for name,data in zip(atts, (hoval, crime, inc)):
             np.testing.assert_allclose(data, 

--- a/libpysal/weights/tests/test_user.py
+++ b/libpysal/weights/tests/test_user.py
@@ -15,10 +15,10 @@ class Testuser(unittest.TestCase):
             pysal_examples.get_path("columbus.shp"))
 
     def test_queen_from_shapefile(self):
-        self.assertAlmostEquals(self.wq.pct_nonzero, 9.82923781757601)
+        self.assertAlmostEqual(self.wq.pct_nonzero, 9.82923781757601)
 
     def test_rook_from_shapefile(self):
-        self.assertAlmostEquals(self.wr.pct_nonzero, 8.329862557267806)
+        self.assertAlmostEqual(self.wr.pct_nonzero, 8.329862557267806)
 
     def test_knnW_from_array(self):
         import numpy as np
@@ -28,14 +28,14 @@ class Testuser(unittest.TestCase):
         data = np.hstack([x, y])
         wnn2 = user.knnW_from_array(data, k=2)
         wnn4 = user.knnW_from_array(data, k=4)
-        self.assertEquals(set(wnn4.neighbors[0]), set([1, 5, 6, 2]))
-        self.assertEquals(set(wnn4.neighbors[5]), set([0, 6, 10, 1]))
-        self.assertEquals(set(wnn2.neighbors[0]), set([1, 5]))
-        self.assertEquals(set(wnn2.neighbors[5]), set([0, 6]))
-        self.assertAlmostEquals(wnn2.pct_nonzero, 8.0)
-        self.assertAlmostEquals(wnn4.pct_nonzero, 16.0)
+        self.assertEqual(set(wnn4.neighbors[0]), set([1, 5, 6, 2]))
+        self.assertEqual(set(wnn4.neighbors[5]), set([0, 6, 10, 1]))
+        self.assertEqual(set(wnn2.neighbors[0]), set([1, 5]))
+        self.assertEqual(set(wnn2.neighbors[5]), set([0, 6]))
+        self.assertAlmostEqual(wnn2.pct_nonzero, 8.0)
+        self.assertAlmostEqual(wnn4.pct_nonzero, 16.0)
         wnn4 = user.knnW_from_array(data, k=4)
-        self.assertEquals(set(wnn4.neighbors[0]), set([1, 5, 6, 2]))
+        self.assertEqual(set(wnn4.neighbors[0]), set([1, 5, 6, 2]))
         '''
         wnn3e = pysal.knnW(data, p=2, k=3)
         self.assertEquals(set(wnn3e.neighbors[0]),set([1, 5, 6]))
@@ -45,22 +45,22 @@ class Testuser(unittest.TestCase):
 
     def test_knnW_from_shapefile(self):
         wc = user.knnW_from_shapefile(pysal_examples.get_path("columbus.shp"))
-        self.assertAlmostEquals(wc.pct_nonzero, 4.081632653061225)
+        self.assertAlmostEqual(wc.pct_nonzero, 4.081632653061225)
         wc3 = user.knnW_from_shapefile(pysal_examples.get_path(
             "columbus.shp"), k=3)
-        self.assertEquals(wc3.weights[1], [1, 1, 1])
-        self.assertEquals(set(wc3.neighbors[1]), set([3, 0, 7]))
-        self.assertEquals(set(wc.neighbors[0]), set([2, 1]))
+        self.assertEqual(wc3.weights[1], [1, 1, 1])
+        self.assertEqual(set(wc3.neighbors[1]), set([3, 0, 7]))
+        self.assertEqual(set(wc.neighbors[0]), set([2, 1]))
         w = user.knnW_from_shapefile(pysal_examples.get_path('juvenile.shp'))
-        self.assertAlmostEquals(w.pct_nonzero, 1.1904761904761904)
+        self.assertAlmostEqual(w.pct_nonzero, 1.1904761904761904)
         w1 = user.knnW_from_shapefile(
             pysal_examples.get_path('juvenile.shp'), k=1)
-        self.assertAlmostEquals(w1.pct_nonzero, 0.5952380952380952)
+        self.assertAlmostEqual(w1.pct_nonzero, 0.5952380952380952)
 
     def test_threshold_binaryW_from_array(self):
         points = [(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
         w = user.threshold_binaryW_from_array(points, threshold=11.2)
-        self.assertEquals(w.weights, {0: [1, 1], 1: [1, 1], 2: [],
+        self.assertEqual(w.weights, {0: [1, 1], 1: [1, 1], 2: [],
                                       3: [1, 1], 4: [1], 5: [1]})
         self.assertTrue(neighbor_equality(w, W({0: [1, 3], 1: [0, 3],
                                                         2: [ ], 3: [0, 1],
@@ -69,7 +69,7 @@ class Testuser(unittest.TestCase):
     def test_threshold_binaryW_from_shapefile(self):
         w = user.threshold_binaryW_from_shapefile(pysal_examples.get_path(
             "columbus.shp"), 0.62, idVariable="POLYID")
-        self.assertEquals(w.weights[1], [1, 1])
+        self.assertEqual(w.weights[1], [1, 1])
 
     def test_threshold_continuousW_from_array(self):
         points = [(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
@@ -79,19 +79,19 @@ class Testuser(unittest.TestCase):
                                3: 0.089442719099991588})
         wid2 = user.threshold_continuousW_from_array(points, 11.2, alpha=-2.0)
         wds = {wid2.neighbors[0][i]: v for i, v in enumerate(wid2.weights[0])}
-        self.assertEquals(wid2.weights[0], [0.01, 0.0079999999999999984])
+        self.assertEqual(wid2.weights[0], [0.01, 0.0079999999999999984])
 
     def test_threshold_continuousW_from_shapefile(self):
         w = user.threshold_continuousW_from_shapefile(pysal_examples.get_path(
             "columbus.shp"), 0.62, idVariable="POLYID")
         wds = {w.neighbors[1][i]:v for i,v in enumerate(w.weights[1])}
-        self.assertEquals(wds, {2:1.6702346893743334, 3:1.7250729841938093})
+        self.assertEqual(wds, {2:1.6702346893743334, 3:1.7250729841938093})
 
     def test_kernelW(self):
         points = [(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
         kw = user.kernelW(points)
         wds = {kw.neighbors[0][i]:v for i,v in enumerate(kw.weights[0])}
-        self.assertEquals(wds, {0:1.0, 1:0.50000004999999503,
+        self.assertEqual(wds, {0:1.0, 1:0.50000004999999503,
                                           3:0.44098306152674649})
         np.testing.assert_array_almost_equal(
             kw.bandwidth, np.array([[20.000002],
@@ -104,12 +104,12 @@ class Testuser(unittest.TestCase):
     def test_min_threshold_dist_from_shapefile(self):
         f = pysal_examples.get_path('columbus.shp')
         min_d = user.min_threshold_dist_from_shapefile(f)
-        self.assertAlmostEquals(min_d, 0.61886415807685413)
+        self.assertAlmostEqual(min_d, 0.61886415807685413)
 
     def test_kernelW_from_shapefile(self):
         kw = user.kernelW_from_shapefile(pysal_examples.get_path(
             'columbus.shp'), idVariable='POLYID')
-        self.assertEquals(set(kw.weights[1]), set([0.0070787731484506233,
+        self.assertEqual(set(kw.weights[1]), set([0.0070787731484506233,
                                          0.2052478782400463,
                                          0.23051223027663237,
                                          1.0
@@ -146,7 +146,7 @@ class Testuser(unittest.TestCase):
         kwa = user.adaptive_kernelW_from_shapefile(
             pysal_examples.get_path('columbus.shp'))
         wds = {kwa.neighbors[0][i]: v for i, v in enumerate(kwa.weights[0])}
-        self.assertEquals(wds, {0: 1.0, 2: 0.03178906767736345,
+        self.assertEqual(wds, {0: 1.0, 2: 0.03178906767736345,
                                 1: 9.9999990066379496e-08})
         np.testing.assert_array_almost_equal(kwa.bandwidth[:3],
                                              np.array([[0.59871832],
@@ -157,7 +157,7 @@ class Testuser(unittest.TestCase):
         of = "lattice.shp"
         user.build_lattice_shapefile(20, 20, of)
         w = user.rook_from_shapefile(of)
-        self.assertEquals(w.n, 400)
+        self.assertEqual(w.n, 400)
         os.remove('lattice.shp')
         os.remove('lattice.shx')
 
@@ -165,8 +165,8 @@ class Testuser(unittest.TestCase):
         np.random.seed(12345)
         points = np.random.random((5,2))*10 + 10
         w = user.voronoiW(points)
-        self.assertEquals(w.n, 5)
-        self.assertEquals(w.neighbors, {0: [1, 2, 3, 4],
+        self.assertEqual(w.n, 5)
+        self.assertEqual(w.neighbors, {0: [1, 2, 3, 4],
                                         1: [0, 2], 2: [0, 1, 4],
                                         3: [0, 4], 4: [0, 2, 3]})
 

--- a/libpysal/weights/tests/test_util.py
+++ b/libpysal/weights/tests/test_util.py
@@ -41,8 +41,8 @@ class Testutil(unittest.TestCase):
 
     def test_block_weights(self):
         regimes = np.ones(25)
-        regimes[range(10, 20)] = 2
-        regimes[range(21, 25)] = 3
+        regimes[list(range(10, 20))] = 2
+        regimes[list(range(21, 25))] = 3
         regimes = np.array([1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
                             2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 1., 3., 3.,
                             3., 3.])
@@ -66,7 +66,7 @@ class Testutil(unittest.TestCase):
         self.assertEqual(w['id-0'], w0)
 
     def test_comb(self):
-        x = range(4)
+        x = list(range(4))
         l = []
         for i in util.comb(x, 2):
             l.append(i)

--- a/libpysal/weights/tests/test_util.py
+++ b/libpysal/weights/tests/test_util.py
@@ -18,26 +18,26 @@ class Testutil(unittest.TestCase):
 
     def test_lat2W(self):
         w9 = lat2W(3, 3)
-        self.assertEquals(w9.pct_nonzero, 29.62962962962963)
-        self.assertEquals(w9[0], {1: 1.0, 3: 1.0})
-        self.assertEquals(w9[3], {0: 1.0, 4: 1.0, 6: 1.0})
+        self.assertEqual(w9.pct_nonzero, 29.62962962962963)
+        self.assertEqual(w9[0], {1: 1.0, 3: 1.0})
+        self.assertEqual(w9[3], {0: 1.0, 4: 1.0, 6: 1.0})
 
     def test_lat2SW(self):
         w9 = util.lat2SW(3, 3)
         rows, cols = w9.shape
         n = rows * cols
         pct_nonzero = w9.nnz / float(n)
-        self.assertEquals(pct_nonzero, 0.29629629629629628)
+        self.assertEqual(pct_nonzero, 0.29629629629629628)
         data = w9.todense().tolist()
-        self.assertEquals(data[0], [0, 1, 0, 1, 0, 0, 0, 0, 0])
-        self.assertEquals(data[1], [1, 0, 1, 0, 1, 0, 0, 0, 0])
-        self.assertEquals(data[2], [0, 1, 0, 0, 0, 1, 0, 0, 0])
-        self.assertEquals(data[3], [1, 0, 0, 0, 1, 0, 1, 0, 0])
-        self.assertEquals(data[4], [0, 1, 0, 1, 0, 1, 0, 1, 0])
-        self.assertEquals(data[5], [0, 0, 1, 0, 1, 0, 0, 0, 1])
-        self.assertEquals(data[6], [0, 0, 0, 1, 0, 0, 0, 1, 0])
-        self.assertEquals(data[7], [0, 0, 0, 0, 1, 0, 1, 0, 1])
-        self.assertEquals(data[8], [0, 0, 0, 0, 0, 1, 0, 1, 0])
+        self.assertEqual(data[0], [0, 1, 0, 1, 0, 0, 0, 0, 0])
+        self.assertEqual(data[1], [1, 0, 1, 0, 1, 0, 0, 0, 0])
+        self.assertEqual(data[2], [0, 1, 0, 0, 0, 1, 0, 0, 0])
+        self.assertEqual(data[3], [1, 0, 0, 0, 1, 0, 1, 0, 0])
+        self.assertEqual(data[4], [0, 1, 0, 1, 0, 1, 0, 1, 0])
+        self.assertEqual(data[5], [0, 0, 1, 0, 1, 0, 0, 0, 1])
+        self.assertEqual(data[6], [0, 0, 0, 1, 0, 0, 0, 1, 0])
+        self.assertEqual(data[7], [0, 0, 0, 0, 1, 0, 1, 0, 1])
+        self.assertEqual(data[8], [0, 0, 0, 0, 0, 1, 0, 1, 0])
 
     def test_block_weights(self):
         regimes = np.ones(25)
@@ -48,22 +48,22 @@ class Testutil(unittest.TestCase):
                             3., 3.])
         w = util.block_weights(regimes)
         ww0 = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
-        self.assertEquals(w.weights[0], ww0)
+        self.assertEqual(w.weights[0], ww0)
         wn0 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 20]
-        self.assertEquals(w.neighbors[0], wn0)
+        self.assertEqual(w.neighbors[0], wn0)
         regimes = ['n', 'n', 's', 's', 'e', 'e', 'w', 'w', 'e']
         n = len(regimes)
         w = util.block_weights(regimes)
         wn = {0: [1], 1: [0], 2: [3], 3: [2], 4: [5, 8], 5: [4, 8],
               6: [7], 7: [6], 8: [4, 5]}
-        self.assertEquals(w.neighbors, wn)
+        self.assertEqual(w.neighbors, wn)
         ids = ['id-%i'%i for i in range(len(regimes))]
         w = util.block_weights(regimes, ids=np.array(ids))
         w0 = {'id-1': 1.0}
-        self.assertEquals(w['id-0'], w0)
+        self.assertEqual(w['id-0'], w0)
         w = util.block_weights(regimes, ids=ids)
         w0 = {'id-1': 1.0}
-        self.assertEquals(w['id-0'], w0)
+        self.assertEqual(w['id-0'], w0)
 
     def test_comb(self):
         x = range(4)
@@ -71,26 +71,26 @@ class Testutil(unittest.TestCase):
         for i in util.comb(x, 2):
             l.append(i)
         lo = [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]]
-        self.assertEquals(l, lo)
+        self.assertEqual(l, lo)
 
     def test_order(self):
         w3 = util.order(self.w, kmax=3)
         w3105 = [1, -1, 1, 2, 1]
-        self.assertEquals(w3105, w3[1][0:5])
+        self.assertEqual(w3105, w3[1][0:5])
 
     def test_higher_order(self):
         w10 = lat2W(10, 10)
         w10_2 = util.higher_order(w10, 2)
         w10_20 = {2: 1.0, 11: 1.0, 20: 1.0}
-        self.assertEquals(w10_20, w10_2[0])
+        self.assertEqual(w10_20, w10_2[0])
         w5 = lat2W()
         w50 = {1: 1.0, 5: 1.0}
-        self.assertEquals(w50, w5[0])
+        self.assertEqual(w50, w5[0])
         w51 = {0: 1.0, 2: 1.0, 6: 1.0}
-        self.assertEquals(w51, w5[1])
+        self.assertEqual(w51, w5[1])
         w5_2 = util.higher_order(w5, 2)
         w5_20 = {2: 1.0, 10: 1.0, 6: 1.0}
-        self.assertEquals(w5_20, w5_2[0])
+        self.assertEqual(w5_20, w5_2[0])
     
     def test_higher_order_classes(self):
         wdb = DistanceBand.from_shapefile(pysal_examples.get_path('baltim.shp'), 34)
@@ -117,9 +117,9 @@ class Testutil(unittest.TestCase):
         w5 = lat2W()
         w5_shimbel = util.shimbel(w5)
         w5_shimbel024 = 8
-        self.assertEquals(w5_shimbel024, w5_shimbel[0][24])
+        self.assertEqual(w5_shimbel024, w5_shimbel[0][24])
         w5_shimbel004 = [-1, 1, 2, 3]
-        self.assertEquals(w5_shimbel004, w5_shimbel[0][0:4])
+        self.assertEqual(w5_shimbel004, w5_shimbel[0][0:4])
 
     def test_full(self):
         neighbors = {'first': ['second'], 'second': ['first',
@@ -130,7 +130,7 @@ class Testutil(unittest.TestCase):
         wfo = np.array([[0., 1., 0.], [1., 0., 1.], [0., 1., 0.]])
         np.testing.assert_array_almost_equal(wfo, wf, decimal=8)
         idso = ['first', 'second', 'third']
-        self.assertEquals(idso, ids)
+        self.assertEqual(idso, ids)
 
     def test_full2W(self):
         a = np.zeros((4, 4))
@@ -149,45 +149,45 @@ class Testutil(unittest.TestCase):
         sp = util.lat2SW(2, 5)
         wsp = WSP(sp)
         w = util.WSP2W(wsp)
-        self.assertEquals(w.n, 10)
-        self.assertEquals(w[0], {1: 1, 5: 1})
+        self.assertEqual(w.n, 10)
+        self.assertEqual(w[0], {1: 1, 5: 1})
         w = psopen(pysal_examples.get_path('sids2.gal'), 'r').read()
         wsp = WSP(w.sparse, w.id_order)
         w = util.WSP2W(wsp)
-        self.assertEquals(w.n, 100)
-        self.assertEquals(w['37135'], {'37001': 1.0, '37033': 1.0,
+        self.assertEqual(w.n, 100)
+        self.assertEqual(w['37135'], {'37001': 1.0, '37033': 1.0,
                                        '37037': 1.0, '37063': 1.0, '37145': 1.0})
 
     def test_insert_diagonal(self):
         w1 = util.insert_diagonal(self.w)
         r1 = {0: 1.0, 1: 1.0, 4: 1.0, 101: 1.0, 85: 1.0, 5: 1.0}
-        self.assertEquals(w1[0], r1)
+        self.assertEqual(w1[0], r1)
         w1 = util.insert_diagonal(self.w, 20)
         r1 = {0: 20, 1: 1.0, 4: 1.0, 101: 1.0, 85: 1.0, 5: 1.0}
-        self.assertEquals(w1[0], r1)
+        self.assertEqual(w1[0], r1)
         diag = np.arange(100, 100 + self.w.n)
         w1 = util.insert_diagonal(self.w, diag)
         r1 = {0: 100, 1: 1.0, 4: 1.0, 101: 1.0, 85: 1.0, 5: 1.0}
-        self.assertEquals(w1[0], r1)
+        self.assertEqual(w1[0], r1)
 
     def test_remap_ids(self):
         w = lat2W(3, 2)
         wid_order = [0, 1, 2, 3, 4, 5]
-        self.assertEquals(wid_order, w.id_order)
+        self.assertEqual(wid_order, w.id_order)
         wneighbors0 = [2, 1]
-        self.assertEquals(wneighbors0, w.neighbors[0])
+        self.assertEqual(wneighbors0, w.neighbors[0])
         old_to_new = {0: 'a', 1: 'b', 2: 'c', 3: 'd', 4: 'e', 5: 'f'}
         w_new = util.remap_ids(w, old_to_new)
         w_newid_order = ['a', 'b', 'c', 'd', 'e', 'f']
-        self.assertEquals(w_newid_order, w_new.id_order)
+        self.assertEqual(w_newid_order, w_new.id_order)
         w_newdneighborsa = ['c', 'b']
-        self.assertEquals(w_newdneighborsa, w_new.neighbors['a'])
+        self.assertEqual(w_newdneighborsa, w_new.neighbors['a'])
 
     def test_get_ids(self):
         polyids = util.get_ids(
             pysal_examples.get_path('columbus.shp'), "POLYID")
         polyids5 = [1, 2, 3, 4, 5]
-        self.assertEquals(polyids5, polyids[:5])
+        self.assertEqual(polyids5, polyids[:5])
 
     def test_get_points_array_from_shapefile(self):
         xy = util.get_points_array_from_shapefile(
@@ -206,15 +206,15 @@ class Testutil(unittest.TestCase):
         y.shape = (25, 1)
         data = np.hstack([x, y])
         mint = 1.0
-        self.assertEquals(
+        self.assertEqual(
             mint, util.min_threshold_distance(data))
 
     def test_attach_islands(self):
         w = user.rook_from_shapefile(pysal_examples.get_path('10740.shp'))
         w_knn1 = user.knnW_from_shapefile(pysal_examples.get_path('10740.shp'), k=1)
         w_attach = util.attach_islands(w, w_knn1)
-        self.assertEquals(w_attach.islands, [])
-        self.assertEquals(w_attach[w.islands[0]], {166: 1.0})
+        self.assertEqual(w_attach.islands, [])
+        self.assertEqual(w_attach[w.islands[0]], {166: 1.0})
 
 suite = unittest.TestLoader().loadTestsFromTestCase(Testutil)
 

--- a/libpysal/weights/tests/test_weights.py
+++ b/libpysal/weights/tests/test_weights.py
@@ -109,10 +109,10 @@ class TestW(unittest.TestCase):
                      4: [8, 0, 2, 6], 5: [1, 3, 7], 6: [4, 0, 8], 7: [3, 1, 5],
                      8: [6, 2, 4]}
         wneighbs = {k: {neighb: weights[k][i] for i, neighb in enumerate(v)}
-                    for k, v in neighbors.items()}
+                    for k, v in list(neighbors.items())}
         w2 = util.higher_order(self.w3x3, 2)
         test_wneighbs = {k: {ne: weights[k][i] for i, ne in enumerate(v)}
-                         for k, v in w2.neighbors.items()}
+                         for k, v in list(w2.neighbors.items())}
         self.assertEqual(test_wneighbs, wneighbs)
 
     def test_histogram(self):
@@ -346,10 +346,10 @@ class Test_WSP_Back_To_W(unittest.TestCase):
                      4: [8, 0, 2, 6], 5: [1, 3, 7], 6: [4, 0, 8], 7: [3, 1, 5],
                      8: [6, 2, 4]}
         wneighbs = {k: {neighb: weights[k][i] for i, neighb in enumerate(v)}
-                    for k, v in neighbors.items()}
+                    for k, v in list(neighbors.items())}
         w2 = util.higher_order(self.w3x3, 2)
         test_wneighbs = {k: {ne: w2.weights[k][i] for i, ne in enumerate(v)}
-                         for k, v in w2.neighbors.items()}
+                         for k, v in list(w2.neighbors.items())}
         self.assertEqual(test_wneighbs, wneighbs)
 
     def test_histogram(self):

--- a/libpysal/weights/tests/test_weights.py
+++ b/libpysal/weights/tests/test_weights.py
@@ -167,7 +167,7 @@ class TestW(unittest.TestCase):
         self.assertEqual(self.w3x3.neighbor_offsets, d)
 
     def test_nonzero(self):
-        self.assertEquals(self.w3x3.nonzero, 24)
+        self.assertEqual(self.w3x3.nonzero, 24)
 
     def test_order(self):
         w = util.lat2W(3, 3)
@@ -180,7 +180,7 @@ class TestW(unittest.TestCase):
              6: [2, 3, 0, 1, 2, 3, -1, 1, 2],
              7: [3, 2, 3, 2, 1, 2, 1, -1, 1],
              8: [0, 3, 2, 3, 2, 1, 2, 1, -1]}
-        self.assertEquals(util.order(w), o)
+        self.assertEqual(util.order(w), o)
 
     def test_pct_nonzero(self):
         self.assertEqual(self.w3x3.pct_nonzero, 29.62962962962963)
@@ -200,14 +200,14 @@ class TestW(unittest.TestCase):
         NPTA3E(self.w3x3.s2array, s2a)
 
     def test_sd(self):
-        self.assertEquals(self.w3x3.sd, 0.66666666666666663)
+        self.assertEqual(self.w3x3.sd, 0.66666666666666663)
 
     def test_set_transform(self):
         w = util.lat2W(2, 2)
         self.assertEqual(w.transform, 'O')
-        self.assertEquals(w.weights[0], [1.0, 1.0])
+        self.assertEqual(w.weights[0], [1.0, 1.0])
         w.transform = 'r'
-        self.assertEquals(w.weights[0], [0.5, 0.5])
+        self.assertEqual(w.weights[0], [0.5, 0.5])
 
     def test_shimbel(self):
         d = {0: [-1, 1, 2, 1, 2, 3, 2, 3, 4],
@@ -219,7 +219,7 @@ class TestW(unittest.TestCase):
              6: [2, 3, 4, 1, 2, 3, -1, 1, 2],
              7: [3, 2, 3, 2, 1, 2, 1, -1, 1],
              8: [4, 3, 2, 3, 2, 1, 2, 1, -1]}
-        self.assertEquals(util.shimbel(self.w3x3), d)
+        self.assertEqual(util.shimbel(self.w3x3), d)
 
     def test_sparse(self):
         self.assertEqual(self.w3x3.sparse.nnz, 24)
@@ -391,7 +391,7 @@ class Test_WSP_Back_To_W(unittest.TestCase):
         self.assertEqual(w.n, 25)
 
     def test_nonzero(self):
-        self.assertEquals(self.w3x3.nonzero, 24)
+        self.assertEqual(self.w3x3.nonzero, 24)
 
     def test_order(self):
         w = util.lat2W(3, 3)
@@ -404,7 +404,7 @@ class Test_WSP_Back_To_W(unittest.TestCase):
              6: [2, 3, 0, 1, 2, 3, -1, 1, 2],
              7: [3, 2, 3, 2, 1, 2, 1, -1, 1],
              8: [0, 3, 2, 3, 2, 1, 2, 1, -1]}
-        self.assertEquals(util.order(w), o)
+        self.assertEqual(util.order(w), o)
 
     def test_pct_nonzero(self):
         self.assertEqual(self.w3x3.pct_nonzero, 29.62962962962963)
@@ -424,14 +424,14 @@ class Test_WSP_Back_To_W(unittest.TestCase):
         NPTA3E(self.w3x3.s2array, s2a)
 
     def test_sd(self):
-        self.assertEquals(self.w3x3.sd, 0.66666666666666663)
+        self.assertEqual(self.w3x3.sd, 0.66666666666666663)
 
     def test_set_transform(self):
         w = util.lat2W(2, 2)
         self.assertEqual(w.transform, 'O')
-        self.assertEquals(w.weights[0], [1.0, 1.0])
+        self.assertEqual(w.weights[0], [1.0, 1.0])
         w.transform = 'r'
-        self.assertEquals(w.weights[0], [0.5, 0.5])
+        self.assertEqual(w.weights[0], [0.5, 0.5])
 
     def test_shimbel(self):
         d = {0: [-1, 1, 2, 1, 2, 3, 2, 3, 4],
@@ -443,7 +443,7 @@ class Test_WSP_Back_To_W(unittest.TestCase):
              6: [2, 3, 4, 1, 2, 3, -1, 1, 2],
              7: [3, 2, 3, 2, 1, 2, 1, -1, 1],
              8: [4, 3, 2, 3, 2, 1, 2, 1, -1]}
-        self.assertEquals(util.shimbel(self.w3x3), d)
+        self.assertEqual(util.shimbel(self.w3x3), d)
 
     def test_sparse(self):
         self.assertEqual(self.w3x3.sparse.nnz, 24)
@@ -466,8 +466,8 @@ class TestWSP(unittest.TestCase):
         self.w3x3 = WSP(w3x3.sparse)
 
     def test_WSP(self):
-        self.assertEquals(self.w.id_order, self.wsp.id_order)
-        self.assertEquals(self.w.n, self.wsp.n)
+        self.assertEqual(self.w.id_order, self.wsp.id_order)
+        self.assertEqual(self.w.n, self.wsp.n)
         np.testing.assert_array_equal(
             self.w.sparse.todense(), self.wsp.sparse.todense())
 

--- a/libpysal/weights/tests/test_weights.py
+++ b/libpysal/weights/tests/test_weights.py
@@ -109,10 +109,10 @@ class TestW(unittest.TestCase):
                      4: [8, 0, 2, 6], 5: [1, 3, 7], 6: [4, 0, 8], 7: [3, 1, 5],
                      8: [6, 2, 4]}
         wneighbs = {k: {neighb: weights[k][i] for i, neighb in enumerate(v)}
-                    for k, v in neighbors.iteritems()}
+                    for k, v in neighbors.items()}
         w2 = util.higher_order(self.w3x3, 2)
         test_wneighbs = {k: {ne: weights[k][i] for i, ne in enumerate(v)}
-                         for k, v in w2.neighbors.iteritems()}
+                         for k, v in w2.neighbors.items()}
         self.assertEqual(test_wneighbs, wneighbs)
 
     def test_histogram(self):
@@ -346,10 +346,10 @@ class Test_WSP_Back_To_W(unittest.TestCase):
                      4: [8, 0, 2, 6], 5: [1, 3, 7], 6: [4, 0, 8], 7: [3, 1, 5],
                      8: [6, 2, 4]}
         wneighbs = {k: {neighb: weights[k][i] for i, neighb in enumerate(v)}
-                    for k, v in neighbors.iteritems()}
+                    for k, v in neighbors.items()}
         w2 = util.higher_order(self.w3x3, 2)
         test_wneighbs = {k: {ne: w2.weights[k][i] for i, ne in enumerate(v)}
-                         for k, v in w2.neighbors.iteritems()}
+                         for k, v in w2.neighbors.items()}
         self.assertEqual(test_wneighbs, wneighbs)
 
     def test_histogram(self):

--- a/libpysal/weights/tests/test_weights.py
+++ b/libpysal/weights/tests/test_weights.py
@@ -88,7 +88,7 @@ class TestW(unittest.TestCase):
                        [0., 0., 0., 1., 0., 0., 0., 1., 0.],
                        [0., 0., 0., 0., 1., 0., 1., 0., 1.],
                        [0., 0., 0., 0., 0., 1., 0., 1., 0.]])
-        ids = range(9)
+        ids = list(range(9))
 
         wf1, ids1 = self.w3x3.full()
         NPTA3E(wf1, wf)
@@ -325,7 +325,7 @@ class Test_WSP_Back_To_W(unittest.TestCase):
                        [0., 0., 0., 1., 0., 0., 0., 1., 0.],
                        [0., 0., 0., 0., 1., 0., 1., 0., 1.],
                        [0., 0., 0., 0., 0., 1., 0., 1., 0.]])
-        ids = range(9)
+        ids = list(range(9))
 
         wf1, ids1 = self.w3x3.full()
         NPTA3E(wf1, wf)

--- a/libpysal/weights/user.py
+++ b/libpysal/weights/user.py
@@ -5,13 +5,13 @@ contiguity and distance criteria.
 
 __author__ = "Sergio J. Rey <srey@asu.edu> "
 
-from Contiguity import buildContiguity, Queen, Rook
-from Distance import knnW, Kernel, DistanceBand
-from util import get_ids, get_points_array_from_shapefile, min_threshold_distance
+from .Contiguity import buildContiguity, Queen, Rook
+from .Distance import knnW, Kernel, DistanceBand
+from .util import get_ids, get_points_array_from_shapefile, min_threshold_distance
 from ..io.FileIO import FileIO as ps_open
 from .. import cg
 from ..cg.voronoi import voronoi_frames
-from weights import WSP
+from .weights import WSP
 import numpy as np
 
 __all__ = ['queen_from_shapefile', 'rook_from_shapefile', 'knnW_from_array',

--- a/libpysal/weights/user.py
+++ b/libpysal/weights/user.py
@@ -1178,8 +1178,8 @@ def build_lattice_shapefile(nrows, ncols, outFileName):
     d.header = [ 'ID' ]
     d.field_spec = [ ('N', 8, 0) ]
     c = 0
-    for i in xrange(nrows):
-        for j in xrange(ncols):
+    for i in range(nrows):
+        for j in range(ncols):
             ll = i, j
             ul = i, j + 1
             ur = i + 1, j + 1

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -70,13 +70,13 @@ def hexLat2W(nrows=5, ncols=5):
         return lat2W(nrows, ncols)
 
     n = nrows * ncols
-    rid = [i // ncols for i in xrange(n)]
-    cid = [i % ncols for i in xrange(n)]
+    rid = [i // ncols for i in range(n)]
+    cid = [i % ncols for i in range(n)]
     r1 = nrows - 1
     c1 = ncols - 1
 
     w = lat2W(nrows, ncols).neighbors
-    for i in xrange(n):
+    for i in range(n):
         odd = cid[i] % 2
         if odd:
             if rid[i] < r1:  # odd col index above last row
@@ -153,11 +153,11 @@ def lat2W(nrows=5, ncols=5, rook=True, id_type='int'):
     n = nrows * ncols
     r1 = nrows - 1
     c1 = ncols - 1
-    rid = [i // ncols for i in xrange(n)] #must be floor!
-    cid = [i % ncols for i in xrange(n)]
+    rid = [i // ncols for i in range(n)] #must be floor!
+    cid = [i % ncols for i in range(n)]
     w = {}
     r = below = 0
-    for i in xrange(n - 1):
+    for i in range(n - 1):
         if rid[i] < r1:
             below = rid[i] + 1
             r = below * ncols + cid[i]
@@ -184,13 +184,13 @@ def lat2W(nrows=5, ncols=5, rook=True, id_type='int'):
     weights = {}
     for key in w:
         weights[key] = [1.] * len(w[key])
-    ids = range(n)
+    ids = list(range(n))
     if id_type == 'string':
         ids = ['id' + str(i) for i in ids]
     elif id_type == 'float':
         ids = [i * 1. for i in ids]
     if id_type == 'string' or id_type == 'float':
-        id_dict = dict(list(zip(range(n), ids)))
+        id_dict = dict(list(zip(list(range(n)), ids)))
         alt_w = {}
         alt_weights = {}
         for i in w:
@@ -769,7 +769,7 @@ def full2W(m, ids=None):
     if m.shape[0] != m.shape[1]:
         raise ValueError('Your array is not square')
     neighbors, weights = {}, {}
-    for i in xrange(m.shape[0]):
+    for i in range(m.shape[0]):
     # for i, row in enumerate(m):
         row = m[i]
         if ids:
@@ -833,10 +833,10 @@ def WSP2W(wsp, silent_island_warning=False):
         # replace indices with user IDs
         indices = [id_order[i] for i in indices]
     else:
-        id_order = range(wsp.n)
+        id_order = list(range(wsp.n))
     neighbors, weights = {}, {}
     start = indptr[0]
-    for i in xrange(wsp.n):
+    for i in range(wsp.n):
         oid = id_order[i]
         end = indptr[i + 1]
         neighbors[oid] = indices[start:end]
@@ -1217,7 +1217,7 @@ def write_gal(file, k=10):
     f = open(file, 'w')
     n = k * k
     f.write("0 %d" % n)
-    for i in xrange(n):
+    for i in range(n):
         row = i / k
         col = i % k
         neighs = [i - i, i + 1, i - k, i + k]

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -964,7 +964,7 @@ def remap_ids(w, old2new, id_order=[]):
         raise Exception("w must be a spatial weights object")
     new_neigh = {}
     new_weights = {}
-    for key, value in w.neighbors.items():
+    for key, value in list(w.neighbors.items()):
         new_values = [old2new[i] for i in value]
         new_key = old2new[key]
         new_neigh[new_key] = new_values

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -65,8 +65,8 @@ def hexLat2W(nrows=5, ncols=5):
     """
 
     if nrows == 1 or ncols == 1:
-        print "Hexagon lattice requires at least 2 rows and columns"
-        print "Returning a linear contiguity structure"
+        print("Hexagon lattice requires at least 2 rows and columns")
+        print("Returning a linear contiguity structure")
         return lat2W(nrows, ncols)
 
     n = nrows * ncols
@@ -252,7 +252,7 @@ def regime_weights(regimes):
     """
     msg = "PendingDepricationWarning: regime_weights will be "
     msg += "renamed to block_weights in PySAL 2.0"
-    print msg
+    print(msg)
     return block_weights(regimes)
 
 

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -11,6 +11,7 @@ import os
 import operator
 import scipy
 from warnings import warn
+import numbers
 
 __all__ = ['lat2W', 'block_weights', 'comb', 'order', 'higher_order',
            'shimbel', 'remap_ids', 'full2W', 'full', 'WSP2W',
@@ -908,7 +909,7 @@ def fill_diagonal(w, val=1.0, wsp=False):
         if w.n != val.shape[0]:
             raise Exception("shape of w and diagonal do not match")
         w_new.setdiag(val)
-    elif operator.isNumberType(val):
+    elif isinstance(val, numbers.Number):
         w_new.setdiag([val] * w.n)
     else:
         raise Exception("Invalid value passed to diagonal")

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -190,7 +190,7 @@ def lat2W(nrows=5, ncols=5, rook=True, id_type='int'):
     elif id_type == 'float':
         ids = [i * 1. for i in ids]
     if id_type == 'string' or id_type == 'float':
-        id_dict = dict(zip(range(n), ids))
+        id_dict = dict(list(zip(range(n), ids)))
         alt_w = {}
         alt_weights = {}
         for i in w:
@@ -527,7 +527,7 @@ def higher_order_sp(w, k=2, shortest_path=True, diagonal=False):
     """
     id_order = None
     if issubclass(type(w), W) or isinstance(w, W):
-        if np.unique(np.hstack(w.weights.values())) == np.array([1.0]):
+        if np.unique(np.hstack(list(w.weights.values()))) == np.array([1.0]):
             id_order = w.id_order
             w = w.sparse
         else:
@@ -964,7 +964,7 @@ def remap_ids(w, old2new, id_order=[]):
         raise Exception("w must be a spatial weights object")
     new_neigh = {}
     new_weights = {}
-    for key, value in w.neighbors.iteritems():
+    for key, value in w.neighbors.items():
         new_values = [old2new[i] for i in value]
         new_key = old2new[key]
         new_neigh[new_key] = new_values

--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -360,7 +360,7 @@ class W(object):
         col = []
         data = []
         id2i = self.id2i
-        for i, neigh_list in self.neighbor_offsets.items():
+        for i, neigh_list in list(self.neighbor_offsets.items()):
             card = self.cardinalities[i]
             row.extend([id2i[i]] * card)
             col.extend(neigh_list)
@@ -861,7 +861,7 @@ class W(object):
         if "neighbors_0" not in self._cache:
             self.__neighbors_0 = {}
             id2i = self.id2i
-            for j, neigh_list in self.neighbors.items():
+            for j, neigh_list in list(self.neighbors.items()):
                 self.__neighbors_0[j] = [id2i[neigh] for neigh in neigh_list]
             self._cache['neighbors_0'] = self.__neighbors_0
         return self.__neighbors_0

--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -955,7 +955,7 @@ class W(object):
                     row_sum = sum(wijs) * 1.0
                     if row_sum == 0.0:
                         if not self.silent_island_warning:
-                            print('WARNING: ', i, ' is an island (no neighbors)')
+                            print(('WARNING: ', i, ' is an island (no neighbors)'))
                     weights[i] = [wij / row_sum for wij in wijs]
                 weights = weights
                 self.transformations[value] = weights

--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -635,7 +635,7 @@ class W(object):
         """
         if 'histogram' not in self._cache:
             ct, bin = np.histogram(list(self.cardinalities.values()),
-                                   range(self.min_neighbors, self.max_neighbors + 2))
+                                   list(range(self.min_neighbors, self.max_neighbors + 2)))
             self._histogram = list(zip(bin, ct))
             self._cache['histogram'] = self._histogram
         return self._histogram
@@ -1456,7 +1456,7 @@ class WSP(object):
             # replace indices with user IDs
             indices = [id_order[i] for i in indices]
         else:
-            id_order = range(self.n)
+            id_order = list(range(self.n))
         neighbors, weights = {}, {}
         start = indptr[0]
         for i in range(self.n):

--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -169,7 +169,7 @@ class W(object):
         self.transformations['O'] = self.weights.copy()  # original weights
         self.transform = 'O'
         if id_order is None:
-            self._id_order = self.neighbors.keys()
+            self._id_order = list(self.neighbors.keys())
             self._id_order.sort()
             self._id_order_set = False
         else:
@@ -246,9 +246,9 @@ class W(object):
         neighbors = grouper[neighbor_col].apply(list).to_dict()
         weights = grouper[weight_col].apply(list).to_dict()
         neighbors.update({k:[] for k in 
-                          all_ids.difference(neighbors.keys())})
+                          all_ids.difference(list(neighbors.keys()))})
         weights.update({k:[] for k in 
-                        all_ids.difference(weights.keys())})
+                        all_ids.difference(list(weights.keys()))})
         return cls(neighbors=neighbors, weights=weights)
 
     def to_adjlist(self, remove_symmetric=False, 
@@ -277,7 +277,7 @@ class W(object):
         except ImportError:
             raise ImportError('pandas must be installed to use this method')
         adjlist = pd.DataFrame(((idx, n,w) for idx, neighb in self 
-                                           for n,w in neighb.items()),
+                                           for n,w in list(neighb.items())),
                                columns = ('focal', 'neighbor', 'weight'))
         return adjtools.filter_adjlist(adjlist) if remove_symmetric else adjlist
 
@@ -330,7 +330,7 @@ class W(object):
             links = graph[focal]
             neighbors.update({focal:[]})
             weights.update({focal:[]})
-            for neighbor, weight in links.items():
+            for neighbor, weight in list(links.items()):
                    neighbors[focal].append(neighbor)
                    if weight == {}:
                        weights[focal].append(1)
@@ -360,7 +360,7 @@ class W(object):
         col = []
         data = []
         id2i = self.id2i
-        for i, neigh_list in self.neighbor_offsets.iteritems():
+        for i, neigh_list in self.neighbor_offsets.items():
             card = self.cardinalities[i]
             row.extend([id2i[i]] * card)
             col.extend(neigh_list)
@@ -572,7 +572,7 @@ class W(object):
 
         """
         if 'mean_neighbors' not in self._cache:
-            self._mean_neighbors = np.mean(self.cardinalities.values())
+            self._mean_neighbors = np.mean(list(self.cardinalities.values()))
             self._cache['mean_neighbors'] = self._mean_neighbors
         return self._mean_neighbors
 
@@ -602,7 +602,7 @@ class W(object):
 
         """
         if 'sd' not in self._cache:
-            self._sd = np.std(self.cardinalities.values())
+            self._sd = np.std(list(self.cardinalities.values()))
             self._cache['sd'] = self._sd
         return self._sd
 
@@ -623,7 +623,7 @@ class W(object):
         """
         if 'islands' not in self._cache:
             self._islands = [i for i,
-                             c in self.cardinalities.items() if c == 0]
+                             c in list(self.cardinalities.items()) if c == 0]
             self._cache['islands'] = self._islands
         return self._islands
 
@@ -634,9 +634,9 @@ class W(object):
 
         """
         if 'histogram' not in self._cache:
-            ct, bin = np.histogram(self.cardinalities.values(),
+            ct, bin = np.histogram(list(self.cardinalities.values()),
                                    range(self.min_neighbors, self.max_neighbors + 2))
-            self._histogram = zip(bin, ct)
+            self._histogram = list(zip(bin, ct))
             self._cache['histogram'] = self._histogram
         return self._histogram
 
@@ -656,7 +656,7 @@ class W(object):
         >>> w[0]
         {1: 1.0, 5: 1.0, 4: 1.0, 101: 1.0, 85: 1.0}
         """
-        return dict(zip(self.neighbors[key], self.weights[key]))
+        return dict(list(zip(self.neighbors[key], self.weights[key])))
 
     def __iter__(self):
         """
@@ -681,7 +681,7 @@ class W(object):
         >>>
         """
         for i in self._id_order:
-            yield i, dict(zip(self.neighbors[i], self.weights[i]))
+            yield i, dict(list(zip(self.neighbors[i], self.weights[i])))
 
     def remap_ids(self, new_ids):
         '''
@@ -861,7 +861,7 @@ class W(object):
         if "neighbors_0" not in self._cache:
             self.__neighbors_0 = {}
             id2i = self.id2i
-            for j, neigh_list in self.neighbors.iteritems():
+            for j, neigh_list in self.neighbors.items():
                 self.__neighbors_0[j] = [id2i[neigh] for neigh in neigh_list]
             self._cache['neighbors_0'] = self.__neighbors_0
         return self.__neighbors_0
@@ -1072,7 +1072,7 @@ class W(object):
         if len(ids[0]) == 0:
             return []
         else:
-            ijs = zip(ids[0], ids[1])
+            ijs = list(zip(ids[0], ids[1]))
             ijs.sort()
             return ijs
 
@@ -1093,7 +1093,7 @@ class W(object):
             out_W.symmetrize(inplace=True)
             return out_W
         else:
-            for focal, fneighbs in self.neighbors.items():
+            for focal, fneighbs in list(self.neighbors.items()):
                 for j, neighbor in enumerate(fneighbs):
                     neighb_neighbors = self.neighbors[neighbor]
                     if focal not in neighb_neighbors:
@@ -1132,7 +1132,7 @@ class W(object):
         ['first', 'second', 'third']
         """
         wfull = np.zeros([self.n, self.n], dtype=float)
-        keys = self.neighbors.keys()
+        keys = list(self.neighbors.keys())
         if self.id_order:
             keys = self.id_order
         for i, key in enumerate(keys):

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,7 @@
 
 from setuptools import setup, find_packages
 
-try:
-    from distutils.command.build_py import build_py_2to3 as build_py
-except ImportError:
-    from distutils.command.build_py import build_py
+from distutils.command.build_py import build_py
 
 import os
 
@@ -87,17 +84,14 @@ def setup_package():
             'Topic :: Scientific/Engineering :: GIS',
             'License :: OSI Approved :: BSD License',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 2.5',
-            'Programming Language :: Python :: 2.6',
-            'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6'
         ],
         package_data={'libpysal':list(example_data_files)},
         install_requires=install_reqs,
         extras_require=extras_reqs,
-        cmdclass={'build_py': build_py}
+        cmdclass={'build_py': build_py},
+        python_requires='>3.4'
     )
 
 


### PR DESCRIPTION
with this, we're commiting the auto-converted code for libpysal that only works in two. 

If someone else wants to deal with trying to get libpysal into common subset, they need to:
1. refactor/extract the weights readers from `io` and kill the `FileIO` metaclass
2. see 1. 