### PR TITLE
(docs) automatically generate docstrings for class members

### DIFF
--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -263,10 +263,15 @@ texinfo_documents = [
 
 # Generate the API documentation when building
 autosummary_generate = True
-numpydoc_show_class_members = True
-class_members_toctree = True
-numpydoc_show_inherited_class_members = True
+
+# avoid to show members twice
+numpydoc_show_class_members = False
 numpydoc_use_plots = True
+
+# automatically document class members
+autodoc_default_options = {
+    'members': True
+}
 
 # display the source code for Plot directive
 plot_include_source = True

--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -264,7 +264,7 @@ texinfo_documents = [
 # Generate the API documentation when building
 autosummary_generate = True
 
-# avoid to show members twice
+# avoid showing members twice
 numpydoc_show_class_members = False
 numpydoc_use_plots = True
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,5 +1,5 @@
 sphinx>=1.4.3
 sphinx_gallery
 sphinxcontrib-bibtex
-sphinx_bootstrap_theme
+sphinx_bootstrap_theme>=0.7.0
 numpydoc


### PR DESCRIPTION
This PR is to update the configuration file for sphinx to:
* automatically generate docstrings for class members including methods, attributes, properties
* avoid display class members twice 

this would be a more convenient fix compared with the solution suggested in https://github.com/pysal/libpysal/pull/209