### PR TITLE
Bugfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ script:
 notifications:
     email:
         recipients:
-            - joshua.wagner93@gmail.com
+            - sjsrey@gmail.com
+            - levi.john.wolf@gmail.com
         on_success: change 
         on_failure: always
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,7 @@ script:
 notifications:
     email:
         recipients:
-            - sjsrey@gmail.com
-            - levi.john.wolf@gmail.com
+            - joshua.wagner93@gmail.com
         on_success: change 
         on_failure: always
 

--- a/libpysal/cg/kdtree.py
+++ b/libpysal/cg/kdtree.py
@@ -47,7 +47,7 @@ def KDTree(data, leafsize=10, distance_metric='Euclidean',
     """
 
     if distance_metric.lower() == 'euclidean':
-        if int(scipy.version.version.split(".")[1]) < 12:
+        if int(scipy.version.version.split(".")[1]) < 12 and int(scipy.version.version.split(".")[0]) == 0:
             return scipy.spatial.KDTree(data, leafsize)
         else:
             return scipy.spatial.cKDTree(data, leafsize)
@@ -56,7 +56,7 @@ def KDTree(data, leafsize=10, distance_metric='Euclidean',
 
 
 # internal hack for the Arc_KDTree class inheritance
-if int(scipy.version.version.split(".")[1]) < 12:
+if int(scipy.version.version.split(".")[1]) < 12 and int(scipy.version.version.split(".")[0]) == 0:
     temp_KDTree = scipy.spatial.KDTree
 else:
     temp_KDTree = scipy.spatial.cKDTree


### PR DESCRIPTION
5. [x] The justification for this PR is: 
fixes the bug that libpysal.cg.kdtree uses scipy.spatial.KDTree instead of scipy.spatial.cKDTree for scipy version 1.* with *<12