### PR TITLE
make id_order propagate through symmetrize(inplace=False)

### DIFF
--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -1085,7 +1085,7 @@ class W(object):
         if not inplace:
             neighbors = copy.deepcopy(self.neighbors)
             weights = copy.deepcopy(self.weights)
-            out_W = W(neighbors, weights)
+            out_W = W(neighbors, weights, id_order=self.id_order)
             out_W.symmetrize(inplace=True)
             return out_W
         else:


### PR DESCRIPTION
This resolves #136 by sending the `id_order` down to the new copy of the `W` object. This works in all cases:

1. if `id_order` is not set by the user, then this simply propagates the default (lexsorted) id_order for the dataset, which is now forced to be the same in the new and the old data. 
2. if `id_order` *is* set by user, then this propagates that order exactly. 