### PR TITLE
Always make spherical KDTrees if radius is passed

### DIFF
--- a/libpysal/cg/kdtree.py
+++ b/libpysal/cg/kdtree.py
@@ -51,7 +51,7 @@ def KDTree(data, leafsize=10, distance_metric='Euclidean',
             return scipy.spatial.KDTree(data, leafsize)
         else:
             return scipy.spatial.cKDTree(data, leafsize)
-    elif distance_metric == 'Arc':
+    elif distance_metric.lower() == 'arc':
         return Arc_KDTree(data, leafsize, radius)
 
 

--- a/libpysal/weights/distance.py
+++ b/libpysal/weights/distance.py
@@ -88,7 +88,8 @@ class KNN(W):
     """
     def __init__(self, data, k=2, p=2, ids=None, radius=None,
                  distance_metric='euclidean', **kwargs):
-
+        if radius is not None: 
+            distance_metric='arc'
         if isKDTree(data):
             self.kdtree = data
             self.data = self.kdtree.data
@@ -484,6 +485,8 @@ class Kernel(W):
                  diagonal=False, 
                  distance_metric='euclidean', radius=None, 
                  **kwargs):
+        if radius is not None:
+            distance_metric='arc'
         if isKDTree(data):
             self.kdtree = data
             self.data = self.kdtree.data
@@ -756,6 +759,8 @@ class DistanceBand(W):
         """
         if ids is not None:
             ids = list(ids)
+        if radius is not None:
+            distance_metric='arc'
         self.p = p
         self.threshold = threshold
         self.binary = binary


### PR DESCRIPTION
This makes it so that if `radius` is provided, `distance_metric='arc'` is implied. 

This should ensure the API behaves as expected in #116. 

Currently, you have to pass `distance_metric='Arc'` in order for `radius` to be used. This is because, when we pass a `radius` but keep `distance_metric='euclidean'`, `KDTree` ignores the radius, and returns the `KDTree` according to `distance_metric`