### PR TITLE
Fuzzy contiguity

### DIFF
--- a/libpysal/api.py
+++ b/libpysal/api.py
@@ -15,7 +15,7 @@ from .weights.user import threshold_continuousW_from_shapefile, kernelW, kernelW
 from .weights.user import adaptive_kernelW, adaptive_kernelW_from_shapefile
 from .weights.user import min_threshold_dist_from_shapefile, build_lattice_shapefile
 from .weights.user import voronoi_frames, voronoiW as VoronoiW
-from .weights.util import lat2W, block_weights, comb, order, higher_order, shimbel, remap_ids, full2W, full, WSP2W, insert_diagonal, get_ids, get_points_array_from_shapefile, min_threshold_distance, lat2SW, w_local_cluster, higher_order_sp, hexLat2W, regime_weights, attach_islands
+from .weights.util import lat2W, block_weights, comb, order, higher_order, shimbel, remap_ids, full2W, full, WSP2W, insert_diagonal, get_ids, get_points_array_from_shapefile, min_threshold_distance, lat2SW, w_local_cluster, higher_order_sp, hexLat2W, regime_weights, attach_islands, nonplanar_neighbors, fuzzy_contiguity
 from .weights.spatial_lag import lag_spatial, lag_categorical
 from .weights.Contiguity import Rook, Queen
 from .weights.Distance import KNN, Kernel, DistanceBand

--- a/libpysal/weights/tests/test_util.py
+++ b/libpysal/weights/tests/test_util.py
@@ -236,6 +236,16 @@ class Testutil(unittest.TestCase):
         self.assertEqual(wnp.neighbors[0], [23, 59, 152, 239])
         self.assertEqual(wnp.neighbors[23], [0, 45, 59, 107, 152, 185, 246])
 
+    @unittest.skipIf(not HAS_GEOPANDAS, "Missing geopandas, cannot test nonplanar neighbors")
+    def test_fuzzy_contiguity(self):
+        import libpysal.api as lps
+        import geopandas as gpd
+        rs = lps.get_path('map_RS_BR.shp')
+        rs_df = gpd.read_file(rs)
+        wf = lps.fuzzy_contiguity(rs_df)
+        self.assertEqual(wf.islands, [])
+        self.assertEqual(set(wf.neighbors[0]), set([239, 59, 152, 23, 107]))
+
 
 suite = unittest.TestLoader().loadTestsFromTestCase(Testutil)
 

--- a/libpysal/weights/tests/test_util.py
+++ b/libpysal/weights/tests/test_util.py
@@ -236,7 +236,7 @@ class Testutil(unittest.TestCase):
         self.assertEqual(wnp.neighbors[0], [23, 59, 152, 239])
         self.assertEqual(wnp.neighbors[23], [0, 45, 59, 107, 152, 185, 246])
 
-    @unittest.skipIf(not HAS_GEOPANDAS, "Missing geopandas, cannot test nonplanar neighbors")
+    @unittest.skipIf(not HAS_GEOPANDAS, "Missing geopandas, cannot test fuzzy_contiguity")
     def test_fuzzy_contiguity(self):
         import libpysal.api as lps
         import geopandas as gpd

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -1578,7 +1578,7 @@ def fuzzy_contiguity(gdf, tolerance=0.005, buffering=False, drop=True):
     neighbors = {}
     n,k = gdf.shape
     for i in range(n):
-        geom = gdf['geometry'].iloc[i]
+        geom = gdf[gdf.geometry.name].iloc[i]
         hits = list(tree.intersection(geom.bounds))
         possible = gdf.iloc[hits]
         ids = possible.intersects(geom).index.tolist()

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -19,7 +19,7 @@ from ..common import requires
 try:
     import geopandas as gpd
 except ImportError:
-    _warnings.warn('geopandas not available. Some functionality will be disabled.')
+    warn('geopandas not available. Some functionality will be disabled.')
 
 __all__ = ['lat2W', 'block_weights', 'comb', 'order', 'higher_order',
            'shimbel', 'remap_ids', 'full2W', 'full', 'WSP2W',

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -1578,7 +1578,7 @@ def fuzzy_contiguity(gdf, tolerance=0.005, buffering=False, drop=True):
     neighbors = {}
     n,k = gdf.shape
     for i in range(n):
-        geom = gdf[gdf.geometry.name].iloc[i]
+        geom = gdf.geometry.iloc[i]
         hits = list(tree.intersection(geom.bounds))
         possible = gdf.iloc[hits]
         ids = possible.intersects(geom).index.tolist()


### PR DESCRIPTION
This implements fuzzy contiguity detection for all features in a GeoDatatFrame. 

It is intended as a complement to #51 which focuses only on fixing island features. This is a more general treatment in that the geometric operations are applied to all features, not just island features.