### PR TITLE
Weights/util/get ids gdf

### DIFF
--- a/libpysal/weights/tests/test_util.py
+++ b/libpysal/weights/tests/test_util.py
@@ -187,12 +187,19 @@ class Testutil(unittest.TestCase):
         w_newdneighborsa = ['c', 'b']
         self.assertEqual(w_newdneighborsa, w_new.neighbors['a'])
 
-    def test_get_ids(self):
+    def test_get_ids_shp(self):
         polyids = util.get_ids(
             examples.get_path('columbus.shp'), "POLYID")
         polyids5 = [1, 2, 3, 4, 5]
         self.assertEqual(polyids5, polyids[:5])
 
+    @unittest.skipIf(not HAS_GEOPANDAS, "Missing geopandas, cannot test get_ids with gdf")
+    def test_get_ids_gdf(self):
+        gdf = gpd.read_file(examples.get_path('columbus.shp'))
+        polyids = list(gdf["POLYID"])
+        polyids5 = [1, 2, 3, 4, 5]
+        self.assertEqual(polyids5, polyids[:5])
+    
     def test_get_points_array_from_shapefile(self):
         xy = util.get_points_array_from_shapefile(
             examples.get_path('juvenile.shp'))

--- a/libpysal/weights/tests/test_util.py
+++ b/libpysal/weights/tests/test_util.py
@@ -196,7 +196,7 @@ class Testutil(unittest.TestCase):
     @unittest.skipIf(not HAS_GEOPANDAS, "Missing geopandas, cannot test get_ids with gdf")
     def test_get_ids_gdf(self):
         gdf = gpd.read_file(examples.get_path('columbus.shp'))
-        polyids = list(gdf["POLYID"])
+        polyids = util.get_ids(gdf, "POLYID")
         polyids5 = [1, 2, 3, 4, 5]
         self.assertEqual(polyids5, polyids[:5])
     

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -990,7 +990,7 @@ def get_ids(in_shps, idVariable):
         msg = 'The shapefile "%s" appears to be missing its DBF file. '\
               + ' The DBF file "%s" could not be found.' % (in_shps, dbname)
         raise IOError(msg)
-    except AttributeError:
+    except (AttributeError, KeyError):
         msg = 'The variable "%s" not found in the DBF/GDF. The the following '\
               + 'variables are present: %s.' % (idVariable, ','.join(cols))
         raise KeyError(msg)


### PR DESCRIPTION
The justification for this PR is: 

- Add functionality to accept a `geopandas.GeoDataFrame` in `weights.util.get_ids()`
- update doc strings in the function and added an example
   - the function does not `@requires geopandas`, so will the example still be appropriate?
- add test as `weights.tests.test_util.test_get_ids_gdf()`
