### PR TITLE
Update reqs for tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,5 @@ omit =
     __init__.py 
     */contrib/* 
     */test/*
+[run]
+include=libpysal/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,10 +3,10 @@ omit =
     __init__.py
     */contrib/*
     */test/*
+include=libpysal/*
 [report]
 omit = 
     __init__.py 
     */contrib/* 
     */test/*
-[run]
-include=libpysal/*
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ notifications:
         on_failure: always
 
 after_success:
-  - coveralls
+  - codecov

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,9 @@ Python Spatial Analysis Library Core
 
 .. image:: https://ci.appveyor.com/api/projects/status/db18n032qo49xwlb/branch/master?svg=true
    :target: https://ci.appveyor.com/project/SergeRey/libpysal/branch/master
+   
+.. image:: https://codecov.io/gh/pysal/libpysal/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/pysal/libpysal
 
 .. image:: https://badge.fury.io/py/libpysal.svg
     :target: https://badge.fury.io/py/libpysal
@@ -14,7 +17,7 @@ Python Spatial Analysis Library Core
    :target: https://anaconda.org/conda-forge/libpysal
 
 .. image:: https://zenodo.org/badge/81501824.svg
-   :target: https://zenodo.org/badge/latestdoi/81501824   
+   :target: https://zenodo.org/badge/latestdoi/81501824
 
 
 

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,6 +1,4 @@
-nose
-nose-progressive
-nose-exclude
-coverage
-coveralls
+pytest
+pytest-cov
+codecov
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ def setup_package():
             "License :: OSI Approved :: BSD License",
             "Programming Language :: Python",
             "Programming Language :: Python :: 3.6",
-            "Programming Language :: Python :: 3.7"
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8"
         ],
         package_data={"libpysal": list(example_data_files)},
         install_requires=install_reqs,

--- a/setup.py
+++ b/setup.py
@@ -6,49 +6,51 @@ from distutils.command.build_py import build_py
 
 import os
 
-with open('README.rst', 'r', encoding='utf8') as file:
+with open("README.rst", "r", encoding="utf8") as file:
     long_description = file.read()
 
 # Get __version__ from libpysal/__init__.py without importing the package
 # __version__ has to be defined in the first line
-with open('libpysal/__init__.py', 'r') as f:
+with open("libpysal/__init__.py", "r") as f:
     exec(f.readline())
 
 # BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
 # update it when the contents of directories change.
-if os.path.exists('MANIFEST'):
-    os.remove('MANIFEST')
+if os.path.exists("MANIFEST"):
+    os.remove("MANIFEST")
+
 
 def _get_requirements_from_files(groups_files):
     groups_reqlist = {}
 
-    for k,v in groups_files.items():
-        with open(v, 'r') as f:
+    for k, v in groups_files.items():
+        with open(v, "r") as f:
             pkg_list = f.read().splitlines()
         groups_reqlist[k] = pkg_list
 
     return groups_reqlist
 
+
 def setup_package():
     # get all file endings and copy whole file names without a file suffix
     # assumes nested directories are only down one level
     _groups_files = {
-        'base': 'requirements.txt',
-        'plus_conda': 'requirements_plus_conda.txt',
-        'plus_pip': 'requirements_plus_pip.txt',
-        'dev': 'requirements_dev.txt',
-        'docs': 'requirements_docs.txt'
+        "base": "requirements.txt",
+        "plus_conda": "requirements_plus_conda.txt",
+        "plus_pip": "requirements_plus_pip.txt",
+        "dev": "requirements_dev.txt",
+        "docs": "requirements_docs.txt",
     }
 
     reqs = _get_requirements_from_files(_groups_files)
-    install_reqs = reqs.pop('base')
+    install_reqs = reqs.pop("base")
     extras_reqs = reqs
 
     # get all file endings and copy whole file names without a file suffix
     # assumes nested directories are only down one level
     example_data_files = set()
     for i in os.listdir("libpysal/examples"):
-        if i.endswith(('py', 'pyc')):
+        if i.endswith(("py", "pyc")):
             continue
         if not os.path.isdir("libpysal/examples/" + i):
             if "." in i:
@@ -61,39 +63,40 @@ def setup_package():
         example_data_files.add(glob_name)
 
     setup(
-        name='libpysal',
+        name="libpysal",
         version=__version__,
         description="Core components of PySAL A library of spatial analysis functions.",
         long_description=long_description,
         maintainer="PySAL Developers",
-        maintainer_email='pysal-dev@googlegroups.com',
-        url='http://pysal.org',
-        download_url='https://pypi.python.org/pypi/libpysal',
-        license='BSD',
-        py_modules=['libpysal'],
+        maintainer_email="pysal-dev@googlegroups.com",
+        url="http://pysal.org",
+        download_url="https://pypi.python.org/pypi/libpysal",
+        license="BSD",
+        py_modules=["libpysal"],
         packages=find_packages(),
-        test_suite='nose.collector',
-        tests_require=['nose'],
-        keywords='spatial statistics',
+        setup_requires=["pytest-runner"],
+        tests_require=["pytest"],
+        keywords="spatial statistics",
         classifiers=[
-            'Development Status :: 5 - Production/Stable',
-            'Intended Audience :: Science/Research',
-            'Intended Audience :: Developers',
-            'Intended Audience :: Education',
-            'Topic :: Scientific/Engineering',
-            'Topic :: Scientific/Engineering :: GIS',
-            'License :: OSI Approved :: BSD License',
-            'Programming Language :: Python',
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7'
+            "Development Status :: 5 - Production/Stable",
+            "Intended Audience :: Science/Research",
+            "Intended Audience :: Developers",
+            "Intended Audience :: Education",
+            "Topic :: Scientific/Engineering",
+            "Topic :: Scientific/Engineering :: GIS",
+            "License :: OSI Approved :: BSD License",
+            "Programming Language :: Python",
+            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
         ],
-        package_data={'libpysal':list(example_data_files)},
+        package_data={"libpysal": list(example_data_files)},
         install_requires=install_reqs,
         extras_require=extras_reqs,
-        cmdclass={'build_py': build_py},
-        python_requires='>3.5'
+        cmdclass={"build_py": build_py},
+        python_requires=">3.5",
     )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     setup_package()

--- a/setup.py
+++ b/setup.py
@@ -87,8 +87,7 @@ def setup_package():
             "License :: OSI Approved :: BSD License",
             "Programming Language :: Python",
             "Programming Language :: Python :: 3.6",
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.7"
         ],
         package_data={"libpysal": list(example_data_files)},
         install_requires=install_reqs,


### PR DESCRIPTION
This PR makes adjusting following the adoption of `pytest`:
 * updates `requirements_tests.py` 
 * updates and blackens `setup.py` 

See [good integration practices](http://doc.pytest.org/en/3.0.2/goodpractices.html).

Also adding Python 3.8 to supported versions.