### PR TITLE
dropping nose in ci/36.yml

### DIFF
--- a/ci/36.yaml
+++ b/ci/36.yaml
@@ -11,8 +11,6 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-  - nose
-  - codecov
   - matplotlib
   # optional
   - geopandas


### PR DESCRIPTION
This is a minor PR the drops `nose` and a duplicated `codecov` in `ci/36.yml`.