### PR TITLE
correct name for beautifulsoup4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 scipy>=0.11
 numpy>=1.3
 pandas
-bs4
+beautifulsoup4
 requests
 jinja2


### PR DESCRIPTION
This PR addresses the issue raised by @QuLogic [here](https://github.com/pysal/libpysal/pull/176#pullrequestreview-355542455).

* adding full (correct) name for `beautifulsoup4` in `requirements.txt`.
  * ~~`bs4`~~ --> `beautifulsoup4`