### PR TITLE
Fix and simplify filter_adjlist.

### DIFF
--- a/libpysal/weights/adjtools.py
+++ b/libpysal/weights/adjtools.py
@@ -180,21 +180,15 @@ def filter_adjlist(adjlist, focal_col = 'focal', neighbor_col = 'neighbor'):
     -------
     an adjacency table with reversible entries removed. 
     """
-    directed = set(map(tuple, adjlist[[focal_col, neighbor_col]].values))
+    edges = adjlist.loc[:, [focal_col, neighbor_col]]
     undirected = set()
-    for tupe in directed:
-        #print(tupe)
-        if (tupe in undirected):
-            to_drop_mask = ((adjlist[focal_col] == tupe[0])
-                            & (adjlist[neighbor_col] == tupe[-1]))
-            to_drop = adjlist[to_drop_mask]
-        elif (tuple(reversed(tupe)) in undirected):
-            to_drop_mask = ((adjlist[focal_col] == tupe[-1])
-                            & (adjlist[neighbor_col] == tupe[0]))
-            to_drop = adjlist[to_drop_mask]
+    to_remove = []
+    for index, *edge in edges.itertuples(name=None):
+        edge = tuple(edge)
+        if edge in undirected or edge[::-1] in undirected:
+            to_remove.append(index)
         else:
-            undirected.update((tupe,))
-            undirected.update((tuple(reversed(tupe),)))
-            continue
-        adjlist = adjlist.drop(to_drop.index)
+            undirected.add(edge)
+            undirected.add(edge[::-1])
+    adjlist = adjlist.drop(to_remove)
     return adjlist

--- a/libpysal/weights/tests/test_adjlist.py
+++ b/libpysal/weights/tests/test_adjlist.py
@@ -34,8 +34,8 @@ class Test_Adjlist(ut.TestCase):
             badgrid = weights.W.from_adjlist(alist)
             np.testing.assert_allclose(badgrid.sparse.toarray(),
                                        grid.sparse.toarray())
-        assert set(alist.focal.unique().tolist()) == set(list(range(4)))
-        assert set(alist.neighbor.unique().tolist()) == set(list(range(4)))
+        assert set(alist.focal.unique()) == {0, 1, 2}
+        assert set(alist.neighbor.unique()) == {1, 2, 3}
         assert alist.weight.unique().item() == 1
         grid = lat2W(2,2, id_type='string')
         alist = grid.to_adjlist(remove_symmetric=True)


### PR DESCRIPTION
1. [x] You have run tests on this submission, either by using [Travis Continuous Integration testing](https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures#automated-testing-w-travis-ci) testing or running `nosetests` on your changes?
2. [x] This pull request is directed to the `pysal/master` branch.
3. [x] This pull introduces new functionality covered by    [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [N/A] You have [assigned a reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/) <- not possible
5. [x] The justification for this PR is: The docs say `filter_adjust` should remove elements in insertion order, but it doesn't do that because `set` is unordered. It is dependent on the order Python decides, which does in fact change between versions, and the related test breaks on 3.8.
   The test itself is also wrong because it removed elements in a 'nice' manner, not insertion order.

