### PR TITLE
Ensure consistency in `from .module import *` in components of libpysal

### DIFF
--- a/libpysal/io/__init__.py
+++ b/libpysal/io/__init__.py
@@ -1,3 +1,5 @@
 from . import FileIO
-from . import IOHandlers
+from .Tables import *
+from .IOHandlers import *
+from .util import *
 open = FileIO.FileIO

--- a/libpysal/io/util/__init__.py
+++ b/libpysal/io/util/__init__.py
@@ -1,2 +1,3 @@
 from .wkt import *
+from .wkb import *
 from .shapefile import *

--- a/libpysal/io/util/wkb.py
+++ b/libpysal/io/util/wkb.py
@@ -28,8 +28,8 @@ SOURCE: http://webhelp.esri.com/arcgisserver/9.3/dotNet/index.htm#geodatabases/t
 
 
 """
-from cStringIO import StringIO
-from pysal import cg
+from io import StringIO
+from ... import cg
 import sys
 import struct
 

--- a/libpysal/weights/__init__.py
+++ b/libpysal/weights/__init__.py
@@ -1,8 +1,8 @@
-from .weights import W
-from .Distance import KNN, Kernel, DistanceBand
-from .Contiguity import Queen, Rook
-from . import spintW as spatial_interaction
-from . import util
-from . import user
-from . import Wsets as set_operations
-from .spatial_lag import (lag_spatial, lag_categorical)
+from .weights import *
+from .Distance import *
+from .Contiguity import *
+from .spintW import *
+from .util import *
+from .user import *
+from .Wsets import *
+from .spatial_lag import *

--- a/libpysal/weights/user.py
+++ b/libpysal/weights/user.py
@@ -10,12 +10,7 @@ from ..io.FileIO import FileIO as ps_open
 from .. import cg
 import numpy as np
 
-__all__ = ['queen_from_shapefile', 'rook_from_shapefile', 'knnW_from_array',
-           'knnW_from_shapefile', 'threshold_binaryW_from_array',
-           'threshold_binaryW_from_shapefile', 'threshold_continuousW_from_array',
-           'threshold_continuousW_from_shapefile', 'kernelW', 'kernelW_from_shapefile',
-           'adaptive_kernelW', 'adaptive_kernelW_from_shapefile',
-           'min_threshold_dist_from_shapefile', 'build_lattice_shapefile', 'voronoiW']
+__all__ = ['min_threshold_dist_from_shapefile', 'build_lattice_shapefile', 'spw_from_gal']
 
 def spw_from_gal(galfile):
     """


### PR DESCRIPTION
This does what we chatted about on gitter.im/pysal/pysal today. 

Please double check that this is consistent over my fork. 

If you'd prefer, please [check it out locally.](https://help.github.com/articles/checking-out-pull-requests-locally/) If your reference to the `pysal/pysal` remote repository is called `upstream`, then you can:

```
git fetch upstream pull/95/head:ljw-imports
git checkout ljw-imports
```