### PR TITLE
bump supported Python versions and correct lat2SW doctest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,20 @@ sudo: false
 branches:
 only:
   - master
-python:
-  - 3.5
-  - 3.6
-
-env:
-  - PYSAL_PLUS=false
-  - PYSAL_PLUS=true
+matrix:
+  include:
+    - python: 3.6
+      env: PYSAL_PLUS=false
+    - python: 3.6
+      env: PYSAL_PLUS=true
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: PYSAL_PLUS=false
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: PYSAL_PLUS=true
 
 before_install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -1154,8 +1154,8 @@ def lat2SW(nrows=3, ncols=5, criterion="rook", row_st=False):
     >>> from libpysal.weights import lat2W
     >>> w9 = lat2SW(3,3)
     >>> w9[0,1]
-    1
-    >>> w9[3,6]
+    array(1, dtype=int8)
+    >>> w9[3,6].tolist()
     1
     >>> w9r = lat2SW(3,3, row_st=True)
     >>> w9r[3,6] == 1./3


### PR DESCRIPTION
Bumping  supporting Python versions in TravisCI to match pysal/pysal#1095

{3.5, 3.6} --> {3.6, 3.7}