### PR TITLE
Allow for **kwargs any time there's a weights construction

### DIFF
--- a/libpysal/weights/set_operations.py
+++ b/libpysal/weights/set_operations.py
@@ -13,7 +13,7 @@ __all__ = ['w_union', 'w_intersection', 'w_difference',
            'w_symmetric_difference', 'w_subset', 'w_clip']
 
 
-def w_union(w1, w2, silence_warnings=False):
+def w_union(w1, w2, **kwargs):
     """
     Returns a binary weights object, w, that includes all neighbor pairs that
     exist in either w1 or w2.
@@ -21,18 +21,17 @@ def w_union(w1, w2, silence_warnings=False):
     Parameters
     ----------
 
-    w1                      : W 
+    w1                      : W
                               object
-    w2                      : W 
+    w2                      : W
                               object
-    silence_warnings   : boolean
-                              Switch to turn off (default on) print statements
-                              for every observation with islands
+    **kwargs                : keyword arguments
+                              optional arguments for :class:`pysal.weights.W`
 
     Returns
     -------
 
-    w       : W 
+    w       : W
               object
 
     Notes
@@ -69,34 +68,33 @@ def w_union(w1, w2, silence_warnings=False):
             neighbors[i] = list(add_neigh)
         else:
             neighbors[i] = copy.copy(w2.neighbors[i])
-    return W(neighbors, silence_warnings=silence_warnings)
+    return W(neighbors, **kwargs)
 
 
-def w_intersection(w1, w2, w_shape='w1', silence_warnings=False):
+def w_intersection(w1, w2, w_shape='w1', **kwargs):
     """
-    Returns a binary weights object, w, that includes only 
+    Returns a binary weights object, w, that includes only
     those neighbor pairs that exist in both w1 and w2.
 
     Parameters
     ----------
 
-    w1                      : W 
+    w1                      : W
                               object
-    w2                      : W 
+    w2                      : W
                               object
     w_shape                 : string
                               Defines the shape of the returned weights matrix. 'w1' returns a
                               matrix with the same IDs as w1; 'all' returns a matrix with all
                               the unique IDs from w1 and w2; and 'min' returns a matrix with
                               only the IDs occurring in both w1 and w2.
-    silence_warnings   : boolean
-                              Switch to turn off (default on) print statements
-                              for every observation with islands
+    **kwargs                : keyword arguments
+                              optional arguments for :class:`pysal.weights.W`
 
     Returns
     -------
 
-    w       : W 
+    w       : W
               object
 
     Notes
@@ -144,10 +142,10 @@ def w_intersection(w1, w2, w_shape='w1', silence_warnings=False):
         else:
             neighbors[i] = []
 
-    return W(neighbors, silence_warnings=silence_warnings)
+    return W(neighbors, **kwargs)
 
 
-def w_difference(w1, w2, w_shape='w1', constrained=True, silence_warnings=False):
+def w_difference(w1, w2, w_shape='w1', constrained=True, **kwargs):
     """
     Returns a binary weights object, w, that includes only neighbor pairs
     in w1 that are not in w2. The w_shape and constrained parameters
@@ -156,9 +154,9 @@ def w_difference(w1, w2, w_shape='w1', constrained=True, silence_warnings=False)
     Parameters
     ----------
 
-    w1                      : W 
+    w1                      : W
                               object
-    w2                      : W 
+    w2                      : W
                               object
     w_shape                 : string
                               Defines the shape of the returned weights matrix. 'w1' returns a
@@ -170,14 +168,13 @@ def w_difference(w1, w2, w_shape='w1', constrained=True, silence_warnings=False)
                               not in w2 are returned. If True then those pairs that would
                               not be possible if w_shape='min' are dropped. Ignored if
                               w_shape is set to 'min'.
-    silence_warnings   : boolean
-                              Switch to turn off (default on) print statements
-                              for every observation with islands
+    **kwargs                : keyword arguments
+                              optional arguments for :class:`pysal.weights.W`
 
     Returns
     -------
 
-    w       : W 
+    w       : W
               object
 
     Notes
@@ -244,10 +241,10 @@ def w_difference(w1, w2, w_shape='w1', constrained=True, silence_warnings=False)
             neighbors[i] = list(
                 set(neighbors[i]).intersection(constrained_keys))
 
-    return W(neighbors, silence_warnings=silence_warnings)
+    return W(neighbors, **kwargs)
 
 
-def w_symmetric_difference(w1, w2, w_shape='all', constrained=True, silence_warnings=False):
+def w_symmetric_difference(w1, w2, w_shape='all', constrained=True, **kwargs):
     """
     Returns a binary weights object, w, that includes only neighbor pairs
     that are not shared by w1 and w2. The w_shape and constrained parameters
@@ -256,9 +253,9 @@ def w_symmetric_difference(w1, w2, w_shape='all', constrained=True, silence_warn
     Parameters
     ----------
 
-    w1                      : W 
+    w1                      : W
                               object
-    w2                      : W 
+    w2                      : W
                               object
     w_shape                 : string
                               Defines the shape of the returned weights matrix. 'all' returns a
@@ -269,14 +266,13 @@ def w_symmetric_difference(w1, w2, w_shape='all', constrained=True, silence_warn
                               shared by w1 and w2 are returned. If True then those pairs
                               that would not be possible if w_shape='min' are dropped.
                               Ignored if w_shape is set to 'min'.
-    silence_warnings   : boolean
-                              Switch to turn off (default on) print statements
-                              for every observation with islands
+    **kwargs                : keyword arguments
+                              optional arguments for :class:`pysal.weights.W`
 
     Returns
     -------
 
-    w       : W 
+    w       : W
               object
 
     Notes
@@ -340,10 +336,10 @@ def w_symmetric_difference(w1, w2, w_shape='all', constrained=True, silence_warn
             neighbors[i] = list(
                 set(neighbors[i]).intersection(constrained_keys))
 
-    return W(neighbors, silence_warnings=silence_warnings)
+    return W(neighbors, **kwargs)
 
 
-def w_subset(w1, ids, silence_warnings=False):
+def w_subset(w1, ids, **kwargs):
     """
     Returns a binary weights object, w, that includes only those
     observations in ids.
@@ -351,19 +347,18 @@ def w_subset(w1, ids, silence_warnings=False):
     Parameters
     ----------
 
-    w1                      : W 
+    w1                      : W
                               object
     ids                     : list
                               A list containing the IDs to be include in the returned weights
                               object.
-    silence_warnings   : boolean
-                              Switch to turn off (default on) print statements
-                              for every observation with islands
+    **kwargs                : keyword arguments
+                              optional arguments for :class:`pysal.weights.W`
 
     Returns
     -------
 
-    w       : W 
+    w       : W
               object
 
     Examples
@@ -386,7 +381,7 @@ def w_subset(w1, ids, silence_warnings=False):
     >>> w.neighbors[15]
     [11, 14]
 
-    """ 
+    """
 
     neighbors = {}
     ids_set = set(list(ids))
@@ -397,10 +392,10 @@ def w_subset(w1, ids, silence_warnings=False):
         else:
             neighbors[i] = []
 
-    return W(neighbors, id_order=list(ids), silence_warnings=silence_warnings)
+    return W(neighbors, id_order=list(ids), **kwargs)
 
 
-def w_clip(w1, w2, outSP=True, silence_warnings=False):
+def w_clip(w1, w2, outSP=True, **kwargs):
     '''
     Clip a continuous W object (w1) with a different W object (w2) so only cells where
     w2 has a non-zero value remain with non-zero values in w1.
@@ -422,9 +417,8 @@ def w_clip(w1, w2, outSP=True, silence_warnings=False):
     outSP                   : boolean
                               If True (default) return sparse version of the clipped W, if
                               False, return W object of the clipped matrix
-    silence_warnings   : boolean
-                              Switch to turn off (default on) print statements
-                              for every observation with islands
+    **kwargs                : keyword arguments
+                              optional arguments for :class:`pysal.weights.W`
 
     Returns
     -------
@@ -526,5 +520,5 @@ def w_clip(w1, w2, outSP=True, silence_warnings=False):
     wc = w1.multiply(w2)
     wc = WSP(wc, id_order=id_order)
     if not outSP:
-        wc = WSP2W(wc, silence_warnings=silence_warnings)
+        wc = WSP2W(wc, **kwargs)
     return wc

--- a/libpysal/weights/spintW.py
+++ b/libpysal/weights/spintW.py
@@ -72,14 +72,14 @@ def ODW(Wo, Wd, transform='r', silence_warnings=True):
     Ww.transform = transform
     return Ww
 
-def netW(link_list, share='A', transform = 'r'):
+def netW(link_list, share='A', transform = 'r', **kwargs):
     """
     Create a network-contiguity based weight object based on different nodal
     relationships encoded in a network.
 
     Parameters
     ----------
-    link_list   : list 
+    link_list   : list
                   of tuples where each tuple is of the form (o,d) where o is an
                   origin id and d is a destination id
 
@@ -87,7 +87,7 @@ def netW(link_list, share='A', transform = 'r'):
                   denoting how to define the nodal relationship used to
                   determine neighboring edges; defualt is 'A' for any shared
                   nodes between two network edges; options include:
-                    'A': any shared nodes 
+                    'A': any shared nodes
                     'O': a shared origin node
                     'D': a shared destination node
                     'OD' a shared origin node or a shared destination node
@@ -98,7 +98,10 @@ def netW(link_list, share='A', transform = 'r'):
 
     transform   : Transformation for standardization of final OD spatial weight; default
                   is 'r' for row standardized
-       
+    **kwargs    : keyword arguments
+                  optional arguments for :class:`pysal.weights.W`
+
+
     Returns
     -------
      W          : nodal contiguity W object for networkd edges or flows
@@ -147,12 +150,12 @@ def netW(link_list, share='A', transform = 'r'):
             else:
                 raise AttributeError("Parameter 'share' must be 'O', 'D',"
                        " 'OD', or 'C'")
-    netW = W(neighbors)
+    netW = W(neighbors, **kwargs)
     netW.tranform = transform
     return netW
 
 def vecW(origin_x, origin_y, dest_x, dest_y, threshold, p=2, alpha=-1.0,
-        binary=True, ids=None, build_sp=False, silence_warnings=False):
+        binary=True, ids=None, build_sp=False, **kwargs):
     """
     Distance-based spatial weight for vectors that is computed using a
     4-dimensional distance between the origin x,y-coordinates and the
@@ -190,16 +193,14 @@ def vecW(origin_x, origin_y, dest_x, dest_y, threshold, p=2, alpha=-1.0,
                   distance matrix; significant speed gains may be obtained
                   dending on the sparsity of the of distance_matrix and
                   threshold that is applied
-    silence_warnings : boolean
-                  By default PySAL will print a warning if the
-                  dataset contains any disconnected observations or
-                  islands. To silence this warning set this
-                  parameter to True.
-    
+    **kwargs    : keyword arguments
+                  optional arguments for :class:`pysal.weights.W`
+
+
     Returns
     ------
     W           : DistanceBand W object that uses 4-dimenional distances between
-                  vectors origin and destination coordinates. 
+                  vectors origin and destination coordinates.
 
     Examples
     --------
@@ -218,7 +219,7 @@ def vecW(origin_x, origin_y, dest_x, dest_y, threshold, p=2, alpha=-1.0,
     """
     data = list(zip(origin_x, origin_y, dest_x, dest_y))
     W = DistanceBand(data, threshold=threshold, p=p, binary=binary, alpha=alpha,
-            ids=ids, build_sp=False, silence_warnings=silence_warnings)
+            ids=ids, build_sp=False, **kwargs)
     return W
 
 def mat2L(edge_matrix):
@@ -228,7 +229,7 @@ def mat2L(edge_matrix):
 
     Parameters
     ----------
-    edge_matrix   : array 
+    edge_matrix   : array
                     where rows denote network edge origins, columns denote
                     network edge destinations, and non-zero entries denote the
                     existence of an edge between a given origin and destination

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -381,10 +381,12 @@ def higher_order(w, k=2, **kwargs):
     Parameters
     ----------
 
-    w     : W
-            spatial weights object
-    k     : int
-            order of contiguity
+    w        : W
+               spatial weights object
+    k        : int
+               order of contiguity
+    **kwargs : keyword arguments
+               optional arguments for :class:`pysal.weights.W`
 
     Returns
     -------
@@ -435,6 +437,8 @@ def higher_order_sp(w, k=2, shortest_path=True, diagonal=False, **kwargs):
     diagonal      : boolean
                     True:  keep k-order (i,j) joins when i==j
                     False: remove k-order (i,j) joins when i==j
+    **kwargs      : keyword arguments
+                    optional arguments for :class:`pysal.weights.W`
 
     Returns
     -------

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -374,7 +374,7 @@ def order(w, kmax=3):
     return info
 
 
-def higher_order(w, k=2):
+def higher_order(w, k=2, **kwargs):
     """
     Contiguity weights object of order k.
 
@@ -413,10 +413,10 @@ def higher_order(w, k=2):
     >>> w5_2[0] == {10: 1.0, 2: 1.0, 6: 1.0}
     True
     """
-    return higher_order_sp(w, k)
+    return higher_order_sp(w, k, **kwargs)
 
 
-def higher_order_sp(w, k=2, shortest_path=True, diagonal=False):
+def higher_order_sp(w, k=2, shortest_path=True, diagonal=False, **kwargs):
     """
     Contiguity weights for either a sparse W or W  for order k.
 
@@ -503,7 +503,7 @@ def higher_order_sp(w, k=2, shortest_path=True, diagonal=False):
             k = id_order[k]
             v = id_order[v]
             d[k].append(v)
-        return W(neighbors=d)
+        return W(neighbors=d, **kwargs)
     else:
         d = {}
         for pair in sk:
@@ -512,7 +512,7 @@ def higher_order_sp(w, k=2, shortest_path=True, diagonal=False):
                 d[k].append(v)
             else:
                 d[k] = [v]
-        return WSP(W(neighbors=d).sparse)
+        return WSP(W(neighbors=d, **kwargs).sparse)
 
 
 def w_local_cluster(w):
@@ -550,7 +550,7 @@ def w_local_cluster(w):
     --------
     >>> from libpysal.weights import lat2W, w_local_cluster
     >>> w = lat2W(3,3, rook=False)
-    >>> w_local_cluster(w) 
+    >>> w_local_cluster(w)
     array([[1.        ],
            [0.6       ],
            [1.        ],
@@ -934,7 +934,7 @@ def get_ids(in_shps, idVariable):
                    (1) a path to a shapefile including suffix (str); or
                    (2) a geopandas.GeoDataFrame.
     idVariable   : str
-                   name of a column in the shapefile's DBF or the 
+                   name of a column in the shapefile's DBF or the
                    geopandas.GeoDataFrame to use for ids.
 
     Returns
@@ -949,7 +949,7 @@ def get_ids(in_shps, idVariable):
     >>> polyids = get_ids(libpysal.examples.get_path("columbus.shp"), "POLYID")
     >>> polyids[:5]
     [1, 2, 3, 4, 5]
-    
+
     >>> from libpysal.weights.util import get_ids
     >>> import libpysal
     >>> import geopandas as gpd
@@ -962,7 +962,7 @@ def get_ids(in_shps, idVariable):
     3    4
     4    5
     Name: POLYID, dtype: int64
-    
+
     """
 
     try:
@@ -976,7 +976,7 @@ def get_ids(in_shps, idVariable):
             cols = list(in_shps.columns)
             var = list(in_shps[idVariable])
         return var
-    
+
     except IOError:
         msg = 'The shapefile "%s" appears to be missing its DBF file. '\
               + ' The DBF file "%s" could not be found.' % (in_shps, dbname)
@@ -1041,7 +1041,7 @@ def get_points_array_from_shapefile(shapefile):
     >>> import libpysal
     >>> from libpysal.weights.util import get_points_array_from_shapefile
     >>> xy = get_points_array_from_shapefile(libpysal.examples.get_path('juvenile.shp'))
-    >>> xy[:3] 
+    >>> xy[:3]
     array([[94., 93.],
            [80., 95.],
            [79., 90.]])

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -28,16 +28,19 @@ __all__ = ['lat2W', 'block_weights', 'comb', 'order', 'higher_order',
 
 KDTREE_TYPES = [scipy.spatial.KDTree, scipy.spatial.cKDTree]
 
-def hexLat2W(nrows=5, ncols=5):
+def hexLat2W(nrows=5, ncols=5, **kwargs):
     """
     Create a W object for a hexagonal lattice.
 
     Parameters
     ----------
-    nrows   : int
-              number of rows
-    ncols   : int
-              number of columns
+    nrows      : int
+                 number of rows
+    ncols      : int
+                 number of columns
+    **kwargs   : keyword arguments
+                 optional arguments for :class:`pysal.weights.W`
+
 
     Returns
     -------
@@ -107,26 +110,29 @@ def hexLat2W(nrows=5, ncols=5):
                     w[i] = w.get(i, []) + jnw
 
 
-    return W(w)
+    return W(w, **kwargs)
 
 
-def lat2W(nrows=5, ncols=5, rook=True, id_type='int'):
+def lat2W(nrows=5, ncols=5, rook=True, id_type='int', **kwargs):
     """
     Create a W object for a regular lattice.
 
     Parameters
     ----------
 
-    nrows   : int
-              number of rows
-    ncols   : int
-              number of columns
-    rook    : boolean
-              type of contiguity. Default is rook. For queen, rook =False
-    id_type : string
-              string defining the type of IDs to use in the final W object;
-              options are 'int' (0, 1, 2 ...; default), 'float' (0.0,
-              1.0, 2.0, ...) and 'string' ('id0', 'id1', 'id2', ...)
+    nrows      : int
+                 number of rows
+    ncols      : int
+                 number of columns
+    rook       : boolean
+                 type of contiguity. Default is rook. For queen, rook =False
+    id_type    : string
+                 string defining the type of IDs to use in the final W object;
+                 options are 'int' (0, 1, 2 ...; default), 'float' (0.0,
+                 1.0, 2.0, ...) and 'string' ('id0', 'id1', 'id2', ...)
+    **kwargs   : keyword arguments
+                 optional arguments for :class:`pysal.weights.W`
+
 
     Returns
     -------
@@ -201,10 +207,10 @@ def lat2W(nrows=5, ncols=5, rook=True, id_type='int'):
             alt_weights[key] = weights[i]
         w = alt_w
         weights = alt_weights
-    return W(w, weights, ids=ids, id_order=ids[:])
+    return W(w, weights, ids=ids, id_order=ids[:], **kwargs)
 
 
-def block_weights(regimes, ids=None, sparse=False):
+def block_weights(regimes, ids=None, sparse=False, **kwargs):
     """
     Construct spatial weights for regime neighbors.
 
@@ -222,6 +228,9 @@ def block_weights(regimes, ids=None, sparse=False):
     sparse      : boolean
                   If True return WSP instance
                   If False return W instance
+    **kwargs    : keyword arguments
+                  optional arguments for :class:`pysal.weights.W`
+
 
     Returns
     -------
@@ -257,7 +266,7 @@ def block_weights(regimes, ids=None, sparse=False):
         members = NPNZ(regimes == rid)[0]
         for member in members:
             neighbors[member] = members[NPNZ(members != member)[0]].tolist()
-    w = W(neighbors)
+    w = W(neighbors, **kwargs)
     if ids is not None:
         w.remap_ids(ids)
     if sparse:
@@ -661,16 +670,19 @@ def full(w):
     """
     return w.full()
 
-def full2W(m, ids=None):
+def full2W(m, ids=None, **kwargs):
     '''
     Create a PySAL W object from a full array.
 
     Parameters
     ----------
-    m       : array
-              nxn array with the full weights matrix
-    ids     : list
-              User ids assumed to be aligned with m
+    m          : array
+                 nxn array with the full weights matrix
+    ids        : list
+                 User ids assumed to be aligned with m
+    **kwargs   : keyword arguments
+                 optional arguments for :class:`pysal.weights.W`
+
 
     Returns
     -------
@@ -726,10 +738,10 @@ def full2W(m, ids=None):
         if ids:
             ngh = [ids[j] for j in ngh]
         neighbors[i] = ngh
-    return W(neighbors, weights, id_order=ids)
+    return W(neighbors, weights, id_order=ids, **kwargs)
 
 
-def WSP2W(wsp, silence_warnings=False):
+def WSP2W(wsp, **kwargs):
 
     """
     Convert a pysal WSP object (thin weights matrix) to a pysal W object.
@@ -738,9 +750,8 @@ def WSP2W(wsp, silence_warnings=False):
     ----------
     wsp                     : WSP
                               PySAL sparse weights object
-    silence_warnings   : boolean
-                              Switch to turn off (default on) print statements
-                              for every observation with islands
+    **kwargs                : keyword arguments
+                              optional arguments for :class:`pysal.weights.W`
 
     Returns
     -------
@@ -790,8 +801,7 @@ def WSP2W(wsp, silence_warnings=False):
         weights[oid] = data[start:end]
         start = end
     ids = copy.copy(wsp.id_order)
-    w = W(neighbors, weights, ids,
-                silence_warnings=silence_warnings)
+    w = W(neighbors, weights, ids, **kwargs)
     w._sparse = copy.deepcopy(wsp.sparse)
     w._cache['sparse'] = w._sparse
     return w
@@ -866,7 +876,7 @@ def fill_diagonal(w, val=1.0, wsp=False):
         return WSP2W(w_out)
 
 
-def remap_ids(w, old2new, id_order=[]):
+def remap_ids(w, old2new, id_order=[], **kwargs):
     """
     Remaps the IDs in a spatial weights object.
 
@@ -883,6 +893,9 @@ def remap_ids(w, old2new, id_order=[]):
                An ordered list of new IDs, which defines the order of observations when
                iterating over W. If not set then the id_order in w will be
                used.
+    **kwargs : keyword arguments
+               optional arguments for :class:`pysal.weights.W`
+
 
     Returns
     -------
@@ -917,13 +930,13 @@ def remap_ids(w, old2new, id_order=[]):
         new_neigh[new_key] = new_values
         new_weights[new_key] = copy.copy(w.weights[key])
     if id_order:
-        return W(new_neigh, new_weights, id_order)
+        return W(new_neigh, new_weights, id_order, **kwargs)
     else:
         if w.id_order:
             id_order = [old2new[i] for i in w.id_order]
-            return W(new_neigh, new_weights, id_order)
+            return W(new_neigh, new_weights, id_order, **kwargs)
         else:
-            return W(new_neigh, new_weights)
+            return W(new_neigh, new_weights, **kwargs)
 
 
 def get_ids(in_shps, idVariable):
@@ -1266,7 +1279,7 @@ def isKDTree(obj):
     """
     return any([issubclass(type(obj), KDTYPE) for KDTYPE in KDTREE_TYPES])
 
-def attach_islands(w, w_knn1):
+def attach_islands(w, w_knn1, **kwargs):
     """
     Attach nearest neighbor to islands in spatial weight w.
 
@@ -1277,6 +1290,9 @@ def attach_islands(w, w_knn1):
                    pysal spatial weight object (unstandardized).
     w_knn1       : libpysal.weights.W
                    Nearest neighbor pysal spatial weight object (k=1).
+    **kwargs     : keyword arguments
+                   optional arguments for :class:`pysal.weights.W`
+
 
     Returns
     -------
@@ -1312,9 +1328,9 @@ def attach_islands(w, w_knn1):
             weights[island] = [1.0]
             neighbors[nb] = neighbors[nb] + [island]
             weights[nb] = weights[nb] + [1.0]
-        return W(neighbors, weights, id_order=w.id_order)
+        return W(neighbors, weights, id_order=w.id_order, **kwargs)
 
-def nonplanar_neighbors(w, geodataframe, tolerance=0.001):
+def nonplanar_neighbors(w, geodataframe, tolerance=0.001, **kwargs):
     """
     Detect neighbors for non-planar polygon collections
 
@@ -1333,6 +1349,9 @@ def nonplanar_neighbors(w, geodataframe, tolerance=0.001):
                The percentage of the minimum horizontal or vertical extent (minextent) of
                the dataframe to use in defining  a buffering distance to allow for fuzzy
                contiguity detection. The buffering distance is equal to tolerance*minextent.
+    **kwargs:  keyword arguments
+               optional arguments for :class:`pysal.weights.W`
+
 
     Attributes
     ----------
@@ -1428,12 +1447,12 @@ def nonplanar_neighbors(w, geodataframe, tolerance=0.001):
                         fixes[neighbor].append(island)
                         joins[neighbor].append(island)
 
-    w = W(joins)
+    w = W(joins, **kwargs)
     w.non_planar_joins = fixes
     return w
 
 @requires('geopandas')
-def fuzzy_contiguity(gdf, tolerance=0.005, buffering=False, drop=True):
+def fuzzy_contiguity(gdf, tolerance=0.005, buffering=False, drop=True, **kwargs):
     """
     Fuzzy contiguity spatial weights
 
@@ -1451,6 +1470,9 @@ def fuzzy_contiguity(gdf, tolerance=0.005, buffering=False, drop=True):
 
     drop: boolean
           If True (default), the buffered features are removed from the GeoDataFrame. If False, buffered features are added to the GeoDataFrame.
+    **kwargs: keyword arguments
+              optional arguments for :class:`pysal.weights.W`
+
 
     Returns
     -------
@@ -1546,7 +1568,7 @@ def fuzzy_contiguity(gdf, tolerance=0.005, buffering=False, drop=True):
         if drop:
             gdf.drop(columns=['_buffer'], inplace=True)
 
-    return W(neighbors)
+    return W(neighbors, **kwargs)
 
 
 


### PR DESCRIPTION
Many functions do not support `silence_warnings` as mentioned in #134. This PR tries to generically allow `**kwargs` whenever there is a weight constructor underneath a function as proposed by @ljwolf . Even if some functions do support `silence_warnings` now, it is replaced by `**kwargs` for more flexibility. 
Fixes #134