### PR TITLE
[ENH] moving jit import to common.py / improve documentation

### DIFF
--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -457,13 +457,31 @@ def alpha_shape(xys, alpha):
     return geoms
 
 def _valid_hull(geoms, points):
+    '''
+    Sanity check within ``alpha_shape_auto()`` to verify the generated
+    alpha shape actually contains the original set of points (xys).
+    
+    Arguments
+    ---------
+    geoms   : GeoSeries
+              see alpha_geoms()
+    points  : list
+              xys parameter cast as shapely.geometry.Point objects
+    
+    Returns
+    -------
+    flag    : bool
+              Valid hull for alpha shape [True] or not [False]
+    '''
+    flag = True
+    # if there is not exactly one polygon
     if geoms.shape[0] != 1:
-        return False
+        flag = False
+    # if any (xys) points do not intersect the polygon
     for point in points:
         if not point.intersects(geoms[0]):
-            return False
-    return True
-
+            flag = False
+    return flag
 
 @requires('geopandas', 'shapely')
 def alpha_shape_auto(xys, step=1, verbose=False):

--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -21,14 +21,6 @@ EPS = np.finfo(float).eps
 
 __all__ = ['alpha_shape', 'alpha_shape_auto']
 
-def _valid_hull(geoms, points):
-    if geoms.shape[0] != 1:
-        return False
-    for point in points:
-        if not point.intersects(geoms[0]):
-            return False
-    return True
-
 @jit
 def nb_dist(x, y):
     '''
@@ -463,6 +455,15 @@ def alpha_shape(xys, alpha):
     del triangles, a_pts, b_pts, c_pts
     geoms = alpha_geoms(alpha, triangulation.simplices, radii, xys)
     return geoms
+
+def _valid_hull(geoms, points):
+    if geoms.shape[0] != 1:
+        return False
+    for point in points:
+        if not point.intersects(geoms[0]):
+            return False
+    return True
+
 
 @requires('geopandas', 'shapely')
 def alpha_shape_auto(xys, step=1, verbose=False):

--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -8,26 +8,10 @@ Author(s):
     Dani Arribas-Bel daniel.arribas.bel@gmail.com
 """
 
-try:
-    from numba import jit
-    HAS_JIT = True
-except ImportError:
-    from warnings import warn
-    def jit(function=None, **kwargs):
-        if function is not None:
-            def wrapped(*original_args, **original_kw):
-                return function(*original_args, **original_kw)
-            return wrapped
-        else:
-            def partial_inner(func):
-                return jit(func)
-            return partial_inner
-    HAS_JIT = False
-
 import numpy as np
 import scipy.spatial as spat
 
-from ..common import requires
+from ..common import requires, jit, HAS_JIT
 
 EPS = np.finfo(float).eps
 
@@ -40,7 +24,6 @@ def _valid_hull(geoms, points):
         if not point.intersects(geoms[0]):
             return False
     return True
-
 
 @jit
 def nb_dist(x, y):

--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -13,6 +13,10 @@ import scipy.spatial as spat
 
 from ..common import requires, jit, HAS_JIT
 
+if not HAS_JIT:
+    from warnings import warn
+    NUMBA_WARN = "Numba not imported, so alpha shape construction may be slower than expected."
+
 EPS = np.finfo(float).eps
 
 __all__ = ['alpha_shape', 'alpha_shape_auto']
@@ -444,7 +448,7 @@ def alpha_shape(xys, alpha):
         29(4), 551-559.
     '''
     if not HAS_JIT:
-        warn("Numba not imported, so alpha shape construction may be slower than expected.")
+        warn(NUMBA_WARN)
     if xys.shape[0] < 4:
         from shapely import ops, geometry as geom
         return ops.cascaded_union([geom.Point(xy)
@@ -513,7 +517,7 @@ def alpha_shape_auto(xys, step=1, verbose=False):
         29(4), 551-559.
     '''
     if not HAS_JIT:
-        warn("Numba not imported, so alpha shape construction may be slower than expected.")
+        warn(NUMBA_WARN)
     from shapely import geometry as geom
     if xys.shape[0] < 4:
         from shapely import ops

--- a/libpysal/common.py
+++ b/libpysal/common.py
@@ -1,3 +1,7 @@
+import copy
+import sys
+import time
+
 # external imports
 import numpy as np
 import numpy.linalg as la
@@ -9,18 +13,13 @@ from scipy.spatial.distance import pdist, cdist
 
 import pandas
 
-RTOL = .00001
-ATOL = 1e-7
-
-import copy
-import sys
-import time
 try:
     from patsy import PatsyError
 except ImportError:
     PatsyError = Exception
 
-
+RTOL = .00001
+ATOL = 1e-7
 MISSINGVALUE = None
 
 ######################

--- a/libpysal/common.py
+++ b/libpysal/common.py
@@ -1,12 +1,7 @@
-
 # external imports
+import numpy as np
+import numpy.linalg as la
 
-try:
-    import numpy as np
-    import numpy.linalg as la
-except:
-    print('numpy 1.3 is required')
-    raise
 try:
     import scipy as sp
     import scipy.stats as stats
@@ -15,6 +10,8 @@ try:
 except:
     print('scipy 0.7+ is required')
     raise
+
+
 
 RTOL = .00001
 ATOL = 1e-7

--- a/libpysal/common.py
+++ b/libpysal/common.py
@@ -2,16 +2,10 @@
 import numpy as np
 import numpy.linalg as la
 
-try:
-    import scipy as sp
-    import scipy.stats as stats
-    from .cg.kdtree import KDTree
-    from scipy.spatial.distance import pdist, cdist
-except:
-    print('scipy 0.7+ is required')
-    raise
-
-
+import scipy as sp
+import scipy.stats as stats
+from .cg.kdtree import KDTree
+from scipy.spatial.distance import pdist, cdist
 
 RTOL = .00001
 ATOL = 1e-7

--- a/libpysal/common.py
+++ b/libpysal/common.py
@@ -33,6 +33,22 @@ except ImportError:
 
 MISSINGVALUE = None
 
+try:
+    from numba import jit
+    HAS_JIT = True
+except ImportError:
+    from warnings import warn
+    def jit(function=None, **kwargs):
+        if function is not None:
+            def wrapped(*original_args, **original_kw):
+                return function(*original_args, **original_kw)
+            return wrapped
+        else:
+            def partial_inner(func):
+                return jit(func)
+            return partial_inner
+    HAS_JIT = False
+
 ######################
 # Decorators/Utils   #
 ######################

--- a/libpysal/common.py
+++ b/libpysal/common.py
@@ -37,7 +37,6 @@ try:
     from numba import jit
     HAS_JIT = True
 except ImportError:
-    from warnings import warn
     def jit(function=None, **kwargs):
         if function is not None:
             def wrapped(*original_args, **original_kw):

--- a/libpysal/common.py
+++ b/libpysal/common.py
@@ -7,6 +7,8 @@ import scipy.stats as stats
 from .cg.kdtree import KDTree
 from scipy.spatial.distance import pdist, cdist
 
+import pandas
+
 RTOL = .00001
 ATOL = 1e-7
 
@@ -17,10 +19,7 @@ try:
     from patsy import PatsyError
 except ImportError:
     PatsyError = Exception
-try:
-    import pandas
-except ImportError:
-    pandas = None
+
 
 MISSINGVALUE = None
 
@@ -54,7 +53,7 @@ except ImportError:
 
 def simport(modname):
     """
-    Safely import a module without raising an error. 
+    Safely import a module without raising an error.
 
     Parameters
     -----------
@@ -126,5 +125,5 @@ def requires(*args, **kwargs):
                     print(('not running {}'.format(function.__name__)))
                 else:
                     pass
-            return passer 
+            return passer
     return inner

--- a/libpysal/common.py
+++ b/libpysal/common.py
@@ -33,24 +33,33 @@ except ImportError:
 
 MISSINGVALUE = None
 
+######################
+# Decorators/Utils   #
+######################
+
+# import numba.jit OR create mimic decorator and set existence flag
 try:
     from numba import jit
     HAS_JIT = True
 except ImportError:
     def jit(function=None, **kwargs):
+        """Mimic numba.jit() with synthetic wrapper
+        """
         if function is not None:
             def wrapped(*original_args, **original_kw):
+                """Case 1 - structure of a standard decorator
+                i.e., jit(function)(*args, **kwargs)
+                """
                 return function(*original_args, **original_kw)
             return wrapped
         else:
             def partial_inner(func):
+                """Case 2 - returns Case 1
+                i.e., jit()(function)(*args, **kwargs)
+                """
                 return jit(func)
             return partial_inner
     HAS_JIT = False
-
-######################
-# Decorators/Utils   #
-######################
 
 def simport(modname):
     """
@@ -110,7 +119,7 @@ def requires(*args, **kwargs):
     Returns
     -------
     Original function is all arg in args are importable, otherwise returns a
-    function that passes. 
+    function that passes.
     """
     v = kwargs.pop('verbose', True)
     wanted = copy.deepcopy(args)


### PR DESCRIPTION
This PR moves the import of [`numba.jit`](https://github.com/pysal/libpysal/blob/8c2627f258b5a2ba377f14e80985d8cbcf2b50f1/libpysal/cg/alpha_shapes.py#L11-L25) from `cg.alpha_shapes.py` into `common.py`, which also includes the `HAS_JIT` flag. By switching to this import schema functions within `libpysal` or a federated submodule can benefit from the potential performance improvements (if `numba` is installed).