### PR TITLE
GH-263: Don't implicitly import examples when importing base library

### DIFF
--- a/libpysal/examples/base.py
+++ b/libpysal/examples/base.py
@@ -45,17 +45,20 @@ def get_list_of_files(dir_name):
     create a list of file and sub directories in dir_name
     """
     #names in the given directory
-    file_list = os.listdir(dir_name)
     all_files = list()
-    # Iterate over all the entries
-    for entry in file_list:
-        # Create full path
-        full_path = os.path.join(dir_name, entry)
-        # If entry is a directory then get the list of files in this directory
-        if os.path.isdir(full_path):
-            all_files = all_files + get_list_of_files(full_path)
-        else:
-            all_files.append(full_path)
+    try:
+        file_list = os.listdir(dir_name)
+        # Iterate over all the entries
+        for entry in file_list:
+            # Create full path
+            full_path = os.path.join(dir_name, entry)
+            # If entry is a directory then get the list of files in this directory
+            if os.path.isdir(full_path):
+                all_files = all_files + get_list_of_files(full_path)
+            else:
+                all_files.append(full_path)
+    except FileNotFoundError:
+        pass
 
     return all_files
 


### PR DESCRIPTION
As #263 states:
> When importing libpysal, the examples are parsed and exported at module import time.
> This means that the example files must be present in all deployments of libpysal,
> which is problematic for us as we're deploying under pyInstaller on a Windows host.
> 
> Furthermore, the usage of __file__ means we cannot simply add the examples to our pyinstaller > spec, as pyinstaller has an odd split of sourcecode files and data files and so the files will not be > where you expect them to be.

This addresses the above by simply making the import of `libpysal.examples` explicit. This passes all tests (I'm erroring on two locally due to missing geopandas, but I expect them to pass on Travis)

There are other ways of resolving this, but this is the simplest and will get discussion started.