### PR TITLE
(bug) replace silent_island_warning with silence_warnings for weights

### DIFF
--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -942,7 +942,7 @@ class W(object):
                     wijs = self.weights[i]
                     row_sum = sum(wijs) * 1.0
                     if row_sum == 0.0:
-                        if not self.silent_island_warning:
+                        if not self.silence_warnings:
                             print(('WARNING: ', i, ' is an island (no neighbors)'))
                     weights[i] = [wij / row_sum for wij in wijs]
                 weights = weights


### PR DESCRIPTION
`silent_island_warning` was removed from the attribute list of `libpysal.weights.W` and was replaced with the name `silence_warnings`, but one occurence was not updated to reflect such change, leading to errors reported in https://github.com/pysal/libpysal/issues/204 and https://github.com/pysal/spreg/pull/27
