### PR TITLE
replace deprecated "fromstring" with "frombytes"

### DIFF
--- a/libpysal/io/util/shapefile.py
+++ b/libpysal/io/util/shapefile.py
@@ -21,7 +21,6 @@ import array
 import sys
 import io
 
-
 if sys.byteorder == 'little':
     SYS_BYTE_ORDER = '<'
 else:
@@ -45,8 +44,12 @@ def struct2arrayinfo(struct):
     lname, ltype, lorder = struct.pop(0)
     groups = {}
     g = 0
-    groups[g] = {'names': [lname], 'size': STRUCT_ITEMSIZE[ltype],
-                 'fmt': ltype, 'order': lorder}
+    groups[g] = {
+        'names': [lname],
+        'size': STRUCT_ITEMSIZE[ltype],
+        'fmt': ltype,
+        'order': lorder
+    }
     while struct:
         name, type, order = struct.pop(0)
         if order == lorder:
@@ -55,34 +58,32 @@ def struct2arrayinfo(struct):
             groups[g]['fmt'] += type
         else:
             g += 1
-            groups[g] = {'names': [name], 'size': STRUCT_ITEMSIZE[
-                type], 'fmt': type, 'order': order}
+            groups[g] = {
+                'names': [name],
+                'size': STRUCT_ITEMSIZE[type],
+                'fmt': type,
+                'order': order
+            }
         lname, ltype, lorder = name, type, order
     return [groups[x] for x in range(g + 1)]
 
 
-HEADERSTRUCT = (
-    ('File Code', 'i', '>'),
-    ('Unused0', 'i', '>'),
-    ('Unused1', 'i', '>'),
-    ('Unused2', 'i', '>'),
-    ('Unused3', 'i', '>'),
-    ('Unused4', 'i', '>'),
-    ('File Length', 'i', '>'),
-    ('Version', 'i', '<'),
-    ('Shape Type', 'i', '<'),
-    ('BBOX Xmin', 'd', '<'),
-    ('BBOX Ymin', 'd', '<'),
-    ('BBOX Xmax', 'd', '<'),
-    ('BBOX Ymax', 'd', '<'),
-    ('BBOX Zmin', 'd', '<'),
-    ('BBOX Zmax', 'd', '<'),
-    ('BBOX Mmin', 'd', '<'),
-    ('BBOX Mmax', 'd', '<'))
+HEADERSTRUCT = (('File Code', 'i', '>'), ('Unused0', 'i',
+                                          '>'), ('Unused1', 'i',
+                                                 '>'), ('Unused2', 'i', '>'),
+                ('Unused3', 'i', '>'), ('Unused4', 'i',
+                                        '>'), ('File Length', 'i',
+                                               '>'), ('Version', 'i', '<'),
+                ('Shape Type', 'i',
+                 '<'), ('BBOX Xmin', 'd', '<'), ('BBOX Ymin', 'd',
+                                                 '<'), ('BBOX Xmax', 'd', '<'),
+                ('BBOX Ymax', 'd', '<'), ('BBOX Zmin', 'd',
+                                          '<'), ('BBOX Zmax', 'd',
+                                                 '<'), ('BBOX Mmin', 'd',
+                                                        '<'), ('BBOX Mmax',
+                                                               'd', '<'))
 UHEADERSTRUCT = struct2arrayinfo(HEADERSTRUCT)
-RHEADERSTRUCT = (
-    ('Record Number', 'i', '>'),
-    ('Content Length', 'i', '>'))
+RHEADERSTRUCT = (('Record Number', 'i', '>'), ('Content Length', 'i', '>'))
 URHEADERSTRUCT = struct2arrayinfo(RHEADERSTRUCT)
 
 
@@ -152,7 +153,7 @@ def _unpackDict2(d, structure, fileObj):
     for name, dtype, order in structure:
         dtype, n = dtype
         result = array.array(dtype)
-        result.fromstring(fileObj.read(result.itemsize * n))
+        result.frombytes(fileObj.read(result.itemsize * n))
         if order != SYS_BYTE_ORDER:
             result.byteswap()
         d[name] = result.tolist()
@@ -204,37 +205,53 @@ class shp_file:
     The header of both the SHP and SHX files are indentical.
     
     """
-    SHAPE_TYPES = {'POINT': 1, 'ARC': 3, 'POLYGON': 5, 'MULTIPOINT': 8, 'POINTZ': 11, 'ARCZ': 13, 'POLYGONZ': 15, 'MULTIPOINTZ': 18, 'POINTM': 21, 'ARCM': 23, 'POLYGONM': 25, 'MULTIPOINTM': 28, 'MULTIPATCH': 31}
-    
+    SHAPE_TYPES = {
+        'POINT': 1,
+        'ARC': 3,
+        'POLYGON': 5,
+        'MULTIPOINT': 8,
+        'POINTZ': 11,
+        'ARCZ': 13,
+        'POLYGONZ': 15,
+        'MULTIPOINTZ': 18,
+        'POINTM': 21,
+        'ARCM': 23,
+        'POLYGONM': 25,
+        'MULTIPOINTM': 28,
+        'MULTIPATCH': 31
+    }
+
     def __iswritable(self):
         try:
             assert self.__mode == 'w'
         except AssertionError:
             raise IOError("[Errno 9] Bad file descriptor")
         return True
-    
+
     def __isreadable(self):
         try:
             assert self.__mode == 'r'
         except AssertionError:
             raise IOError("[Errno 9] Bad file descriptor")
         return True
-    
+
     def __init__(self, fileName, mode='r', shape_type=None):
         self.__mode = mode
-        if fileName.lower().endswith('.shp') or fileName.lower().endswith('.shx') or fileName.lower().endswith('.dbf'):
+        if fileName.lower().endswith('.shp') or fileName.lower().endswith(
+                '.shx') or fileName.lower().endswith('.dbf'):
             fileName = fileName[:-4]
         self.fileName = fileName
-    
+
         if mode == 'r':
             self._open_shp_file()
         elif mode == 'w':
             if shape_type not in self.SHAPE_TYPES:
-                raise Exception('Attempt to create shp/shx file of invalid type')
+                raise Exception(
+                    'Attempt to create shp/shx file of invalid type')
             self._create_shp_file(shape_type)
         else:
             raise Exception('Only "w" and "r" modes are supported')
-    
+
     def _open_shp_file(self):
         """Opens a shp/shx file.
         
@@ -269,10 +286,11 @@ class shp_file:
         self.__numRecords = self._shx.numRecords
         # constructing bounding box from header
         h = self.header
-        self.bbox = [h['BBOX Xmin'], h['BBOX Ymin'],
-                     h['BBOX Xmax'], h['BBOX Ymax']]
+        self.bbox = [
+            h['BBOX Xmin'], h['BBOX Ymin'], h['BBOX Xmax'], h['BBOX Ymax']
+        ]
         self.shapeType = self.header['Shape Type']
-    
+
     def _create_shp_file(self, shape_type):
         """Creates a shp/shx file.
         
@@ -330,17 +348,16 @@ class shp_file:
         self.header['BBOX Zmin'] = None
         self.shape = TYPE_DISPATCH[self.header['Shape Type']]
         #self.__numRecords = self._shx.numRecords
-    
-    
+
     def __len__(self):
         return self.__numRecords
-    
+
     def __iter__(self):
         return self
-    
+
     def type(self):
         return self.shape.String_Type
-    
+
     def __next__(self):
         """returns the next Shape in the shapeFile
         
@@ -360,17 +377,17 @@ class shp_file:
         else:
             self.__lastShape = nextShape + 1
             return self.get_shape(nextShape)
-    
+
     def __seek(self, pos):
         if pos != self.fileObj.tell():
             self.fileObj.seek(pos)
-    
+
     def __read(self, pos, size):
         self.__isreadable()
         if pos != self.fileObj.tell():
             self.fileObj.seek(pos)
         return self.fileObj.read(size)
-    
+
     def get_shape(self, shpId):
         self.__isreadable()
         if shpId + 1 > self.__numRecords:
@@ -381,7 +398,7 @@ class shp_file:
         rec_id, con_len = _unpackDict(URHEADERSTRUCT, self.fileObj)
         return self.shape.unpack(io.BytesIO(self.fileObj.read(byts)))
         #return self.shape.unpack(self.fileObj.read(bytes))
-    
+
     def __update_bbox(self, s):
         h = self.header
         if s.get('Shape Type') == 1:
@@ -408,7 +425,7 @@ class shp_file:
         if not self.shape.HASZ:
             self.header['BBOX Zmax'] = 0.0
             self.header['BBOX Zmin'] = 0.0
-    
+
     def add_shape(self, s):
         self.__iswritable()
         self.__update_bbox(s)
@@ -419,7 +436,7 @@ class shp_file:
         self.__seek(pos)
         self.fileObj.write(pack('>ii', rec_id, con_len // 2))
         self.fileObj.write(rec)
-    
+
     def close(self):
         self._shx.close(self.header)
         if self.__mode == 'w':
@@ -439,31 +456,33 @@ class shx_file:
     numRecords -- int -- Number of records
     
     """
+
     def __iswritable(self):
         try:
             assert self.__mode == 'w'
         except AssertionError:
             raise IOError("[Errno 9] Bad file descriptor")
         return True
-    
+
     def __isreadable(self):
         try:
             assert self.__mode == 'r'
         except AssertionError:
             raise IOError("[Errno 9] Bad file descriptor")
         return True
-    
+
     def __init__(self, fileName=None, mode='r'):
         self.__mode = mode
-        if fileName.endswith('.shp') or fileName.endswith('.shx') or fileName.endswith('.dbf'):
+        if fileName.endswith('.shp') or fileName.endswith(
+                '.shx') or fileName.endswith('.dbf'):
             fileName = fileName[:-4]
         self.fileName = fileName
-        
+
         if mode == 'r':
             self._open_shx_file()
         elif mode == 'w':
             self._create_shx_file()
-    
+
     def _open_shx_file(self):
         """Opens the SHX file.
         
@@ -494,9 +513,9 @@ class shx_file:
         fmt = '>%di' % (2 * numRecords)
         size = calcsize(fmt)
         dat = unpack(fmt, self.fileObj.read(size))
-        self.index = [(dat[i] * 2, dat[i + 1] * 2) for i in range(
-            0, len(dat), 2)]
-    
+        self.index = [(dat[i] * 2, dat[i + 1] * 2)
+                      for i in range(0, len(dat), 2)]
+
     def _create_shx_file(self):
         """ Creates the SHX file.
         
@@ -517,14 +536,14 @@ class shx_file:
         True
         
         """
-        
+
         self.__iswritable()
         self.fileObj = open(self.fileName + '.shx', 'wb')
         self.numRecords = 0
         self.index = []
         self.__offset = 100  # length of header
         self.__next_rid = 1  # record IDs start at 1
-    
+
     def add_record(self, size):
         """Add a record to the shx index.
         
@@ -563,7 +582,7 @@ class shx_file:
         >>> os.remove('test.shx')
         
         """
-        
+
         self.__iswritable()
         pos = self.__offset
         rec_id = self.__next_rid
@@ -572,7 +591,7 @@ class shx_file:
         self.numRecords += 1
         self.__next_rid += 1
         return rec_id, pos
-    
+
     def close(self, header):
         if self.__mode == 'w':
             self.__iswritable()
@@ -591,10 +610,10 @@ class shx_file:
 class NullShape:
     Shape_Type = 0
     STRUCT = (('Shape Type', 'i', '<'))
-    
+
     def unpack(self):
         return None
-    
+
     def pack(self, x=None):
         return pack('<i', 0)
 
@@ -620,16 +639,18 @@ class Point(object):
     String_Type = 'POINT'
     HASZ = False
     HASM = False
-    STRUCT = (('Shape Type', 'i', '<'),
-              ('X', 'd', '<'),
-              ('Y', 'd', '<'))
-    USTRUCT = [{'fmt': 'idd', 'order': '<', 'names': ['Shape Type',
-                                                      'X', 'Y'], 'size': 20}]
-    
+    STRUCT = (('Shape Type', 'i', '<'), ('X', 'd', '<'), ('Y', 'd', '<'))
+    USTRUCT = [{
+        'fmt': 'idd',
+        'order': '<',
+        'names': ['Shape Type', 'X', 'Y'],
+        'size': 20
+    }]
+
     @classmethod
     def unpack(cls, dat):
         return _unpackDict(cls.USTRUCT, dat)
-    
+
     @classmethod
     def pack(cls, record):
         rheader = _packDict(cls.STRUCT, record)
@@ -641,13 +662,14 @@ class PointZ(Point):
     String_Type = "POINTZ"
     HASZ = True
     HASM = True
-    STRUCT = (('Shape Type', 'i', '<'),
-              ('X', 'd', '<'),
-              ('Y', 'd', '<'),
-              ('Z', 'd', '<'),
-              ('M', 'd', '<'))
-    USTRUCT = [{'fmt': 'idddd', 'order': '<', 'names': ['Shape Type',
-                                                        'X', 'Y', 'Z', 'M'], 'size': 36}]
+    STRUCT = (('Shape Type', 'i', '<'), ('X', 'd', '<'), ('Y', 'd', '<'),
+              ('Z', 'd', '<'), ('M', 'd', '<'))
+    USTRUCT = [{
+        'fmt': 'idddd',
+        'order': '<',
+        'names': ['Shape Type', 'X', 'Y', 'Z', 'M'],
+        'size': 36
+    }]
 
 
 class PolyLine:
@@ -670,15 +692,23 @@ class PolyLine:
     HASZ = False
     HASM = False
     String_Type = 'ARC'
-    STRUCT = (('Shape Type', 'i', '<'),
-              ('BBOX Xmin', 'd', '<'),
-              ('BBOX Ymin', 'd', '<'),
-              ('BBOX Xmax', 'd', '<'),
-              ('BBOX Ymax', 'd', '<'),
-              ('NumParts', 'i', '<'),
-              ('NumPoints', 'i', '<'))
-    USTRUCT = [{'fmt': 'iddddii', 'order': '<', 'names': ['Shape Type', 'BBOX Xmin', 'BBOX Ymin', 'BBOX Xmax', 'BBOX Ymax', 'NumParts', 'NumPoints'], 'size': 44}]
-    
+    STRUCT = (('Shape Type', 'i', '<'), ('BBOX Xmin', 'd', '<'),
+              ('BBOX Ymin', 'd', '<'), ('BBOX Xmax', 'd', '<'),
+              ('BBOX Ymax', 'd', '<'), ('NumParts', 'i', '<'), ('NumPoints',
+                                                                'i', '<'))
+    USTRUCT = [{
+        'fmt':
+        'iddddii',
+        'order':
+        '<',
+        'names': [
+            'Shape Type', 'BBOX Xmin', 'BBOX Ymin', 'BBOX Xmax', 'BBOX Ymax',
+            'NumParts', 'NumPoints'
+        ],
+        'size':
+        44
+    }]
+
     @classmethod
     def unpack(cls, dat):
         record = _unpackDict(cls.USTRUCT, dat)
@@ -688,15 +718,15 @@ class PolyLine:
         #record['Vertices'] = [(record['Vertices'][i],record['Vertices'][i+1]) for i in xrange(0,record['NumPoints']*2,2)]
         verts = record['Vertices']
         #Next line is equivalent to: zip(verts[::2],verts[1::2])
-        record['Vertices'] = list(zip(
-            islice(verts, 0, None, 2), islice(verts, 1, None, 2)))
+        record['Vertices'] = list(
+            zip(islice(verts, 0, None, 2), islice(verts, 1, None, 2)))
         if not record['Parts Index']:
             record['Parts Index'] = [0]
         return record
         #partsIndex = list(partsIndex)
         #partsIndex.append(None)
         #parts = [vertices[partsIndex[i]:partsIndex[i+1]] for i in xrange(header['NumParts'])]
-    
+
     @classmethod
     def pack(cls, record):
         rheader = _packDict(cls.STRUCT, record)
@@ -715,30 +745,40 @@ class PolyLineZ(object):
     HASZ = True
     HASM = True
     String_Type = 'ARC'
-    STRUCT = (('Shape Type', 'i', '<'),
-              ('BBOX Xmin', 'd', '<'),
-              ('BBOX Ymin', 'd', '<'),
-              ('BBOX Xmax', 'd', '<'),
-              ('BBOX Ymax', 'd', '<'),
-              ('NumParts', 'i', '<'),
-              ('NumPoints', 'i', '<'))
-    USTRUCT = [{'fmt': 'iddddii', 'order': '<', 'names': ['Shape Type', 'BBOX Xmin', 'BBOX Ymin', 'BBOX Xmax', 'BBOX Ymax', 'NumParts', 'NumPoints'], 'size': 44}]
-    
+    STRUCT = (('Shape Type', 'i', '<'), ('BBOX Xmin', 'd', '<'),
+              ('BBOX Ymin', 'd', '<'), ('BBOX Xmax', 'd', '<'),
+              ('BBOX Ymax', 'd', '<'), ('NumParts', 'i', '<'), ('NumPoints',
+                                                                'i', '<'))
+    USTRUCT = [{
+        'fmt':
+        'iddddii',
+        'order':
+        '<',
+        'names': [
+            'Shape Type', 'BBOX Xmin', 'BBOX Ymin', 'BBOX Xmax', 'BBOX Ymax',
+            'NumParts', 'NumPoints'
+        ],
+        'size':
+        44
+    }]
+
     @classmethod
     def unpack(cls, dat):
         record = _unpackDict(cls.USTRUCT, dat)
-        contentStruct = (('Parts Index', ('i', record['NumParts']), '<'),
-                         ('Vertices', ('d', 2 * record['NumPoints']), '<'),
-                         ('Zmin', ('d', 1), '<'),
-                         ('Zmax', ('d', 1), '<'),
-                         ('Zarray', ('d', record['NumPoints']), '<'),
-                         ('Mmin', ('d', 1), '<'),
-                         ('Mmax', ('d', 1), '<'),
-                         ('Marray', ('d', record['NumPoints']), '<'),)
+        contentStruct = (
+            ('Parts Index', ('i', record['NumParts']), '<'),
+            ('Vertices', ('d', 2 * record['NumPoints']), '<'),
+            ('Zmin', ('d', 1), '<'),
+            ('Zmax', ('d', 1), '<'),
+            ('Zarray', ('d', record['NumPoints']), '<'),
+            ('Mmin', ('d', 1), '<'),
+            ('Mmax', ('d', 1), '<'),
+            ('Marray', ('d', record['NumPoints']), '<'),
+        )
         _unpackDict2(record, contentStruct, dat)
         verts = record['Vertices']
-        record['Vertices'] = list(zip(
-            islice(verts, 0, None, 2), islice(verts, 1, None, 2)))
+        record['Vertices'] = list(
+            zip(islice(verts, 0, None, 2), islice(verts, 1, None, 2)))
         if not record['Parts Index']:
             record['Parts Index'] = [0]
         record['Zmin'] = record['Zmin'][0]
@@ -746,17 +786,15 @@ class PolyLineZ(object):
         record['Mmin'] = record['Mmin'][0]
         record['Mmax'] = record['Mmax'][0]
         return record
-    
+
     @classmethod
     def pack(cls, record):
         rheader = _packDict(cls.STRUCT, record)
-        contentStruct = (('Parts Index', '%di' % record['NumParts'], '<'),
-                         ('Vertices', '%dd' % (2 * record['NumPoints']), '<'),
-                         ('Zmin', 'd', '<'),
-                         ('Zmax', 'd', '<'),
-                         ('Zarray', '%dd' % (record['NumPoints']), '<'),
-                         ('Mmin', 'd', '<'),
-                         ('Mmax', 'd', '<'),
+        contentStruct = (('Parts Index', '%di' % record['NumParts'],
+                          '<'), ('Vertices', '%dd' % (2 * record['NumPoints']),
+                                 '<'), ('Zmin', 'd', '<'), ('Zmax', 'd', '<'),
+                         ('Zarray', '%dd' % (record['NumPoints']),
+                          '<'), ('Mmin', 'd', '<'), ('Mmax', 'd', '<'),
                          ('Marray', '%dd' % (record['NumPoints']), '<'))
         content = {}
         content.update(record)
@@ -791,6 +829,7 @@ class Polygon(PolyLine):
 
 class MultiPoint:
     String_Type = "MULTIPOINT"
+
     def __init__(self):
         raise NotImplementedError("No MultiPoint Support at this time.")
 
@@ -801,46 +840,72 @@ class PolygonZ(PolyLineZ):
 
 class MultiPointZ:
     String_Type = "MULTIPOINTZ"
+
     def __init__(self):
         raise NotImplementedError("No MultiPointZ Support at this time.")
 
 
 class PointM:
     String_Type = "POINTM"
+
     def __init__(self):
         raise NotImplementedError("No PointM Support at this time.")
 
 
 class PolyLineM:
     String_Type = "ARCM"
+
     def __init__(self):
         raise NotImplementedError("No PolyLineM Support at this time.")
 
 
 class PolygonM:
     String_Type = "POLYGONM"
+
     def __init__(self):
         raise NotImplementedError("No PolygonM Support at this time.")
 
 
 class MultiPointM:
     String_Type = "MULTIPOINTM"
+
     def __init__(self):
         raise NotImplementedError("No MultiPointM Support at this time.")
 
 
 class MultiPatch:
     String_Type = "MULTIPATCH"
+
     def __init__(self):
         raise NotImplementedError("No MultiPatch Support at this time.")
 
 
-TYPE_DISPATCH = {0: NullShape, 1: Point, 3: PolyLine, 5: Polygon,
-                 8: MultiPoint, 11: PointZ, 13: PolyLineZ, 15: PolygonZ,
-                 18: MultiPointZ, 21: PointM, 23: PolyLineM, 25: PolygonM,
-                 28: MultiPointM, 31: MultiPatch, 'POINT': Point,
-                 'POINTZ': PointZ, 'POINTM': PointM, 'ARC': PolyLine,
-                 'ARCZ': PolyLineZ, 'ARCM': PolyLineM, 'POLYGON': Polygon,
-                 'POLYGONZ': PolygonZ, 'POLYGONM': PolygonM,
-                 'MULTIPOINT': MultiPoint, 'MULTIPOINTZ': MultiPointZ,
-                 'MULTIPOINTM': MultiPointM, 'MULTIPATCH': MultiPatch}
+TYPE_DISPATCH = {
+    0: NullShape,
+    1: Point,
+    3: PolyLine,
+    5: Polygon,
+    8: MultiPoint,
+    11: PointZ,
+    13: PolyLineZ,
+    15: PolygonZ,
+    18: MultiPointZ,
+    21: PointM,
+    23: PolyLineM,
+    25: PolygonM,
+    28: MultiPointM,
+    31: MultiPatch,
+    'POINT': Point,
+    'POINTZ': PointZ,
+    'POINTM': PointM,
+    'ARC': PolyLine,
+    'ARCZ': PolyLineZ,
+    'ARCM': PolyLineM,
+    'POLYGON': Polygon,
+    'POLYGONZ': PolygonZ,
+    'POLYGONM': PolygonM,
+    'MULTIPOINT': MultiPoint,
+    'MULTIPOINTZ': MultiPointZ,
+    'MULTIPOINTM': MultiPointM,
+    'MULTIPATCH': MultiPatch
+}


### PR DESCRIPTION
ugh, sorry about the diff... my editor automatically formats on save. There's only one actual change in this PR (line 155), which is swapping out the deprecated `fromstring` method for the preferred `frombytes` (I'm getting a ton of deprecation warnings when testing geosnap on Travis)