### PR TITLE
force UTF8 encoding for the long description read

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from distutils.command.build_py import build_py
 
 import os
 
-with open('README.rst') as file:
+with open('README.rst', 'r', encoding='utf8') as file:
     long_description = file.read()
 
 MAJOR = 3


### PR DESCRIPTION
Similar to https://github.com/pysal/giddy/pull/46 to resolve potential encoding issue when reading README.rst to setup the long description