### PR TITLE
Remove calls to deprecated/removed time.clock.

### DIFF
--- a/libpysal/cg/rtree.py
+++ b/libpysal/cg/rtree.py
@@ -448,7 +448,7 @@ class _NodeCursor(object):
         if (self.nchildren() <= MAXCHILDREN):
             return
 
-        t = time.clock()
+        t = time.process_time()
 
         cur_score = -10
 
@@ -466,7 +466,8 @@ class _NodeCursor(object):
 
         self._set_children(nodes)
 
-        dur = (time.clock() - t)
+        dur = time.process_time() - t
+
         c = float(self.root.stats["overflow_f"])
         oa = self.root.stats["avg_overflow_t_f"]
         self.root.stats["avg_overflow_t_f"] = (
@@ -593,7 +594,7 @@ def closest(centroids, node):
 
 
 def k_means_cluster(root, k, nodes):
-    t = time.clock()
+    t = time.process_time()
     if len(nodes) <= k:
         return [[n] for n in nodes]
 
@@ -632,8 +633,8 @@ def k_means_cluster(root, k, nodes):
         new_cluster_centers = [center_of_gravity(c) for c in clusters]
         if new_cluster_centers == cluster_centers:
             root.stats["avg_kmeans_iter_f"] = float(root.stats["sum_kmeans_iter_f"] / root.stats["count_kmeans_iter_f"])
-            root.stats["longest_kmeans"] = max(
-                root.stats["longest_kmeans"], (time.clock() - t))
+            root.stats["longest_kmeans"] = max(root.stats["longest_kmeans"],
+                                               time.process_time() - t)
             return clusters
         else:
             cluster_centers = new_cluster_centers


### PR DESCRIPTION
1. [x] You have run tests on this submission, either by using [Travis Continuous Integration testing](https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures#automated-testing-w-travis-ci) testing or running `nosetests` on your changes?
2. [x] This pull request is directed to the `pysal/master` branch.
3. [N/A] This pull introduces new functionality covered by    [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [N/A] You have [assigned a reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/) <- can't do that.
5. [x] The justification for this PR is: `time.clock` is gone in Python 3.8; see #177.
