### PR TITLE
libpysal 4.2.0 Windows import issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changes
+
 Version 4.2.0 (2019-12-14)
 
-We closed a total of 54 issues (enhancements and bug fixes) through 20 pull requests, since our last release on 2019-09-01.
+We closed a total of 57 issues (enhancements and bug fixes) through 21 pull requests, since our last release on 2019-09-01.
 
 ## Issues Closed
+  - Updating requirements (#211)
+  - Big tarball (#174)
   - Fetch (#176)
   - metadata for examples  (#125)
   - DOC: math rendering in sphinx, and members included for W (#209)
@@ -40,6 +43,7 @@ We closed a total of 54 issues (enhancements and bug fixes) through 20 pull requ
   - BUG: Updating manifest for additional requirements files (#179)
 
 ## Pull Requests
+  - Updating requirements (#211)
   - Fetch (#176)
   - (docs) automatically generate docstrings for class members (#210)
   - (docs) keep file .nojekyll in docs when syncing between docs/ and docsrc/_build/html/ (#207)
@@ -68,7 +72,6 @@ The following individuals contributed to this release:
   - James Gaboardi
   - Levi John Wolf
   - Siddharths8212376
-  
   
 # Changes
 Version 4.1.1 (2019-09-01)

--- a/libpysal/examples/__init__.py
+++ b/libpysal/examples/__init__.py
@@ -44,4 +44,4 @@ def get_path(file_name):
         pth = example.get_path(file_name, verbose=False)
         if pth:
             return pth
-    print("{} is not a file in any installed datasets.")
+    print("{} is not a file in any installed dataset.".format(file_name))

--- a/libpysal/examples/builtin.py
+++ b/libpysal/examples/builtin.py
@@ -50,7 +50,6 @@ class LocalExample:
         with open(description, 'r', encoding="utf8") as f:
             print(f.read())
 
-
     def get_description(self):
         description = [f for f in self.get_file_list() if "README.md" in f][0]
         with open(description, 'r', encoding="utf8") as f:

--- a/libpysal/examples/builtin.py
+++ b/libpysal/examples/builtin.py
@@ -47,13 +47,13 @@ class LocalExample:
         Provide a description of the example
         """
         description = [f for f in self.get_file_list() if "README.md" in f][0]
-        with open(description, 'r') as f:
+        with open(description, 'r', encoding="utf8") as f:
             print(f.read())
 
 
     def get_description(self):
         description = [f for f in self.get_file_list() if "README.md" in f][0]
-        with open(description, 'r') as f:
+        with open(description, 'r', encoding="utf8") as f:
             lines = f.readlines()
         return lines[3].strip()
 

--- a/libpysal/io/iohandlers/csvWrapper.py
+++ b/libpysal/io/iohandlers/csvWrapper.py
@@ -18,7 +18,8 @@ class csvWrapper(tables.DataTable):
         Examples
         --------
         >>> import libpysal
-        >>> file_name = libpysal.examples.get_path('stl_hom.csv')
+        >>> stl = libpysal.examples.load_example('stl')
+        >>> file_name = stl.get_path('stl_hom.csv')
         >>> f = libpysal.io.open(file_name,'r')
         >>> y = f.read()
         >>> f.header

--- a/libpysal/io/iohandlers/tests/test_csvWrapper.py
+++ b/libpysal/io/iohandlers/tests/test_csvWrapper.py
@@ -10,7 +10,8 @@ PY3 = int(V[0]) > 2
 
 class test_csvWrapper(unittest.TestCase):
     def setUp(self):
-        self.test_file = test_file = pysal_examples.get_path('stl_hom.csv')
+        stl = pysal_examples.load_example('stl')
+        self.test_file = test_file = stl.get_path('stl_hom.csv')
         self.obj = csvWrapper.csvWrapper(test_file, 'r')
 
     def test_len(self):

--- a/libpysal/weights/tests/test__contW_lists.py
+++ b/libpysal/weights/tests/test__contW_lists.py
@@ -68,10 +68,12 @@ class TestContiguityWeights(unittest.TestCase):
 
     def test_true_rook2(self):
         # load queen gal file created using Open Geoda.
-        geodaW = ps_open(
-            pysal_examples.get_path('stl_hom_rook.gal'), 'r').read()
+
+        stl = pysal_examples.load_example('stl')
+        gal_file = test_file = stl.get_path('stl_hom_rook.gal')
+        geodaW = ps_open(gal_file, 'r').read()
         # build matching W with pysal
-        pysalWb = self.build_W(pysal_examples.get_path(
+        pysalWb = self.build_W(stl.get_path(
             'stl_hom.shp'), ROOK, 'POLY_ID_OG')
         # compare output.
         for key in geodaW.neighbors:


### PR DESCRIPTION
This PR addresses:
  * pysal/libpysal#214

With the following machine `libpysal` can be read in:
```python
In [1]: %load_ext watermark 
In [2]: %watermark
2019-12-29T19:35:00-05:00

CPython 3.7.5
IPython 7.10.2

compiler   : MSC v.1916 64 bit (AMD64)
system     : Windows
release    : 10
machine    : AMD64
processor  : Intel64 Family 6 Model 61 Stepping 4, GenuineIntel
CPU cores  : 1
interpreter: 64bit
```

**However**, the following errors/failures occur ***in windows*** during local `nosetests` (three of which also occur ***in macOS***[see bottom]):

```

======================================================================
ERROR: test_casting (libpysal.io.iohandlers.tests.test_csvWrapper.test_csvWrapper)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\200059719\libpysal\libpysal\io\iohandlers\tests\test_csvWrapper.py", line 47, in test_casting
    self.obj.cast('WKT', WKTParser())
  File "C:\Users\200059719\libpysal\libpysal\io\fileio.py", line 230, in cast
    raise KeyError("%s" % key)
KeyError: 'WKT'

======================================================================
ERROR: test_deserialize (libpysal.io.iohandlers.tests.test_db.Test_sqlite_reader)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\200059719\libpysal\libpysal\io\iohandlers\tests\test_db.py", line 54, in tearDown
    os.remove('test.db')
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'test.db'

======================================================================
ERROR: test_writeNones (libpysal.io.iohandlers.tests.test_pyDbfIO.test_DBF)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\200059719\libpysal\libpysal\io\iohandlers\tests\test_pyDbfIO.py", line 115, in test_writeNones
    os.remove(fname)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\200059~1\\AppData\\Local\\Temp\\tmpzax2d812.dbf'

======================================================================
ERROR: test_true_rook2 (libpysal.weights.tests.test__contW_lists.TestContiguityWeights)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\200059719\libpysal\libpysal\weights\tests\test__contW_lists.py", line 75, in test_true_rook2
    'stl_hom.shp'), ROOK, 'POLY_ID_OG')
  File "C:\Users\200059719\libpysal\libpysal\weights\tests\test__contW_lists.py", line 120, in build_W
    ids = db.by_col[idVariable]
  File "C:\Users\200059719\libpysal\libpysal\io\tables.py", line 21, in __getitem__
    return self.p._get_col(key)
  File "C:\Users\200059719\libpysal\libpysal\io\iohandlers\pyDbfIO.py", line 110, in _get_col
    raise AttributeError('Field: % s does not exist in header' % key)
AttributeError: Field: POLY_ID_OG does not exist in header

======================================================================
FAIL: Doctest: libpysal.cg.shapely_ext.buffer
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\200059719\AppData\Local\conda\conda\envs\test_momepy\lib\doctest.py", line 2196, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for libpysal.cg.shapely_ext.buffer
  File "C:\Users\200059719\libpysal\libpysal\cg\shapely_ext.py", line unknown line number, in buffer

----------------------------------------------------------------------
File "C:\Users\200059719\libpysal\libpysal\cg\shapely_ext.py", line ?, in libpysal.cg.shapely_ext.buffer
Failed example:
    g.buffer(1.0).area        # 16-gon approx of a unit radius circle
Expected:
    3.1365484905459389
Got:
    3.1365484905459384
----------------------------------------------------------------------
File "C:\Users\200059719\libpysal\libpysal\cg\shapely_ext.py", line ?, in libpysal.cg.shapely_ext.buffer
Failed example:
    g.buffer(1.0, 128).area   # 128-gon approximation
Expected:
    3.1415138011443009
Got:
    3.141513801144299
----------------------------------------------------------------------
File "C:\Users\200059719\libpysal\libpysal\cg\shapely_ext.py", line ?, in libpysal.cg.shapely_ext.buffer
Failed example:
    list(g.buffer(1.0, cap_style='square').exterior.coords)
Exception raised:
    Traceback (most recent call last):
      File "C:\Users\200059719\AppData\Local\conda\conda\envs\test_momepy\lib\doctest.py", line 1329, in __run
        compileflags, 1), test.globs)
      File "<doctest libpysal.cg.shapely_ext.buffer[5]>", line 1, in <module>
        list(g.buffer(1.0, cap_style='square').exterior.coords)
      File "C:\Users\200059719\AppData\Local\conda\conda\envs\test_momepy\lib\site-packages\shapely\geometry\base.py", line 593, in buffer
        mitre_limit))
      File "C:\Users\200059719\AppData\Local\conda\conda\envs\test_momepy\lib\site-packages\shapely\topology.py", line 78, in __call__
        return self.fn(this._geom, *args)
    ctypes.ArgumentError: argument 5: <class 'TypeError'>: wrong type
----------------------------------------------------------------------
File "C:\Users\200059719\libpysal\libpysal\cg\shapely_ext.py", line ?, in libpysal.cg.shapely_ext.buffer
Failed example:
    g.buffer(1.0, cap_style='square').area
Exception raised:
    Traceback (most recent call last):
      File "C:\Users\200059719\AppData\Local\conda\conda\envs\test_momepy\lib\doctest.py", line 1329, in __run
        compileflags, 1), test.globs)
      File "<doctest libpysal.cg.shapely_ext.buffer[6]>", line 1, in <module>
        g.buffer(1.0, cap_style='square').area
      File "C:\Users\200059719\AppData\Local\conda\conda\envs\test_momepy\lib\site-packages\shapely\geometry\base.py", line 593, in buffer
        mitre_limit))
      File "C:\Users\200059719\AppData\Local\conda\conda\envs\test_momepy\lib\site-packages\shapely\topology.py", line 78, in __call__
        return self.fn(this._geom, *args)
    ctypes.ArgumentError: argument 5: <class 'TypeError'>: wrong type


======================================================================
FAIL: Doctest: libpysal.cg.sphere.geogrid
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\200059719\AppData\Local\conda\conda\envs\test_momepy\lib\doctest.py", line 2196, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for libpysal.cg.sphere.geogrid
  File "C:\Users\200059719\libpysal\libpysal\cg\sphere.py", line 438, in geogrid

----------------------------------------------------------------------
File "C:\Users\200059719\libpysal\libpysal\cg\sphere.py", line 461, in libpysal.cg.sphere.geogrid
Failed example:
    geogrid(pup,pdown,3,lonx=False)
Expected:
    [(42.023768, -87.946389), (42.02393997819538, -87.80562679358316), (42.02393997819538, -87.66486420641684), (42.023768, -87.524102), (41.897317, -87.94638900000001), (41.8974888973743, -87.80562679296166), (41.8974888973743, -87.66486420703835), (41.897317, -87.524102), (41.770866000000005, -87.94638900000001), (41.77103781320412, -87.80562679234043), (41.77103781320412, -87.66486420765956), (41.770866000000005, -87.524102), (41.644415, -87.946389), (41.64458672568646, -87.80562679171955), (41.64458672568646, -87.66486420828045), (41.644415, -87.524102)]
Got:
    [(42.023768, -87.946389), (42.02393997819538, -87.80562679358316), (42.02393997819538, -87.66486420641684), (42.023768, -87.524102), (41.897317, -87.94638900000001), (41.8974888973743, -87.80562679296166), (41.8974888973743, -87.66486420703835), (41.897317, -87.524102), (41.770866000000005, -87.94638900000001), (41.77103781320412, -87.80562679234043), (41.77103781320412, -87.66486420765956), (41.770866000000005, -87.524102), (41.644415, -87.946389), (41.64458672568647, -87.80562679171955), (41.64458672568647, -87.66486420828045), (41.644415, -87.524102)]


======================================================================
FAIL: Doctest: libpysal.io.iohandlers.csvWrapper.csvWrapper.__init__
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\200059719\AppData\Local\conda\conda\envs\test_momepy\lib\doctest.py", line 2196, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for libpysal.io.iohandlers.csvWrapper.csvWrapper.__init__
  File "C:\Users\200059719\libpysal\libpysal\io\iohandlers\csvWrapper.py", line 15, in __init__

----------------------------------------------------------------------
File "C:\Users\200059719\libpysal\libpysal\io\iohandlers\csvWrapper.py", line 24, in libpysal.io.iohandlers.csvWrapper.csvWrapper.__init__
Failed example:
    f.header
Expected:
    ['WKT', 'NAME', 'STATE_NAME', 'STATE_FIPS', 'CNTY_FIPS', 'FIPS', 'FIPSNO', 'HR7984', 'HR8488', 'HR8893', 'HC7984', 'HC8488', 'HC8893', 'PO7984', 'PO8488', 'PO8893', 'PE77', 'PE82', 'PE87', 'RDAC80', 'RDAC85', 'RDAC90']
Got:
    ['FIPSNO', 'NAME', 'STATE_NAME', 'STATE_FIPS', 'CNTY_FIPS', 'FIPS', 'HC7984', 'HC8488', 'HC8893', 'PO7984', 'PO8488', 'PO8893']
----------------------------------------------------------------------
File "C:\Users\200059719\libpysal\libpysal\io\iohandlers\csvWrapper.py", line 26, in libpysal.io.iohandlers.csvWrapper.csvWrapper.__init__
Failed example:
    f._spec
Expected:
    [<class 'str'>, <class 'str'>, <class 'str'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'float'>, <class 'float'>, <class 'float'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'float'>, <class 'float'>, <class 'float'>, <class 'float'>, <class 'float'>, <class 'float'>]
Got:
    [<class 'int'>, <class 'str'>, <class 'str'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>]


Name                                      Stmts   Miss  Cover
-------------------------------------------------------------
libpysal\__init__.py                          5      0   100%
libpysal\cg\__init__.py                       8      0   100%
libpysal\cg\alpha_shapes.py                 142     55    61%
libpysal\cg\kdtree.py                        84     11    87%
libpysal\cg\locators.py                     218     12    94%
libpysal\cg\ops\__init__.py                   2      0   100%
libpysal\cg\ops\_accessors.py                15      3    80%
libpysal\cg\ops\_shapely.py                  59     32    46%
libpysal\cg\ops\atomic.py                     7      0   100%
libpysal\cg\ops\tabular.py                   47     21    55%
libpysal\cg\polygonQuadTreeStructure.py     553     80    86%
libpysal\cg\rtree.py                        416     35    92%
libpysal\cg\segmentLocator.py               258    131    49%
libpysal\cg\shapely_ext.py                  209    159    24%
libpysal\cg\shapes.py                       473     46    90%
libpysal\cg\sphere.py                       154     42    73%
libpysal\cg\standalone.py                   310     19    94%
libpysal\cg\voronoi.py                       98     21    79%
libpysal\common.py                           51     19    63%
libpysal\examples\__init__.py                21      2    90%
libpysal\examples\base.py                   145     68    53%
libpysal\examples\builtin.py                 39      4    90%
libpysal\examples\remotes.py                 65      9    86%
libpysal\io\__init__.py                       5      0   100%
libpysal\io\fileio.py                       210     75    64%
libpysal\io\geotable\__init__.py              1      0   100%
libpysal\io\geotable\dbf.py                  46     30    35%
libpysal\io\geotable\file.py                 42     24    43%
libpysal\io\geotable\shp.py                  13      5    62%
libpysal\io\geotable\utils.py                30     12    60%
libpysal\io\geotable\wrappers.py             30     19    37%
libpysal\io\iohandlers\__init__.py           23      2    91%
libpysal\io\iohandlers\arcgis_dbf.py         78      6    92%
libpysal\io\iohandlers\arcgis_swm.py        110      4    96%
libpysal\io\iohandlers\arcgis_txt.py         60     14    77%
libpysal\io\iohandlers\csvWrapper.py         61      5    92%
libpysal\io\iohandlers\dat.py                19      1    95%
libpysal\io\iohandlers\db.py                 58      9    84%
libpysal\io\iohandlers\gal.py                99      5    95%
libpysal\io\iohandlers\geobugs_txt.py        84      1    99%
libpysal\io\iohandlers\geoda_txt.py          59     11    81%
libpysal\io\iohandlers\gwt.py               137     25    82%
libpysal\io\iohandlers\mat.py                47      6    87%
libpysal\io\iohandlers\mtx.py                40      1    98%
libpysal\io\iohandlers\pyDbfIO.py           237     49    79%
libpysal\io\iohandlers\pyShpIO.py           116     28    76%
libpysal\io\iohandlers\stata_txt.py          74      1    99%
libpysal\io\iohandlers\template.py           77     57    26%
libpysal\io\iohandlers\wk1.py                91      8    91%
libpysal\io\iohandlers\wkt.py                46      8    83%
libpysal\io\tables.py                        89     16    82%
libpysal\io\util\__init__.py                  3      0   100%
libpysal\io\util\shapefile.py               380     18    95%
libpysal\io\util\weight_converter.py         48     13    73%
libpysal\io\util\wkb.py                      78     66    15%
libpysal\io\util\wkt.py                      42      5    88%
libpysal\weights\__init__.py                  8      0   100%
libpysal\weights\_contW_lists.py             77      6    92%
libpysal\weights\adjtools.py                 89     15    83%
libpysal\weights\contiguity.py              146     34    77%
libpysal\weights\distance.py                250     36    86%
libpysal\weights\set_operations.py          103     34    67%
libpysal\weights\spatial_lag.py              43      3    93%
libpysal\weights\spintW.py                   67      6    91%
libpysal\weights\user.py                     44      7    84%
libpysal\weights\util.py                    465     58    88%
libpysal\weights\weights.py                 510     87    83%
-------------------------------------------------------------
TOTAL                                      7714   1579    80%
----------------------------------------------------------------------
Ran 728 tests in 178.610s

FAILED (SKIP=41, errors=4, failures=3)
```









```
======================================================================
ERROR: test_casting (libpysal.io.iohandlers.tests.test_csvWrapper.test_csvWrapper)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/user/libpysal/libpysal/io/iohandlers/tests/test_csvWrapper.py", line 47, in test_casting
    self.obj.cast('WKT', WKTParser())
  File "/Users/user/libpysal/libpysal/io/fileio.py", line 230, in cast
    raise KeyError("%s" % key)
KeyError: 'WKT'

======================================================================
ERROR: test_true_rook2 (libpysal.weights.tests.test__contW_lists.TestContiguityWeights)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/user/libpysal/libpysal/weights/tests/test__contW_lists.py", line 75, in test_true_rook2
    'stl_hom.shp'), ROOK, 'POLY_ID_OG')
  File "/Users/user/libpysal/libpysal/weights/tests/test__contW_lists.py", line 120, in build_W
    ids = db.by_col[idVariable]
  File "/Users/user/libpysal/libpysal/io/tables.py", line 21, in __getitem__
    return self.p._get_col(key)
  File "/Users/user/libpysal/libpysal/io/iohandlers/pyDbfIO.py", line 110, in _get_col
    raise AttributeError('Field: % s does not exist in header' % key)
AttributeError: Field: POLY_ID_OG does not exist in header

======================================================================
FAIL: Doctest: libpysal.io.iohandlers.csvWrapper.csvWrapper.__init__
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/user/miniconda3/envs/py3_lps_dev/lib/python3.6/doctest.py", line 2199, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for libpysal.io.iohandlers.csvWrapper.csvWrapper.__init__
  File "/Users/user/libpysal/libpysal/io/iohandlers/csvWrapper.py", line 15, in __init__

----------------------------------------------------------------------
File "/Users/user/libpysal/libpysal/io/iohandlers/csvWrapper.py", line 24, in libpysal.io.iohandlers.csvWrapper.csvWrapper.__init__
Failed example:
    f.header
Expected:
    ['WKT', 'NAME', 'STATE_NAME', 'STATE_FIPS', 'CNTY_FIPS', 'FIPS', 'FIPSNO', 'HR7984', 'HR8488', 'HR8893', 'HC7984', 'HC8488', 'HC8893', 'PO7984', 'PO8488', 'PO8893', 'PE77', 'PE82', 'PE87', 'RDAC80', 'RDAC85', 'RDAC90']
Got:
    ['FIPSNO', 'NAME', 'STATE_NAME', 'STATE_FIPS', 'CNTY_FIPS', 'FIPS', 'HC7984', 'HC8488', 'HC8893', 'PO7984', 'PO8488', 'PO8893']
----------------------------------------------------------------------
File "/Users/user/libpysal/libpysal/io/iohandlers/csvWrapper.py", line 26, in libpysal.io.iohandlers.csvWrapper.csvWrapper.__init__
Failed example:
    f._spec
Expected:
    [<class 'str'>, <class 'str'>, <class 'str'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'float'>, <class 'float'>, <class 'float'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'float'>, <class 'float'>, <class 'float'>, <class 'float'>, <class 'float'>, <class 'float'>]
Got:
    [<class 'int'>, <class 'str'>, <class 'str'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>, <class 'int'>]


Name                                      Stmts   Miss  Cover
-------------------------------------------------------------
libpysal/__init__.py                          5      0   100%
libpysal/cg/__init__.py                       8      0   100%
libpysal/cg/alpha_shapes.py                 142     46    68%
libpysal/cg/kdtree.py                        84     11    87%
libpysal/cg/locators.py                     218     12    94%
libpysal/cg/ops/__init__.py                   2      0   100%
libpysal/cg/ops/_accessors.py                15      3    80%
libpysal/cg/ops/_shapely.py                  59     32    46%
libpysal/cg/ops/atomic.py                     7      0   100%
libpysal/cg/ops/tabular.py                   47     21    55%
libpysal/cg/polygonQuadTreeStructure.py     553     80    86%
libpysal/cg/rtree.py                        416     35    92%
libpysal/cg/segmentLocator.py               258    131    49%
libpysal/cg/shapely_ext.py                  209    159    24%
libpysal/cg/shapes.py                       473     46    90%
libpysal/cg/sphere.py                       154     34    78%
libpysal/cg/standalone.py                   310     18    94%
libpysal/cg/voronoi.py                       98     16    84%
libpysal/common.py                           51      4    92%
libpysal/examples/__init__.py                21      1    95%
libpysal/examples/base.py                   145     58    60%
libpysal/examples/builtin.py                 39      4    90%
libpysal/examples/remotes.py                 65      9    86%
libpysal/io/__init__.py                       5      0   100%
libpysal/io/fileio.py                       210     75    64%
libpysal/io/geotable/__init__.py              1      0   100%
libpysal/io/geotable/dbf.py                  46     30    35%
libpysal/io/geotable/file.py                 42     24    43%
libpysal/io/geotable/shp.py                  13      5    62%
libpysal/io/geotable/utils.py                30     12    60%
libpysal/io/geotable/wrappers.py             30     19    37%
libpysal/io/iohandlers/__init__.py           23      2    91%
libpysal/io/iohandlers/arcgis_dbf.py         78      6    92%
libpysal/io/iohandlers/arcgis_swm.py        110      4    96%
libpysal/io/iohandlers/arcgis_txt.py         60     14    77%
libpysal/io/iohandlers/csvWrapper.py         61      0   100%
libpysal/io/iohandlers/dat.py                19      1    95%
libpysal/io/iohandlers/db.py                 58      9    84%
libpysal/io/iohandlers/gal.py                99      5    95%
libpysal/io/iohandlers/geobugs_txt.py        84      1    99%
libpysal/io/iohandlers/geoda_txt.py          59     11    81%
libpysal/io/iohandlers/gwt.py               137     25    82%
libpysal/io/iohandlers/mat.py                47      6    87%
libpysal/io/iohandlers/mtx.py                40      1    98%
libpysal/io/iohandlers/pyDbfIO.py           237     49    79%
libpysal/io/iohandlers/pyShpIO.py           116     28    76%
libpysal/io/iohandlers/stata_txt.py          74      1    99%
libpysal/io/iohandlers/template.py           77     57    26%
libpysal/io/iohandlers/wk1.py                91      8    91%
libpysal/io/iohandlers/wkt.py                46      8    83%
libpysal/io/tables.py                        89     16    82%
libpysal/io/util/__init__.py                  3      0   100%
libpysal/io/util/shapefile.py               380     18    95%
libpysal/io/util/weight_converter.py         48     13    73%
libpysal/io/util/wkb.py                      78     66    15%
libpysal/io/util/wkt.py                      42      5    88%
libpysal/weights/__init__.py                  8      0   100%
libpysal/weights/_contW_lists.py             77      6    92%
libpysal/weights/adjtools.py                 89     14    84%
libpysal/weights/contiguity.py              146     21    86%
libpysal/weights/distance.py                250     18    93%
libpysal/weights/set_operations.py          103     23    78%
libpysal/weights/spatial_lag.py              43      3    93%
libpysal/weights/spintW.py                   67      5    93%
libpysal/weights/user.py                     44      7    84%
libpysal/weights/util.py                    465     40    91%
libpysal/weights/weights.py                 510     43    92%
-------------------------------------------------------------
TOTAL                                      7714   1419    82%
----------------------------------------------------------------------
Ran 727 tests in 68.534s

FAILED (SKIP=41, errors=2, failures=1)
```
