### PR TITLE
ENH: fromstring has been deprecated

### DIFF
--- a/libpysal/io/util/shapefile.py
+++ b/libpysal/io/util/shapefile.py
@@ -152,7 +152,7 @@ def _unpackDict2(d, structure, fileObj):
     for name, dtype, order in structure:
         dtype, n = dtype
         result = array.array(dtype)
-        result.fromstring(fileObj.read(result.itemsize * n))
+        result.frombytes(fileObj.read(result.itemsize * n))
         if order != SYS_BYTE_ORDER:
             result.byteswap()
         d[name] = result.tolist()


### PR DESCRIPTION
This would silence verbose warnings in various test suites in downstream packages. [Example](https://travis-ci.org/sjsrey/geosnap/jobs/575622418#L5600).

Documentation on the [deprecation](https://docs.python.org/3/library/array.html#array.array.frombytes).