### PR TITLE
BUG: add zstd as a dependency to work around conda glitch

### DIFF
--- a/ci/travis/36-latest-conda-forge.yaml
+++ b/ci/travis/36-latest-conda-forge.yaml
@@ -11,3 +11,4 @@ dependencies:
   - matplotlib
   # optional
   - geopandas
+  - zstd

--- a/ci/travis/37-latest-conda-forge.yaml
+++ b/ci/travis/37-latest-conda-forge.yaml
@@ -11,3 +11,4 @@ dependencies:
   # optional
   - geopandas
   - numba
+  - zstd


### PR DESCRIPTION
[Background is here.](https://github.com/conda-forge/segregation-feedstock/pull/2)