### PR TITLE
Initializing complete Github Actions CI

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,0 +1,42 @@
+ on:
+   push:
+     branches:
+     - '*'
+   pull_request:
+     branches:
+     - '*'
+   schedule:
+     - cron: '59 11 * * *'
+
+ jobs:
+   unittests:
+     name: conda (${{ matrix.os }}, ${{ matrix.environment-file }})
+     runs-on: ${{ matrix.os }}
+     timeout-minutes: 15
+     strategy:
+       matrix:
+         os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
+         environment-file: [ci/travis/36-latest-conda-forge.yaml, ci/travis/37-latest-conda-forge.yaml, ci/travis/38-latest-conda-forge.yaml]
+     steps:
+       - uses: actions/checkout@v2
+       - uses: goanpeca/setup-miniconda@v1
+         with:
+            miniconda-version: 'latest'
+            auto-update-conda: true
+            auto-activate-base: false
+            environment-file: ${{ matrix.environment-file }}
+            activate-environment: test
+       - shell: bash -l {0}
+         run: conda info --all
+       - shell: bash -l {0}
+         run: conda list
+       - shell: bash -l {0}
+         run: python -c 'import libpysal; libpysal.examples.fetch_all()'
+       - shell: bash -l {0}
+         run: py.test -v libpysal --cov=libpysal --cov-report=xml
+       - name: codecov (${{ matrix.os }}, ${{ matrix.environment-file }})
+         uses: codecov/codecov-action@v1
+         with:
+           token: ${{ secrets.CODECOV_TOKEN }}
+           file: ./coverage.xml
+           name: libpysal-codecov


### PR DESCRIPTION
This PR proposes a complete solution for CI with GitHub Actions based on that of [`spaghetti`'s](https://github.com/pysal/spaghetti/blob/master/.github/workflows/unittests.yml). This workflow allows for the following (from a single `.yml` with a single service):

 * tests Ubuntu, Mac, Windows
 * tests Python 3.6, 3.7, 3.8
 * performs `codecov`
 * run nightly tests
 * negates dual dependency on Travis and Appveyor for testing
 * all tests run concurrently reducing overall time for testing dramatically, especially with Appveyor/Windows tests

Currently, `codecov` is enabled after the unit tests run. In order for this to function properly, someone with admin privileges will have to put the `codecov` token in the Settings/Secrets/ folder. A token is not needed with Travis or Appveyor, but it is currently  needed for GH Actions.

Related to #264 

See also: pysal/spaghetti#452 and pysal/spaghetti#453

