### PR TITLE
Mac builds seem to take longer — bump up timeout

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,7 +12,7 @@
    unittests:
      name: conda (${{ matrix.os }}, ${{ matrix.environment-file }})
      runs-on: ${{ matrix.os }}
-     timeout-minutes: 15
+     timeout-minutes: 25
      strategy:
        matrix:
          os: ['macos-latest', 'ubuntu-latest', 'windows-latest']


### PR DESCRIPTION
Bump up timeout due to Mac builds seems to take longer. This seems to have solved the issue with `spaghetti` unittests, currently [all 36 are passing](https://github.com/pysal/spaghetti/runs/548801586).