### PR TITLE
Cast arrays as lists (Issue 185) 

### DIFF
--- a/libpysal/weights/spintW.py
+++ b/libpysal/weights/spintW.py
@@ -44,7 +44,7 @@ def ODW(Wo, Wd, transform='r', silence_warnings=True):
     >>> OD.weights[0]
     [0.25, 0.25, 0.25, 0.25]
     >>> OD.neighbors[0]
-    array([ 5,  6,  9, 10], dtype=int32)
+    [5, 6, 9, 10]
     >>> OD.full()[0][0]
     array([0.  , 0.  , 0.  , 0.  , 0.  , 0.25, 0.25, 0.  , 0.  , 0.25, 0.25,
            0.  , 0.  , 0.  , 0.  , 0.  ])

--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -1437,9 +1437,9 @@ class WSP(object):
 
         """
 
-        indices = self.sparse.indices
-        data = self.sparse.data
-        indptr = self.sparse.indptr
+        indices = list(self.sparse.indices)
+        data = list(self.sparse.data)
+        indptr = list(self.sparse.indptr)
         id_order = self.id_order
         if id_order:
             # replace indices with user IDs


### PR DESCRIPTION
Addressing #185 

* casting `self.sparse.indices`, `self.sparse.data`, and `self.sparse.indptr` as lists
* adjusting [`docstring`](https://github.com/pysal/libpysal/blob/e6998425b917d342ece7a569abe5df6a15af220a/libpysal/weights/spintW.py#L46-L47) in `weights/spintW.py` to conform to `list` structure
