### PR TITLE
(docs) keep file .nojekyll in docs when syncing between docs/ and docsrc/_build/html/

### DIFF
--- a/docsrc/Makefile
+++ b/docsrc/Makefile
@@ -23,7 +23,7 @@ github:
 	@make html
 
 sync:
-	@rsync -avh _build/html/ ../docs/ --delete
+	@rsync -avh --exclude '.nojekyll' _build/html/ ../docs/ --delete
 	@make clean
 
 clean:


### PR DESCRIPTION
Currently, we update the contents of [docs/](https://github.com/pysal/libpysal/tree/ed098ea900bde6a9913b96e162d64a72a9615e11/docs) with the built html files in docsrc/_build/html/ (after running `make html`). The existing files in docs/ which do not match those from docsrc/_build/html/ are deleted including  .nojekyll 

This PR is to adjust the makefile to keep .nojekyll in docs/ when syncing between docs/ and docsrc/_build/html/
