### PR TITLE
Docs ci badge

### DIFF
--- a/docs/_sources/index.rst.txt
+++ b/docs/_sources/index.rst.txt
@@ -3,8 +3,8 @@
 libpysal: Python Spatial Analysis Library Core
 ==============================================
 
-.. image:: https://travis-ci.org/pysal/libpysal.svg
-   :target: https://travis-ci.org/pysal/libpysal
+.. image:: https://github.com/pysal/libpysal/workflows/.github/workflows/unittests.yml/badge.svg
+   :target: https://github.com/pysal/libpysal/actions?query=workflow%3A.github%2Fworkflows%2Funittests.yml
 
 .. image:: https://badges.gitter.im/pysal/pysal.svg
    :target: https://gitter.im/pysal/pysal

--- a/docs/index.html
+++ b/docs/index.html
@@ -145,7 +145,7 @@
       
   <div class="section" id="libpysal-python-spatial-analysis-library-core">
 <h1>libpysal: Python Spatial Analysis Library Core<a class="headerlink" href="#libpysal-python-spatial-analysis-library-core" title="Permalink to this headline">¶</a></h1>
-<a class="reference external image-reference" href="https://travis-ci.org/pysal/libpysal"><img alt="https://travis-ci.org/pysal/libpysal.svg" src="https://travis-ci.org/pysal/libpysal.svg" /></a>
+<a class="reference external image-reference" href="https://github.com/pysal/libpysal/actions?query=workflow%3A.github%2Fworkflows%2Funittests.yml"><img alt="https://github.com/pysal/libpysal/workflows/.github/workflows/unittests.yml/badge.svg" src="https://github.com/pysal/libpysal/workflows/.github/workflows/unittests.yml/badge.svg" /></a>
 <a class="reference external image-reference" href="https://gitter.im/pysal/pysal"><img alt="https://badges.gitter.im/pysal/pysal.svg" src="https://badges.gitter.im/pysal/pysal.svg" /></a>
 <a class="reference external image-reference" href="https://badge.fury.io/py/libpysal"><img alt="https://badge.fury.io/py/libpysal.svg" src="https://badge.fury.io/py/libpysal.svg" /></a>
 <div class="container-fluid">

--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -3,8 +3,8 @@
 libpysal: Python Spatial Analysis Library Core
 ==============================================
 
-.. image:: https://travis-ci.org/pysal/libpysal.svg
-   :target: https://travis-ci.org/pysal/libpysal
+.. image:: https://github.com/pysal/libpysal/workflows/.github/workflows/unittests.yml/badge.svg
+   :target: https://github.com/pysal/libpysal/actions?query=workflow%3A.github%2Fworkflows%2Funittests.yml
 
 .. image:: https://badges.gitter.im/pysal/pysal.svg
    :target: https://gitter.im/pysal/pysal


### PR DESCRIPTION
This PR swaps out the Travis CI badge on https://pysal.org/libpysal for the GitHub Actions badge.