### PR TITLE
ENH: allow specific buffer in fuzzy_contiguity

### DIFF
--- a/libpysal/weights/tests/test_util.py
+++ b/libpysal/weights/tests/test_util.py
@@ -248,6 +248,8 @@ class Testutil(unittest.TestCase):
         wf = fuzzy_contiguity(rs_df)
         self.assertEqual(wf.islands, [])
         self.assertEqual(set(wf.neighbors[0]), set([239, 59, 152, 23, 107]))
+        buff = fuzzy_contiguity(rs_df, buffering=True, buffer=.1)
+        self.assertEqual(set(buff.neighbors[0]), set([119, 239, 59, 152, 23, 107]))
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(Testutil)

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -553,7 +553,7 @@ def w_local_cluster(w):
     neighbors of observation :math:`i` are to being a clique:
 
     .. math::
-    
+
        c_i = | \{w_{j,k}\} |/ (k_i(k_i - 1)): j,k \in N_i
 
     where :math:`N_i` is the set of neighbors to :math:`i`, :math:`k_i =
@@ -1454,7 +1454,7 @@ def nonplanar_neighbors(w, geodataframe, tolerance=0.001, **kwargs):
     return w
 
 @requires('geopandas')
-def fuzzy_contiguity(gdf, tolerance=0.005, buffering=False, drop=True, **kwargs):
+def fuzzy_contiguity(gdf, tolerance=0.005, buffering=False, drop=True, buffer=None, **kwargs):
     """
     Fuzzy contiguity spatial weights
 
@@ -1472,6 +1472,10 @@ def fuzzy_contiguity(gdf, tolerance=0.005, buffering=False, drop=True, **kwargs)
 
     drop: boolean
           If True (default), the buffered features are removed from the GeoDataFrame. If False, buffered features are added to the GeoDataFrame.
+
+    buffer : float
+             Specify exact buffering distance. Ignores `tolerance`.
+
     **kwargs: keyword arguments
               optional arguments for :class:`pysal.weights.W`
 
@@ -1545,11 +1549,12 @@ def fuzzy_contiguity(gdf, tolerance=0.005, buffering=False, drop=True, **kwargs)
 
     """
     if buffering:
-        # buffer each shape
-        minx, miny, maxx, maxy = gdf.total_bounds
-        buffer = tolerance * 0.5 * abs(min(maxx-minx, maxy-miny))
+        if not buffer:
+            # buffer each shape
+            minx, miny, maxx, maxy = gdf.total_bounds
+            buffer = tolerance * 0.5 * abs(min(maxx-minx, maxy-miny))
         # create new geometry column
-        new_geometry = gpd.GeoSeries([feature.buffer(buffer) for feature in gdf.geometry])
+        new_geometry = gdf.geometry.buffer(buffer)
         gdf['_buffer'] = new_geometry
         old_geometry_name = gdf.geometry.name
         gdf.set_geometry('_buffer', inplace=True)


### PR DESCRIPTION
Allow specific distance for buffer in `fuzzy_contiguity` instead of a fraction of bbox length. There are cases in which it is better to specify tolerance/buffer as a set known distance instead of a fraction of the df extent. 

I have also change buffering to vectorised operation, so it should be significantly faster, esp. once pygeos will land in GeoPandas.

With this change it could be directly used in https://github.com/pysal/mapclassify/pull/61.