### PR TITLE
Standardize libpysal/examples/*.py docstrings

### DIFF
--- a/libpysal/cg/ops/_accessors.py
+++ b/libpysal/cg/ops/_accessors.py
@@ -1,18 +1,29 @@
 import functools as _f
 
-__all__ = [ 'area', 'bbox', 'bounding_box', 'centroid', 'holes', 'len', 
-            'parts', 'perimeter', 'segments', 'vertices']
+__all__ = [
+    "area",
+    "bbox",
+    "bounding_box",
+    "centroid",
+    "holes",
+    "len",
+    "parts",
+    "perimeter",
+    "segments",
+    "vertices",
+]
 
-def get_attr(df, geom_col='geometry', inplace=False, attr=None):
+
+def get_attr(df, geom_col="geometry", inplace=False, attr=None):
     outval = df[geom_col].apply(lambda x: x.__getattribute__(attr))
     if inplace:
-        outcol = 'shape_{}'.format(func.__name__)
+        outcol = "shape_{}".format(func.__name__)
         df[outcol] = outval
         return None
     return outval
 
-_doc_template =\
-""" 
+
+_doc_template = """ 
 Tabular accessor to grab a geometric object's {n} attribute
 
 Arguments
@@ -32,9 +43,11 @@ If inplace, None, and operation is conducted on dataframe in memory. Otherwise,
 returns a series. 
 
 See Also
----------
+--------
+
 For further documentation about the attributes of the object in question, refer
 to shape classes in pysal.cg.shapes
+
 """
 
 _accessors = dict()

--- a/libpysal/cg/ops/_accessors.py
+++ b/libpysal/cg/ops/_accessors.py
@@ -23,30 +23,31 @@ def get_attr(df, geom_col="geometry", inplace=False, attr=None):
     return outval
 
 
-_doc_template = """ 
-Tabular accessor to grab a geometric object's {n} attribute
+_doc_template = """
+Tabular accessor to grab a geometric object's {n} attribute.
 
 Arguments
 ---------
-df      :   pandas.DataFrame
-            a pandas dataframe with a geometry column
-geom_col:   string
-            the name of the column in df containing the geometry
-inplace :   bool
-            a boolean denoting whether to operate on the dataframe inplace or to
-            return a series contaning the results of the computation. If
-            operating inplace, the derived column will be under 'shape_{n}'
+df : pandas.DataFrame
+    A pandas.Dataframe with a geometry column.
+geom_col : str
+    The name of the column in ``df`` containing the geometry.
+inplace : bool
+    A boolean denoting whether to operate on ``df`` inplace or to return a
+    pandas.Series contaning the results of the computation. If operating
+    inplace, the derived column will be under 'shape_{n}'.
 
 Returns
---------
-If inplace, None, and operation is conducted on dataframe in memory. Otherwise,
-returns a series. 
+-------
+
+``None`` if inplace is set to ``True`` and operation is conducted
+on ``df`` in memory. Otherwise, returns a pandas.Series.
 
 See Also
 --------
 
 For further documentation about the attributes of the object in question, refer
-to shape classes in pysal.cg.shapes
+to shape classes in ``pysal.cg.shapes``.
 
 """
 

--- a/libpysal/cg/voronoi.py
+++ b/libpysal/cg/voronoi.py
@@ -19,16 +19,13 @@ def voronoi(points, radius=None):
 
     Parameters
     ----------
-    
     points : array-like
         An nx2 array of points.
-
     radius : float (optional)
         The distance to 'points at infinity'.
 
     Returns
     -------
-    
     vor : tuple
         A two-element tuple consisting of a list and an array. Each element of
         the list contains the sequence of the indices of Voronoi vertices
@@ -66,16 +63,13 @@ def voronoi_regions(vor, radius=None):
 
     Parameters
     ----------
-
     vor : scipy.spatial.Voronoi
         A planar Voronoi diagram.
-
     radius : float (optional)
         Distance to 'points at infinity'.
     
     Returns
     -------
-    
     regions_vertices : tuple
         A two-element tuple consisting of a list of finite voronoi regions
         and an array Voronoi vertex coordinates.
@@ -139,23 +133,18 @@ def as_dataframes(regions, vertices, points):
 
     Parameters
     ----------
-
     regions : list
         Each element of the list contains sequence of the indexes of
         voronoi vertices composing a vornoi polygon (region).
-
     vertices : array
         The coordinates of the vornoi vertices.
-
     points : array-like
         The originator points.
 
     Returns
     -------
-
     region_df : geopandas.GeoDataFrame
         Finite Voronoi polygons as geometries.
-
     points_df : geopandas.GeoDataFrame
         Originator points as geometries.
     
@@ -196,13 +185,10 @@ def voronoi_frames(points, radius=None, clip="extent"):
 
     Parameters
     ----------
-
     points  : array-like
         The originator points.
-
     radius : float
         The distance to "points at infinity" used in building voronoi cells.
-
     clip : str, shapely.geometry.Polygon
         An overloaded option about how to clip the voronoi cells.
         The options are:
@@ -218,14 +204,12 @@ def voronoi_frames(points, radius=None, clip="extent"):
             contains all points (e.g. the smallest alphashape,
             using ``libpysal.cg.alpha_shape_auto``).
           - Polygon: Clip to an arbitrary Polygon.
-
     tolerance : float
         The percent of map width to use to buffer the extent of the map,
         if clipping (default: .01, or 1 percent).
 
     Returns
     -------
-
     reg_vtx : tuple
         Two ``geopandas.GeoDataFrame`` (or ``pandas.DataFrame`` if ``geopandas``
         is unavailable) objects--``(region_df, points_df)``--of finite 
@@ -268,13 +252,10 @@ def clip_voronoi_frames_to_extent(regions, vertices, clip="extent"):
     
     Parameters
     ----------
-    
     regions : geopandas.GeoDataFrame
         A (geo)dataframe containing voronoi cells to clip.
-    
     vertices : geopandas.GeoDataFrame
         A (geo)dataframe containing vertices used to build voronoi cells.
-    
     clip : str, shapely.geometry.Polygon
         An overloaded option about how to clip the voronoi cells.
         The options are:
@@ -293,7 +274,6 @@ def clip_voronoi_frames_to_extent(regions, vertices, clip="extent"):
     
     Returns
     -------
-    
     clipped_regions : geopandas.GeoDataFrame
         A ``geopandas.GeoDataFrame`` of clipped voronoi regions.
 

--- a/libpysal/cg/voronoi.py
+++ b/libpysal/cg/voronoi.py
@@ -55,9 +55,9 @@ def voronoi(points, radius=None):
            [ -9.22691341,  -4.58994414]])
     
     """
-    
+
     vor = voronoi_regions(Voronoi(points), radius=radius)
-    
+
     return vor
 
 
@@ -81,7 +81,7 @@ def voronoi_regions(vor, radius=None):
         and an array Voronoi vertex coordinates.
     
     """
-    
+
     new_regions = []
     new_vertices = vor.vertices.tolist()
 
@@ -127,9 +127,9 @@ def voronoi_regions(vor, radius=None):
         new_region = np.array(new_region)[np.argsort(angles)]
 
         new_regions.append(new_region.tolist())
-    
+
     regions_vertices = new_regions, np.asarray(new_vertices)
-    
+
     return regions_vertices
 
 
@@ -160,7 +160,7 @@ def as_dataframes(regions, vertices, points):
         Originator points as geometries.
     
     """
-    
+
     try:
         import geopandas as gpd
     except ImportError:
@@ -251,14 +251,14 @@ def voronoi_frames(points, radius=None, clip="extent"):
     True
 
     """
-    
+
     regions, vertices = voronoi(points, radius=radius)
     regions, vertices = as_dataframes(regions, vertices, points)
     if clip:
         regions = clip_voronoi_frames_to_extent(regions, vertices, clip=clip)
-    
+
     reg_vtx = regions, vertices
-    
+
     return reg_vtx
 
 

--- a/libpysal/cg/voronoi.py
+++ b/libpysal/cg/voronoi.py
@@ -14,30 +14,30 @@ __all__ = ["voronoi_frames"]
 
 
 def voronoi(points, radius=None):
-    """
-    Determine finite Voronoi diagram for a 2-d point set 
-
+    """Determine finite Voronoi diagram for a 2-d point set.
+    See also ``voronoi_regions()``.
 
     Parameters
     ----------
-    points      : array-like
-                  nx2 array of points
+    
+    points : array-like
+        An nx2 array of points.
 
-    radius      : float (optional) 
-                  distance to 'points at infinity'
+    radius : float (optional)
+        The distance to 'points at infinity'.
 
     Returns
     -------
-
-    regions    : list
-                  each element of the list contains sequence of the indexes of Voronoi vertices composing a Voronoi polygon (region)
-
-    coordinates : array
-                  coordinates of the Voronoi vertices
-
-
+    
+    vor : tuple
+        A two-element tuple consisting of a list and an array. Each element of
+        the list contains the sequence of the indices of Voronoi vertices
+        composing a Voronoi polygon (region), whereas the array contains
+        the Voronoi vertex coordinates.
+    
     Examples
     --------
+    
     >>> points = [(10.2, 5.1), (4.7, 2.2), (5.3, 5.7), (2.7, 5.3)]
     >>> regions, coordinates = voronoi(points)
     >>> regions
@@ -53,24 +53,35 @@ def voronoi(points, radius=None):
            [  9.4642193 ,  19.3994576 ],
            [  1.78491801,  19.89803294],
            [ -9.22691341,  -4.58994414]])
+    
     """
-    vor = Voronoi(points)
-    return voronoi_regions(vor, radius=radius)
+    
+    vor = voronoi_regions(Voronoi(points), radius=radius)
+    
+    return vor
 
 
 def voronoi_regions(vor, radius=None):
-    """
-    Finite voronoi regions for a 2-d point set.
-
+    """Finite voronoi regions for a 2-d point set. See also ``voronoi()``.
 
     Parameters
     ----------
 
-    vor:  Voronoi (scipy.spatial)
+    vor : scipy.spatial.Voronoi
+        A planar Voronoi diagram.
 
-    radius: float (optional)
-            Distance to 'points at infinity'
+    radius : float (optional)
+        Distance to 'points at infinity'.
+    
+    Returns
+    -------
+    
+    regions_vertices : tuple
+        A two-element tuple consisting of a list of finite voronoi regions
+        and an array Voronoi vertex coordinates.
+    
     """
+    
     new_regions = []
     new_vertices = vor.vertices.tolist()
 
@@ -116,39 +127,40 @@ def voronoi_regions(vor, radius=None):
         new_region = np.array(new_region)[np.argsort(angles)]
 
         new_regions.append(new_region.tolist())
-
-    return new_regions, np.asarray(new_vertices)
+    
+    regions_vertices = new_regions, np.asarray(new_vertices)
+    
+    return regions_vertices
 
 
 def as_dataframes(regions, vertices, points):
-    """
-    Helper function to store finite Voronoi regions and originator points as
-    geopandas (or pandas) data frames
-
+    """Helper function to store finite Voronoi regions and
+    originator points as geopandas (or pandas) data frames.
 
     Parameters
     ----------
 
-    regions     : list
-                  each element of the list contains sequence of the indexes of
-                  voronoi vertices composing a vornoi polygon (region)
+    regions : list
+        Each element of the list contains sequence of the indexes of
+        voronoi vertices composing a vornoi polygon (region).
 
-    vertices    : array
-                  coordinates of the vornoi vertices
+    vertices : array
+        The coordinates of the vornoi vertices.
 
-    points      : array-like
-                  originator points
-
+    points : array-like
+        The originator points.
 
     Returns
     -------
 
-    region_df   : GeoDataFrame
-                  Finite Voronoi polygons as geometries
+    region_df : geopandas.GeoDataFrame
+        Finite Voronoi polygons as geometries.
 
-    points_df   : GeoDataFrame
-                  Originator points as geometries
+    points_df : geopandas.GeoDataFrame
+        Originator points as geometries.
+    
     """
+    
     try:
         import geopandas as gpd
     except ImportError:
@@ -179,52 +191,58 @@ def as_dataframes(regions, vertices, points):
 
 
 def voronoi_frames(points, radius=None, clip="extent"):
-    """
-    Composite helper to return Voronoi regions and generator points as individual dataframes
+    """Composite helper to return Voronoi regions and
+    generator points as individual dataframes.
 
     Parameters
     ----------
 
-    points      : array-like
-                  originator points
+    points  : array-like
+        The originator points.
 
-    radius      : float
-                  distance to "points at infinity" used in building voronoi cells
+    radius : float
+        The distance to "points at infinity" used in building voronoi cells.
 
-    clip        : str, or shapely.geometry.Polygon
-                  an overloaded option about how to clip the voronoi
-                  cells. The options are:
-                  - 'none'/None: no clip is applied. Voronoi cells may be arbitrarily larger that the source map. Note that this may lead to cells that are many orders of magnitude larger in extent than the original map. Not recommended.
-                  - 'bbox'/'extent'/'bounding box': clip the voronoi cells to the bounding box of the input points.
-                  - 'chull'/'convex hull': clip the voronoi cells to the convex hull of the input points.
-                  - 'ashape'/'ahull': clip the voronoi cells to the tightest hull that contains all points (e.g. the smallest alphashape, using libpysal.cg.alpha_shape_auto)
-                  - Polygon: clip to an arbitrary Polygon
+    clip : str, shapely.geometry.Polygon
+        An overloaded option about how to clip the voronoi cells.
+        The options are:
+          - 'none'/None: No clip is applied. Voronoi cells may be arbitrarily
+            larger that the source map. Note that this may lead to cells that
+            are many orders of magnitude larger in extent than
+            the original map. Not recommended.
+          - 'bbox'/'extent'/'bounding box': Clip the voronoi cells to the
+            bounding box of the input points.
+          - 'chull'/'convex hull': Clip the voronoi cells to the
+            convex hull of the input points.
+          - 'ashape'/'ahull': Clip the voronoi cells to the tightest hull that
+            contains all points (e.g. the smallest alphashape,
+            using ``libpysal.cg.alpha_shape_auto``).
+          - Polygon: Clip to an arbitrary Polygon.
 
-    tolerance   : float
-                  percent of map width to use to buffer the extent of the map, if clipping (default: .01, or 1 percent)
+    tolerance : float
+        The percent of map width to use to buffer the extent of the map,
+        if clipping (default: .01, or 1 percent).
 
     Returns
     -------
 
-    _           : tuple
-                  (region_df, points_df)
-
-                  region_df   : GeoDataFrame (if geopandas available, otherwise Pandas DataFrame)
-                                Finite Voronoi polygons as geometries
-
-                  points_df   : GeoDataFrame (if geopandas available, otherwise Pandas DataFrame)
-                                Originator points as geometries
+    reg_vtx : tuple
+        Two ``geopandas.GeoDataFrame`` (or ``pandas.DataFrame`` if ``geopandas``
+        is unavailable) objects--``(region_df, points_df)``--of finite 
+        Voronoi polygons and the originator points as geometries.
 
     Notes
     -----
 
-    If Geopandas is not available the return types will be Pandas DataFrames
-    each with a geometry column populated with PySAL shapes. If Geopandas is
-    available, return types are GeoDataFrames with a geometry column populated
+    If ``geopandas`` is not available the return types will be
+    ``pandas.DataFrame`` objects, each with a geometry column populated
+    with PySAL shapes. If ``geopandas`` is available, return types are
+    ``pandas.GeoDataFrame`` objects with a geometry column populated
     with shapely geometry types.
 
     Examples
     --------
+    
     >>> points = [(10.2, 5.1), (4.7, 2.2), (5.3, 5.7), (2.7, 5.3)]
     >>> regions_df, points_df = voronoi_frames(points)
     >>> regions_df.shape
@@ -233,40 +251,51 @@ def voronoi_frames(points, radius=None, clip="extent"):
     True
 
     """
+    
     regions, vertices = voronoi(points, radius=radius)
     regions, vertices = as_dataframes(regions, vertices, points)
     if clip:
         regions = clip_voronoi_frames_to_extent(regions, vertices, clip=clip)
-    return regions, vertices
+    
+    reg_vtx = regions, vertices
+    
+    return reg_vtx
 
 
 def clip_voronoi_frames_to_extent(regions, vertices, clip="extent"):
-    """
-    Arguments
-    ---------
-    regions :   geopandas geodataframe
-                dataframe containing voronoi cells to clip
-    vertices:   geopandas geodataframe
-                dataframe containing vertices used to build voronoi cells
-    clip        : str, or shapely.geometry.Polygon
-                  an overloaded option about how to clip the voronoi
-                  cells. The options are:
-                  - 'none'/None: no clip is applied. Voronoi cells may be arbitrarily
-                                 larger that the source map. Note that this may lead
-                                 to cells that are many orders of magnitude larger
-                                 in extent than the original map. Not recommended. 
-                  - 'bbox'/'extent'/'bounding box': clip the voronoi cells to the 
-                                                    bounding box of the input points.
-                  - 'chull'/'convex hull': clip the voronoi cells to the convex hull
-                                           of the input points.
-                  - 'ashape'/'ahull': clip the voronoi cells to the tightest hull that
-                                      contains all points (e.g. the smallest alphashape,
-                                      using libpysal.cg.alpha_shape_auto)
-                  - Polygon: clip to an arbitrary shapely.geometry.Polygon
+    """Generate a geopandas.GeoDataFrame of Voronoi cells clipped to
+    a specified extent.
+    
+    Parameters
+    ----------
+    
+    regions : geopandas.GeoDataFrame
+        A (geo)dataframe containing voronoi cells to clip.
+    
+    vertices : geopandas.GeoDataFrame
+        A (geo)dataframe containing vertices used to build voronoi cells.
+    
+    clip : str, shapely.geometry.Polygon
+        An overloaded option about how to clip the voronoi cells.
+        The options are:
+          - 'none'/None: No clip is applied. Voronoi cells may be arbitrarily
+            larger that the source map. Note that this may lead to cells that
+            are many orders of magnitude larger in extent than
+            the original map. Not recommended.
+          - 'bbox'/'extent'/'bounding box': Clip the voronoi cells to the
+            bounding box of the input points.
+          - 'chull'/'convex hull': Clip the voronoi cells to the
+            convex hull of the input points.
+          - 'ashape'/'ahull': Clip the voronoi cells to the tightest hull that
+            contains all points (e.g. the smallest alphashape,
+            using ``libpysal.cg.alpha_shape_auto``).
+          - Polygon: Clip to an arbitrary Polygon.
     
     Returns
     -------
-    a geodataframe of clipped voronoi regions
+    
+    clipped_regions : geopandas.GeoDataFrame
+        A ``geopandas.GeoDataFrame`` of clipped voronoi regions.
 
     """
     try:

--- a/libpysal/cg/voronoi.py
+++ b/libpysal/cg/voronoi.py
@@ -1,16 +1,16 @@
 """
-Voronoi tesslation of 2-d point sets
-
+Voronoi tesslation of 2-d point sets.
 
 Adapted from https://gist.github.com/pv/8036995
 
 """
+
 import numpy as np
 from scipy.spatial import Voronoi
 
 __author__ = "Serge Rey <sjsrey@gmail.com>"
 
-__all__ = ['voronoi_frames']
+__all__ = ["voronoi_frames"]
 
 
 def voronoi(points, radius=None):
@@ -161,25 +161,24 @@ def as_dataframes(regions, vertices, points):
 
     if gpd is not None:
         region_df = gpd.GeoDataFrame()
-        region_df['geometry'] = [
-            Polygon(vertices[region]) for region in regions
-        ]
+        region_df["geometry"] = [Polygon(vertices[region]) for region in regions]
 
         point_df = gpd.GeoDataFrame()
-        point_df['geometry'] = gpd.GeoSeries(Point(pnt) for pnt in points)
+        point_df["geometry"] = gpd.GeoSeries(Point(pnt) for pnt in points)
     else:
         import pandas as pd
+
         region_df = pd.DataFrame()
-        region_df['geometry'] = [
+        region_df["geometry"] = [
             Polygon(vertices[region].tolist()) for region in regions
         ]
         point_df = pd.DataFrame()
-        point_df['geometry'] = [Point(pnt) for pnt in points]
+        point_df["geometry"] = [Point(pnt) for pnt in points]
 
     return region_df, point_df
 
 
-def voronoi_frames(points, radius=None, clip='extent'):
+def voronoi_frames(points, radius=None, clip="extent"):
     """
     Composite helper to return Voronoi regions and generator points as individual dataframes
 
@@ -241,7 +240,7 @@ def voronoi_frames(points, radius=None, clip='extent'):
     return regions, vertices
 
 
-def clip_voronoi_frames_to_extent(regions, vertices, clip='extent'):
+def clip_voronoi_frames_to_extent(regions, vertices, clip="extent"):
     """
     Arguments
     ---------
@@ -277,34 +276,48 @@ def clip_voronoi_frames_to_extent(regions, vertices, clip='extent'):
     try:
         import geopandas
     except ImportError:
-        raise ImportError('geopandas is required to clip voronoi regions')
+        raise ImportError("geopandas is required to clip voronoi regions")
 
     if isinstance(clip, Polygon):
         clipper = geopandas.GeoDataFrame(geometry=[clip])
     elif clip is None:
         return regions
-    elif clip.lower() == 'none':
+    elif clip.lower() == "none":
         return regions
-    elif clip.lower() in ('bounds', 'bounding box', 'bbox', 'extent'):
+    elif clip.lower() in ("bounds", "bounding box", "bbox", "extent"):
         min_x, min_y, max_x, max_y = vertices.total_bounds
-        bounding_poly = Polygon([(min_x, min_y), (min_x, max_y),
-                                 (max_x, max_y), (max_x, min_y),
-                                 (min_x, min_y)])
+        bounding_poly = Polygon(
+            [
+                (min_x, min_y),
+                (min_x, max_y),
+                (max_x, max_y),
+                (max_x, min_y),
+                (min_x, min_y),
+            ]
+        )
         clipper = geopandas.GeoDataFrame(geometry=[bounding_poly])
-    elif clip.lower() in ('chull', 'convex hull', 'convex_hull'):
-        clipper = geopandas.GeoDataFrame(geometry=[vertices.geometry\
-                                                           .unary_union\
-                                                           .convex_hull])
-    elif clip.lower() in ('ahull', 'alpha hull', 'alpha_hull', 'ashape',
-                          'alpha shape', 'alpha_shape'):
+    elif clip.lower() in ("chull", "convex hull", "convex_hull"):
+        clipper = geopandas.GeoDataFrame(
+            geometry=[vertices.geometry.unary_union.convex_hull]
+        )
+    elif clip.lower() in (
+        "ahull",
+        "alpha hull",
+        "alpha_hull",
+        "ashape",
+        "alpha shape",
+        "alpha_shape",
+    ):
         from .alpha_shapes import alpha_shape_auto
         from ..weights.distance import get_points_array
+
         coordinates = get_points_array(vertices.geometry)
-        clipper = geopandas.GeoDataFrame(
-            geometry=[alpha_shape_auto(coordinates)])
+        clipper = geopandas.GeoDataFrame(geometry=[alpha_shape_auto(coordinates)])
     else:
-        raise ValueError('clip type "{}" not understood. Try one '
-                         ' of the supported options: [None, "extent", '
-                         '"chull", "ahull"]'.format(clip))
-    clipped_regions = geopandas.overlay(regions, clipper, how='intersection')
+        raise ValueError(
+            'clip type "{}" not understood. Try one '
+            ' of the supported options: [None, "extent", '
+            '"chull", "ahull"]'.format(clip)
+        )
+    clipped_regions = geopandas.overlay(regions, clipper, how="intersection")
     return clipped_regions

--- a/libpysal/common.py
+++ b/libpysal/common.py
@@ -67,13 +67,11 @@ def simport(modname):
 
     Parameters
     ----------
-    
     modname : str
         Module name needed to import.
     
     Returns
     -------
-    
     _simport : tuple
         Either (True, Module) or (False, None) depending
         on whether the import succeeded.
@@ -118,19 +116,15 @@ def requires(*args, **kwargs):
 
     Parameters
     ----------
-    
     args : list
         Modules names as strings to import.
-    
     verbose : bool
         Set as ``True`` to print a warning message on import failure.
     
     Returns
     -------
-    
     inner : func
         The original function if all arg in args are importable.
-    
     passer : func
         A function that passes if ``inner`` fails.
     

--- a/libpysal/common.py
+++ b/libpysal/common.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     PatsyError = Exception
 
-RTOL = .00001
+RTOL = 0.00001
 ATOL = 1e-7
 MISSINGVALUE = None
 
@@ -29,26 +29,34 @@ MISSINGVALUE = None
 # import numba.jit OR create mimic decorator and set existence flag
 try:
     from numba import jit
+
     HAS_JIT = True
 except ImportError:
+
     def jit(function=None, **kwargs):
         """Mimic numba.jit() with synthetic wrapper
         """
         if function is not None:
+
             def wrapped(*original_args, **original_kw):
                 """Case 1 - structure of a standard decorator
                 i.e., jit(function)(*args, **kwargs)
                 """
                 return function(*original_args, **original_kw)
+
             return wrapped
         else:
+
             def partial_inner(func):
                 """Case 2 - returns Case 1
                 i.e., jit()(function)(*args, **kwargs)
                 """
                 return jit(func)
+
             return partial_inner
+
     HAS_JIT = False
+
 
 def simport(modname):
     """
@@ -89,10 +97,11 @@ def simport(modname):
     The first idiom makes it work kind of a like a with statement.
     """
     try:
-        exec('import {}'.format(modname))
+        exec("import {}".format(modname))
         return True, eval(modname)
     except:
         return False, None
+
 
 def requires(*args, **kwargs):
     """
@@ -110,19 +119,23 @@ def requires(*args, **kwargs):
     Original function is all arg in args are importable, otherwise returns a
     function that passes.
     """
-    v = kwargs.pop('verbose', True)
+    v = kwargs.pop("verbose", True)
     wanted = copy.deepcopy(args)
+
     def inner(function):
         available = [simport(arg)[0] for arg in args]
         if all(available):
             return function
         else:
-            def passer(*args,**kwargs):
+
+            def passer(*args, **kwargs):
                 if v:
                     missing = [arg for i, arg in enumerate(wanted) if not available[i]]
-                    print(('missing dependencies: {d}'.format(d=missing)))
-                    print(('not running {}'.format(function.__name__)))
+                    print(("missing dependencies: {d}".format(d=missing)))
+                    print(("not running {}".format(function.__name__)))
                 else:
                     pass
+
             return passer
+
     return inner

--- a/libpysal/common.py
+++ b/libpysal/common.py
@@ -22,35 +22,39 @@ RTOL = 0.00001
 ATOL = 1e-7
 MISSINGVALUE = None
 
-######################
-# Decorators/Utils   #
-######################
+####################
+# Decorators/Utils #
+####################
 
 # import numba.jit OR create mimic decorator and set existence flag
 try:
     from numba import jit
 
     HAS_JIT = True
+
 except ImportError:
 
     def jit(function=None, **kwargs):
-        """Mimic numba.jit() with synthetic wrapper
-        """
+        """Mimic numba.jit() with synthetic wrapper."""
+
         if function is not None:
 
             def wrapped(*original_args, **original_kw):
                 """Case 1 - structure of a standard decorator
-                i.e., jit(function)(*args, **kwargs)
+                i.e., jit(function)(*args, **kwargs).
                 """
+
                 return function(*original_args, **original_kw)
 
             return wrapped
+
         else:
 
             def partial_inner(func):
                 """Case 2 - returns Case 1
-                i.e., jit()(function)(*args, **kwargs)
+                i.e., jit()(function)(*args, **kwargs).
                 """
+
                 return jit(func)
 
             return partial_inner
@@ -59,26 +63,28 @@ except ImportError:
 
 
 def simport(modname):
-    """
-    Safely import a module without raising an error.
+    """Safely import a module without raising an error.
 
     Parameters
-    -----------
+    ----------
+    
     modname : str
-              module name needed to import
+        Module name needed to import.
     
     Returns
-    --------
-    tuple of (True, Module) or (False, None) depending on whether the import
-    succeeded.
+    -------
+    
+    _simport : tuple
+        Either (True, Module) or (False, None) depending
+        on whether the import succeeded.
 
     Notes
-    ------
-    Wrapping this function around an iterative context or a with context would
-    allow the module to be used without necessarily attaching it permanently in
-    the global namespace:
-
+    -----
     
+    Wrapping this function around an iterative context or a with
+    context would allow the module to be used without necessarily
+    attaching it permanently in the global namespace:
+
         for t,mod in simport('pandas'):
             if t:
                 mod.DataFrame()
@@ -95,30 +101,41 @@ def simport(modname):
             #do alternative behavior here
 
     The first idiom makes it work kind of a like a with statement.
+    
     """
+
     try:
         exec("import {}".format(modname))
-        return True, eval(modname)
+        _simport = True, eval(modname)
     except:
-        return False, None
+        _simport = False, None
+
+    return _simport
 
 
 def requires(*args, **kwargs):
-    """
-    Decorator to wrap functions with extra dependencies:
+    """Decorator to wrap functions with extra dependencies.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
+    
     args : list
-            list of strings containing module to import
+        Modules names as strings to import.
+    
     verbose : bool
-                boolean describing whether to print a warning message on import
-                failure
+        Set as ``True`` to print a warning message on import failure.
+    
     Returns
     -------
-    Original function is all arg in args are importable, otherwise returns a
-    function that passes.
+    
+    inner : func
+        The original function if all arg in args are importable.
+    
+    passer : func
+        A function that passes if ``inner`` fails.
+    
     """
+
     v = kwargs.pop("verbose", True)
     wanted = copy.deepcopy(args)
 

--- a/libpysal/examples/__init__.py
+++ b/libpysal/examples/__init__.py
@@ -7,7 +7,7 @@ from .remotes import datasets as remote_datasets
 from .remotes import download as fetch_all
 from .builtin import datasets as builtin_datasets
 
-#from typing import Union ######################################################################################
+from typing import Union
 
 __all__ = ["get_path", "available", "explain", "fetch_all"]
 
@@ -27,8 +27,7 @@ def explain(name: str) -> str:
     return example_manager.explain(name)
 
 
-#def load_example(example_name: str) -> Union[base.Example, builtin.LocalExample]: ######################################################################################
-def load_example(example_name: str):
+def load_example(example_name: str) -> Union[base.Example, builtin.LocalExample]:
     """Load example dataset instance."""
 
     return example_manager.load(example_name)

--- a/libpysal/examples/__init__.py
+++ b/libpysal/examples/__init__.py
@@ -7,7 +7,7 @@ from .remotes import datasets as remote_datasets
 from .remotes import download as fetch_all
 from .builtin import datasets as builtin_datasets
 
-from typing import Union
+#from typing import Union ######################################################################################
 
 __all__ = ["get_path", "available", "explain", "fetch_all"]
 
@@ -27,7 +27,8 @@ def explain(name: str) -> str:
     return example_manager.explain(name)
 
 
-def load_example(example_name: str) -> Union[base.Example, builtin.LocalExample]:
+#def load_example(example_name: str) -> Union[base.Example, builtin.LocalExample]: ######################################################################################
+def load_example(example_name: str):
     """Load example dataset instance."""
 
     return example_manager.load(example_name)

--- a/libpysal/examples/__init__.py
+++ b/libpysal/examples/__init__.py
@@ -13,23 +13,17 @@ example_manager.add_examples(builtin_datasets)
 
 
 def available():
-    """
-    List available datasets
-    """
+    """List available datasets."""
     return example_manager.available()
 
 
 def explain(name):
-    """
-    Explain a dataset by name
-    """
+    """Explain a dataset by name."""
     return example_manager.explain(name)
 
 
 def load_example(example_name):
-    """
-    Load example dataset instance
-    """
+    """Load example dataset instance."""
     return example_manager.load(example_name)
 
 

--- a/libpysal/examples/__init__.py
+++ b/libpysal/examples/__init__.py
@@ -1,10 +1,13 @@
 """ The :mod:`libpysal.examples` module includes a number of small built-in
     example datasets as well as functions to fetch larger datasets.
 """
+
 from .base import example_manager
 from .remotes import datasets as remote_datasets
 from .remotes import download as fetch_all
 from .builtin import datasets as builtin_datasets
+
+from typing import Union
 
 __all__ = ["get_path", "available", "explain", "fetch_all"]
 
@@ -12,7 +15,7 @@ example_manager.add_examples(remote_datasets)
 example_manager.add_examples(builtin_datasets)
 
 
-def available():
+def available() -> str:
     """List available datasets."""
 
     return example_manager.available()
@@ -24,7 +27,7 @@ def explain(name: str) -> str:
     return example_manager.explain(name)
 
 
-def load_example(example_name: str):
+def load_example(example_name: str) -> Union[base.Example, builtin.LocalExample]:
     """Load example dataset instance."""
 
     return example_manager.load(example_name)

--- a/libpysal/examples/__init__.py
+++ b/libpysal/examples/__init__.py
@@ -1,5 +1,5 @@
-"""
-The :mod:`libpysal.examples` module includes a number of small built-in example datasets as well as functions to fetch larger datasets.
+""" The :mod:`libpysal.examples` module includes a number of small built-in
+    example datasets as well as functions to fetch larger datasets.
 """
 from .base import example_manager
 from .remotes import datasets as remote_datasets
@@ -18,19 +18,19 @@ def available():
     return example_manager.available()
 
 
-def explain(name):
+def explain(name: str) -> str:
     """Explain a dataset by name."""
 
     return example_manager.explain(name)
 
 
-def load_example(example_name):
+def load_example(example_name: str):
     """Load example dataset instance."""
 
     return example_manager.load(example_name)
 
 
-def get_path(file_name):
+def get_path(file_name: str) -> str:
     """Get the path for a file by searching installed datasets."""
 
     installed = example_manager.get_installed_names()

--- a/libpysal/examples/__init__.py
+++ b/libpysal/examples/__init__.py
@@ -6,7 +6,7 @@ from .remotes import datasets as remote_datasets
 from .remotes import download as fetch_all
 from .builtin import datasets as builtin_datasets
 
-__all__ = ['get_path', 'available', 'explain', 'fetch_all']
+__all__ = ["get_path", "available", "explain", "fetch_all"]
 
 example_manager.add_examples(remote_datasets)
 example_manager.add_examples(builtin_datasets)
@@ -14,23 +14,24 @@ example_manager.add_examples(builtin_datasets)
 
 def available():
     """List available datasets."""
+
     return example_manager.available()
 
 
 def explain(name):
     """Explain a dataset by name."""
+
     return example_manager.explain(name)
 
 
 def load_example(example_name):
     """Load example dataset instance."""
+
     return example_manager.load(example_name)
 
 
 def get_path(file_name):
-    """
-    get the path for a file by searching installed datasets
-    """
+    """Get the path for a file by searching installed datasets."""
 
     installed = example_manager.get_installed_names()
     for name in installed:

--- a/libpysal/examples/base.py
+++ b/libpysal/examples/base.py
@@ -16,24 +16,25 @@ import pandas
 from bs4 import BeautifulSoup
 from ..io import open as ps_open
 
-PYSALDATA = 'pysal_data'
+PYSALDATA = "pysal_data"
+
 
 def get_data_home():
-    """Return the path of the libpysal data directory.
-
-
-    This folder (~/pysal_data)is used by some large dataset loaders to avoid
-    downloading the data multiple times.
-
-
-    Alternatively, it can be set by the 'PYSALDATA' environment variable or
-    programmatically by giving an explicit folder path. The '~' symbol is
-    expanded to the user home folder
-
-    If the folder does not already exisit, it is automatically created.
+    """Return the path of the ``libpysal`` data directory. This folder (``~/pysal_data``)
+    is used by some large dataset loaders to avoid downloading the data multiple times.
+    Alternatively, it can be set by the 'PYSALDATA' environment variable or programmatically
+    by giving an explicit folder path. The ``'~'`` symbol is expanded to the user home
+    folder If the folder does not already exist, it is automatically created.
+    
+    Returns
+    -------
+    
+    data_home : str
+        The system path where the data is/will be stored.
+     
     """
 
-    data_home = environ.get('PYSALDATA', join("~", PYSALDATA))
+    data_home = environ.get("PYSALDATA", join("~", PYSALDATA))
     data_home = expanduser(data_home)
     if not exists(data_home):
         makedirs(data_home)
@@ -41,10 +42,18 @@ def get_data_home():
 
 
 def get_list_of_files(dir_name):
+    """Create a list of file and sub directories in ``dir_name``.
+    
+    Parameters
+    ----------
+    
+    
+    Returns
+    -------
+    
+    
     """
-    create a list of file and sub directories in dir_name
-    """
-    #names in the given directory
+    # names in the given directory
     all_files = list()
     try:
         file_list = os.listdir(dir_name)
@@ -62,25 +71,68 @@ def get_list_of_files(dir_name):
 
     return all_files
 
+
 def type_of_script():
-    """Helper function to determine run context"""
+    """Helper function to determine run context.
+    
+    Parameters
+    ----------
+    
+    
+    Returns
+    -------
+    
+    """
+
     try:
         ipy_str = str(type(get_ipython()))
-        if 'zmqshell' in ipy_str:
-            return 'jupyter'
-        if 'terminal' in ipy_str:
-            return 'ipython'
+        if "zmqshell" in ipy_str:
+            return "jupyter"
+        if "terminal" in ipy_str:
+            return "ipython"
     except:
-        return 'terminal'
-
+        return "terminal"
 
 
 class Example:
-    """
-    Example Dataset
-    """
-    def __init__(self, name, description, n, k, download_url,
-                explain_url):
+    """An example dataset."""
+
+    def __init__(self, name, description, n, k, download_url, explain_url):
+        """
+        
+        Parameters
+        ----------
+        
+        name : 
+            ....
+        
+        description  : 
+            ....
+        
+        n : 
+            ....
+        
+        k : 
+            ....
+        
+        download_url : 
+            ....
+        
+        explain_url : 
+            ....
+        
+        Attributes
+        ----------
+        
+        root : str
+            ....
+        
+        installed : 
+        
+        zipfile : 
+        
+        """
+
         self.name = name
         self.description = description
         self.n = n
@@ -91,13 +143,13 @@ class Example:
         self.installed = self.downloaded()
 
     def get_local_path(self, path=get_data_home()):
-        """Get local path for example"""
+        """Get the local path for example."""
+
         return join(path, self.root)
 
     def get_path(self, file_name, verbose=True):
-        """
-        get path for local file
-        """
+        """Get the path for local file."""
+
         file_list = self.get_file_list()
         for file_path in file_list:
             base_name = os.path.basename(file_path)
@@ -108,67 +160,61 @@ class Example:
         return None
 
     def downloaded(self):
-        """
-        Check if example has already been installed
-        """
+        """Check if the example has already been installed."""
+
         path = self.get_local_path()
         if os.path.isdir(path):
             self.installed = True
             return True
         return False
 
-
     def explain(self):
-        """
-        Provide a description of the example.
-        """
+        """Provide a description of the example."""
+
         file_name = self.explain_url.split("/")[-1]
-        if file_name == 'README.md':
+        if file_name == "README.md":
             explain_page = requests.get(self.explain_url)
-            crawled = BeautifulSoup(explain_page.text, 'html.parser')
+            crawled = BeautifulSoup(explain_page.text, "html.parser")
             print(crawled.text)
             return None
-        if type_of_script() == 'terminal':
+        if type_of_script() == "terminal":
             webbrowser.open(self.explain_url)
             return None
         from IPython.display import IFrame
+
         return IFrame(self.explain_url, width=700, height=350)
 
     def download(self, path=get_data_home()):
-        """
-        Download the files for the example.
-        """
+        """Download the files for the example."""
+
         if self.downloaded():
-            print('Already downloaded')
+            print("Already downloaded")
         else:
             request = requests.get(self.download_url)
             archive = zipfile.ZipFile(io.BytesIO(request.content))
             target = join(path, self.root)
-            print('Downloading {} to {}'.format(self.name, target))
+            print("Downloading {} to {}".format(self.name, target))
             archive.extractall(path=target)
             self.zipfile = archive
             self.installed = True
 
     def get_file_list(self):
-        """
-        Get list of local files for the example.
-        """
+        """Get the list of local files for the example."""
         path = self.get_local_path()
         if os.path.isdir(path):
             return get_list_of_files(path)
         return None
-
 
     def json_dict(self):
         """
         container for example meta data
         """
         meta = {}
-        meta['name'] = self.name
-        meta['description'] = self.description
-        meta['download_url'] = self.download_url
-        meta['explain_url'] = self.explain_url
-        meta['root'] = self.root
+        meta["name"] = self.name
+        meta["description"] = self.description
+        meta["download_url"] = self.download_url
+        meta["explain_url"] = self.explain_url
+        meta["root"] = self.root
         return meta
 
     def load(self, file_name):
@@ -180,8 +226,6 @@ class Example:
             return ps_open(pth)
 
 
-
-
 class Examples:
     """
     Manager for pysal example datasets.
@@ -191,19 +235,17 @@ class Examples:
     def __init__(self):
         self.datasets = {}
 
-
     def add_examples(self, examples):
         """
         add examples to the set of datasets available
         """
         self.datasets.update(examples)
 
-
     def explain(self, example_name):
         if example_name in self.datasets:
             return self.datasets[example_name].explain()
         else:
-            print('not available')
+            print("not available")
 
     def available(self):
         """
@@ -217,10 +259,11 @@ class Examples:
             description = datasets[name].description
             installed = datasets[name].installed
             rows.append([name, description, installed])
-        datasets = pandas.DataFrame(data = rows, columns=['Name', 'Description', 'Installed'])
-        datasets.style.set_properties(subset=['text'], **{'width': '300px'})
+        datasets = pandas.DataFrame(
+            data=rows, columns=["Name", "Description", "Installed"]
+        )
+        datasets.style.set_properties(subset=["text"], **{"width": "300px"})
         print(datasets.to_string())
-
 
     def load(self, example_name):
         """
@@ -235,7 +278,7 @@ class Examples:
                 example.download()
                 return example
         else:
-            print('Example not available: {}'.format(example_name))
+            print("Example not available: {}".format(example_name))
             return None
 
     def download_remotes(self):
@@ -252,13 +295,12 @@ class Examples:
             try:
                 example.download()
             except:
-                print('Example not downloaded: {}'.format(name))
-
+                print("Example not downloaded: {}".format(name))
 
     def get_installed_names(self):
         """Return names of all currently installed datasets"""
         ds = self.datasets
         return [name for name in ds if ds[name].installed]
 
-example_manager = Examples()
 
+example_manager = Examples()

--- a/libpysal/examples/base.py
+++ b/libpysal/examples/base.py
@@ -16,7 +16,7 @@ import pandas
 from bs4 import BeautifulSoup
 from ..io import open as ps_open
 
-# from typing import Union ######################################################################################
+from typing import Union
 
 PYSALDATA = "pysal_data"
 
@@ -137,8 +137,7 @@ class Example:
 
         return join(path, self.root)
 
-    #def get_path(self, file_name, verbose=True) -> Union[str, None]: ######################################################################################
-    def get_path(self, file_name, verbose=True):
+    def get_path(self, file_name, verbose=True) -> Union[str, None]:
         """Get the path for local file."""
 
         file_list = self.get_file_list()
@@ -189,8 +188,7 @@ class Example:
             self.zipfile = archive
             self.installed = True
 
-    #def get_file_list(self) -> Union[list, None]: ######################################################################################
-    def get_file_list(self):
+    def get_file_list(self) -> Union[list, None]:
         """Get the list of local files for the example."""
         path = self.get_local_path()
         if os.path.isdir(path):
@@ -246,8 +244,7 @@ class Examples:
         datasets.style.set_properties(subset=["text"], **{"width": "300px"})
         print(datasets.to_string())
 
-    #def load(self, example_name: str) -> Example: ######################################################################################
-    def load(self, example_name: str):
+    def load(self, example_name: str) -> Example:
         """Load example dataset, download if not locally available."""
         if example_name in self.datasets:
             example = self.datasets[example_name]

--- a/libpysal/examples/base.py
+++ b/libpysal/examples/base.py
@@ -28,7 +28,6 @@ def get_data_home():
     
     Returns
     -------
-    
     data_home : str
         The system path where the data is/will be stored.
      
@@ -46,11 +45,13 @@ def get_list_of_files(dir_name):
     
     Parameters
     ----------
-    
+    dir_name : 
+        ....
     
     Returns
     -------
-    
+    all_files : list
+        ....
     
     """
     # names in the given directory
@@ -81,6 +82,8 @@ def type_of_script():
     
     Returns
     -------
+    .... : str
+        ....
     
     """
 
@@ -102,35 +105,27 @@ class Example:
         
         Parameters
         ----------
-        
         name : 
             ....
-        
-        description  : 
+        description : 
             ....
-        
         n : 
             ....
-        
         k : 
             ....
-        
         download_url : 
             ....
-        
         explain_url : 
             ....
         
         Attributes
         ----------
-        
         root : str
             ....
-        
         installed : 
-        
+            ....
         zipfile : 
-        
+            ....
         """
 
         self.name = name
@@ -206,9 +201,7 @@ class Example:
         return None
 
     def json_dict(self):
-        """
-        container for example meta data
-        """
+        """Container for example meta data."""
         meta = {}
         meta["name"] = self.name
         meta["description"] = self.description
@@ -218,27 +211,20 @@ class Example:
         return meta
 
     def load(self, file_name):
-        """
-        dispatch to libpysal.io to open file
-        """
+        """Dispatch to libpysal.io to open file."""
         pth = self.get_path(file_name)
         if pth:
             return ps_open(pth)
 
 
 class Examples:
-    """
-    Manager for pysal example datasets.
-
-    """
+    """Manager for pysal example datasets."""
 
     def __init__(self):
         self.datasets = {}
 
     def add_examples(self, examples):
-        """
-        add examples to the set of datasets available
-        """
+        """Add examples to the set of datasets available."""
         self.datasets.update(examples)
 
     def explain(self, example_name):
@@ -248,9 +234,7 @@ class Examples:
             print("not available")
 
     def available(self):
-        """
-        report available datasets
-        """
+        """Report available datasets."""
         datasets = self.datasets
         names = list(datasets.keys())
         names.sort()
@@ -266,9 +250,7 @@ class Examples:
         print(datasets.to_string())
 
     def load(self, example_name):
-        """
-        load example dataset, download if not locally available
-        """
+        """Load example dataset, download if not locally available."""
         if example_name in self.datasets:
             example = self.datasets[example_name]
             if example.installed:
@@ -282,10 +264,7 @@ class Examples:
             return None
 
     def download_remotes(self):
-        """
-        Dowload all remotes
-
-        """
+        """Download all remotes."""
         names = list(self.remotes.keys())
         names.sort()
 
@@ -298,7 +277,7 @@ class Examples:
                 print("Example not downloaded: {}".format(name))
 
     def get_installed_names(self):
-        """Return names of all currently installed datasets"""
+        """Return names of all currently installed datasets."""
         ds = self.datasets
         return [name for name in ds if ds[name].installed]
 

--- a/libpysal/examples/base.py
+++ b/libpysal/examples/base.py
@@ -16,7 +16,7 @@ import pandas
 from bs4 import BeautifulSoup
 from ..io import open as ps_open
 
-from typing import Union
+# from typing import Union ######################################################################################
 
 PYSALDATA = "pysal_data"
 
@@ -137,7 +137,8 @@ class Example:
 
         return join(path, self.root)
 
-    def get_path(self, file_name, verbose=True) -> Union[str, None]:
+    #def get_path(self, file_name, verbose=True) -> Union[str, None]: ######################################################################################
+    def get_path(self, file_name, verbose=True):
         """Get the path for local file."""
 
         file_list = self.get_file_list()
@@ -188,7 +189,8 @@ class Example:
             self.zipfile = archive
             self.installed = True
 
-    def get_file_list(self) -> Union[list, None]:
+    #def get_file_list(self) -> Union[list, None]: ######################################################################################
+    def get_file_list(self):
         """Get the list of local files for the example."""
         path = self.get_local_path()
         if os.path.isdir(path):
@@ -244,7 +246,8 @@ class Examples:
         datasets.style.set_properties(subset=["text"], **{"width": "300px"})
         print(datasets.to_string())
 
-    def load(self, example_name: str) -> Example:
+    #def load(self, example_name: str) -> Example: ######################################################################################
+    def load(self, example_name: str):
         """Load example dataset, download if not locally available."""
         if example_name in self.datasets:
             example = self.datasets[example_name]

--- a/libpysal/examples/base.py
+++ b/libpysal/examples/base.py
@@ -1,5 +1,5 @@
 """
-Base class for managing example datasets
+Base class for managing example datasets.
 """
 
 # Authors: Serge Rey
@@ -15,6 +15,8 @@ import requests
 import pandas
 from bs4 import BeautifulSoup
 from ..io import open as ps_open
+
+from typing import Union
 
 PYSALDATA = "pysal_data"
 
@@ -41,17 +43,22 @@ def get_data_home():
 
 
 def get_list_of_files(dir_name):
-    """Create a list of file and sub directories in ``dir_name``.
+    """Create a list of files and sub-directories in ``dir_name``.
     
     Parameters
     ----------
-    dir_name : 
-        ....
+    dir_name : str
+        The path to the directory or examples.
     
     Returns
     -------
     all_files : list
-        ....
+        All file and directory paths.
+    
+    Raises
+    ------
+    FileNotFoundError
+        If the file or directory is not found.
     
     """
     # names in the given directory
@@ -73,19 +80,8 @@ def get_list_of_files(dir_name):
     return all_files
 
 
-def type_of_script():
-    """Helper function to determine run context.
-    
-    Parameters
-    ----------
-    
-    
-    Returns
-    -------
-    .... : str
-        ....
-    
-    """
+def type_of_script() -> str:
+    """Helper function to determine run context."""
 
     try:
         ipy_str = str(type(get_ipython()))
@@ -98,36 +94,35 @@ def type_of_script():
 
 
 class Example:
-    """An example dataset."""
+    """An example dataset.
+
+    Parameters
+    ----------
+    name : str
+        The example dataset name.
+    description : str
+        The example dataset description.
+    n : int
+        The number of records in the dataset.
+    k : int
+        The number of fields in the dataset.
+    download_url : str
+        The URL to download the dataset.
+    explain_url : str
+        The URL to the dataset's READEME file.
+    
+    Attributes
+    ----------
+    root : str
+        The ``name`` parameter with filled spaces (_).
+    installed : bool
+        ``True`` if the example is installed, otherwise ``False``.
+    zipfile : zipfile.ZipFile
+        The archived dataset.
+    
+    """
 
     def __init__(self, name, description, n, k, download_url, explain_url):
-        """
-        
-        Parameters
-        ----------
-        name : 
-            ....
-        description : 
-            ....
-        n : 
-            ....
-        k : 
-            ....
-        download_url : 
-            ....
-        explain_url : 
-            ....
-        
-        Attributes
-        ----------
-        root : str
-            ....
-        installed : 
-            ....
-        zipfile : 
-            ....
-        """
-
         self.name = name
         self.description = description
         self.n = n
@@ -137,12 +132,12 @@ class Example:
         self.root = name.replace(" ", "_")
         self.installed = self.downloaded()
 
-    def get_local_path(self, path=get_data_home()):
+    def get_local_path(self, path=get_data_home()) -> str:
         """Get the local path for example."""
 
         return join(path, self.root)
 
-    def get_path(self, file_name, verbose=True):
+    def get_path(self, file_name, verbose=True) -> Union[str, None]:
         """Get the path for local file."""
 
         file_list = self.get_file_list()
@@ -154,7 +149,7 @@ class Example:
             print("{} is not a file in this example".format(file_name))
         return None
 
-    def downloaded(self):
+    def downloaded(self) -> bool:
         """Check if the example has already been installed."""
 
         path = self.get_local_path()
@@ -163,7 +158,7 @@ class Example:
             return True
         return False
 
-    def explain(self):
+    def explain(self) -> None:
         """Provide a description of the example."""
 
         file_name = self.explain_url.split("/")[-1]
@@ -193,14 +188,14 @@ class Example:
             self.zipfile = archive
             self.installed = True
 
-    def get_file_list(self):
+    def get_file_list(self) -> Union[list, None]:
         """Get the list of local files for the example."""
         path = self.get_local_path()
         if os.path.isdir(path):
             return get_list_of_files(path)
         return None
 
-    def json_dict(self):
+    def json_dict(self) -> dict:
         """Container for example meta data."""
         meta = {}
         meta["name"] = self.name
@@ -210,7 +205,7 @@ class Example:
         meta["root"] = self.root
         return meta
 
-    def load(self, file_name):
+    def load(self, file_name) -> io.FileIO:
         """Dispatch to libpysal.io to open file."""
         pth = self.get_path(file_name)
         if pth:
@@ -227,7 +222,7 @@ class Examples:
         """Add examples to the set of datasets available."""
         self.datasets.update(examples)
 
-    def explain(self, example_name):
+    def explain(self, example_name) -> str:
         if example_name in self.datasets:
             return self.datasets[example_name].explain()
         else:
@@ -249,7 +244,7 @@ class Examples:
         datasets.style.set_properties(subset=["text"], **{"width": "300px"})
         print(datasets.to_string())
 
-    def load(self, example_name):
+    def load(self, example_name: str) -> Example:
         """Load example dataset, download if not locally available."""
         if example_name in self.datasets:
             example = self.datasets[example_name]
@@ -276,7 +271,7 @@ class Examples:
             except:
                 print("Example not downloaded: {}".format(name))
 
-    def get_installed_names(self):
+    def get_installed_names(self) -> list:
         """Return names of all currently installed datasets."""
         ds = self.datasets
         return [name for name in ds if ds[name].installed]

--- a/libpysal/examples/builtin.py
+++ b/libpysal/examples/builtin.py
@@ -39,9 +39,7 @@ dirs = [
 
 
 class LocalExample:
-    """
-    Builtin pysal example dataset
-    """
+    """Builtin pysal example dataset."""
 
     def __init__(self, name, dirname):
         self.name = name
@@ -50,12 +48,12 @@ class LocalExample:
         self.description = self.get_description()
 
     def get_file_list(self):
+        """
+        """
         return get_list_of_files(self.dirname)
 
     def get_path(self, file_name, verbose=True):
-        """
-        get path for local file
-        """
+        """Get path for local file."""
         file_list = self.get_file_list()
         for file_path in file_list:
             base_name = os.path.basename(file_path)
@@ -66,14 +64,14 @@ class LocalExample:
         return None
 
     def explain(self):
-        """
-        Provide a description of the example
-        """
+        """Provide a description of the example."""
         description = [f for f in self.get_file_list() if "README.md" in f][0]
         with open(description, "r", encoding="utf8") as f:
             print(f.read())
 
     def get_description(self):
+        """
+        """
         description = [f for f in self.get_file_list() if "README.md" in f][0]
         with open(description, "r", encoding="utf8") as f:
             lines = f.readlines()

--- a/libpysal/examples/builtin.py
+++ b/libpysal/examples/builtin.py
@@ -1,5 +1,4 @@
-"""
-Handle local builtin datasets
+"""Handle local builtin datasets.
 """
 
 import os
@@ -41,18 +40,17 @@ dirs = [
 class LocalExample:
     """Builtin pysal example dataset."""
 
-    def __init__(self, name, dirname):
+    def __init__(self, name: str, dirname: str):
         self.name = name
         self.dirname = dirname
         self.installed = True
         self.description = self.get_description()
 
-    def get_file_list(self):
-        """
-        """
+    def get_file_list(self) -> list:
+        """Return a list of file names."""
         return get_list_of_files(self.dirname)
 
-    def get_path(self, file_name, verbose=True):
+    def get_path(self, file_name: str, verbose=True) -> str:
         """Get path for local file."""
         file_list = self.get_file_list()
         for file_path in file_list:
@@ -64,14 +62,13 @@ class LocalExample:
         return None
 
     def explain(self):
-        """Provide a description of the example."""
+        """Provide a printed description of the example."""
         description = [f for f in self.get_file_list() if "README.md" in f][0]
         with open(description, "r", encoding="utf8") as f:
             print(f.read())
 
-    def get_description(self):
-        """
-        """
+    def get_description(self) -> str:
+        """Dataset description."""
         description = [f for f in self.get_file_list() if "README.md" in f][0]
         with open(description, "r", encoding="utf8") as f:
             lines = f.readlines()

--- a/libpysal/examples/builtin.py
+++ b/libpysal/examples/builtin.py
@@ -3,16 +3,38 @@ Handle local builtin datasets
 """
 
 import os
-from .base import  get_list_of_files
-
+from .base import get_list_of_files
 
 
 dirs = [
-    "10740", "arcgis", "baltim", "berlin", "book", "burkitt", "calemp",
-    "chicago", "columbus", "desmith", "geodanet", "georgia",
-    "juvenile", "Line", "mexico", "networks", "Point", "Polygon",
-    "Polygon_Holes", "sids2", "snow_maps", "stl", "street_net_pts", "tests",
-    "tokyo", "us_income", "virginia", "wmat"
+    "10740",
+    "arcgis",
+    "baltim",
+    "berlin",
+    "book",
+    "burkitt",
+    "calemp",
+    "chicago",
+    "columbus",
+    "desmith",
+    "geodanet",
+    "georgia",
+    "juvenile",
+    "Line",
+    "mexico",
+    "networks",
+    "Point",
+    "Polygon",
+    "Polygon_Holes",
+    "sids2",
+    "snow_maps",
+    "stl",
+    "street_net_pts",
+    "tests",
+    "tokyo",
+    "us_income",
+    "virginia",
+    "wmat",
 ]
 
 
@@ -20,6 +42,7 @@ class LocalExample:
     """
     Builtin pysal example dataset
     """
+
     def __init__(self, name, dirname):
         self.name = name
         self.dirname = dirname
@@ -47,16 +70,14 @@ class LocalExample:
         Provide a description of the example
         """
         description = [f for f in self.get_file_list() if "README.md" in f][0]
-        with open(description, 'r', encoding="utf8") as f:
+        with open(description, "r", encoding="utf8") as f:
             print(f.read())
 
     def get_description(self):
         description = [f for f in self.get_file_list() if "README.md" in f][0]
-        with open(description, 'r', encoding="utf8") as f:
+        with open(description, "r", encoding="utf8") as f:
             lines = f.readlines()
         return lines[3].strip()
-
-
 
 
 builtin_root = os.path.dirname(__file__)

--- a/libpysal/examples/remotes.py
+++ b/libpysal/examples/remotes.py
@@ -16,7 +16,7 @@ def poll_remotes():
         Example datasets keyed by the dataset name.
         
     """
-    
+
     # Geoda Center Datasets
     url = "https://geodacenter.github.io/data-and-lab//"
     try:

--- a/libpysal/examples/remotes.py
+++ b/libpysal/examples/remotes.py
@@ -94,9 +94,7 @@ datasets = poll_remotes()
 
 
 def download(datasets=datasets):
-    """
-    Download all known remotes
-    """
+    """Download all known remotes."""
     names = list(datasets.keys())
     names.sort()
     for name in names:

--- a/libpysal/examples/remotes.py
+++ b/libpysal/examples/remotes.py
@@ -4,12 +4,10 @@ Handle remote datasets
 from bs4 import BeautifulSoup
 import requests
 import warnings
-from .base import (PYSALDATA, Example, get_list_of_files,
-                   get_data_home)
+from .base import PYSALDATA, Example, get_list_of_files, get_data_home
 
 
 def poll_remotes():
-
 
     # Geoda Center Data Sets
 
@@ -20,83 +18,85 @@ def poll_remotes():
     try:
         page = requests.get(url)
     except:
-        warnings.warn('Remote data sets not available. Check connection.')
+        warnings.warn("Remote data sets not available. Check connection.")
         return {}
-    soup = BeautifulSoup(page.text, 'html.parser')
-    samples = soup.find(class_='samples')
-    rows = samples.find_all('tr')
+    soup = BeautifulSoup(page.text, "html.parser")
+    samples = soup.find(class_="samples")
+    rows = samples.find_all("tr")
     datasets = {}
     for row in rows[1:]:
-        data = row.find_all('td')
+        data = row.find_all("td")
         name = data[0].text.strip()
         description = data[1].text
         n = data[2].text
         k = data[3].text
-        targets = row.find_all('a')
-        download_url = targets[1].attrs['href']
-        explain_url = targets[0].attrs['href']
+        targets = row.find_all("a")
+        download_url = targets[1].attrs["href"]
+        explain_url = targets[0].attrs["href"]
         datasets[name] = Example(name, description, n, k, download_url, explain_url)
-
 
     # Other Remotes
 
     # rio
-    name = 'Rio Grande do Sul'
-    description = 'Cities of the Brazilian State of Rio Grande do Sul'
+    name = "Rio Grande do Sul"
+    description = "Cities of the Brazilian State of Rio Grande do Sul"
     n = 497
     k = 3
-    download_url = 'https://github.com/sjsrey/rio_grande_do_sul/archive/master.zip'
-    explain_url = 'https://raw.githubusercontent.com/sjsrey/rio_grande_do_sul/master/README.md'
+    download_url = "https://github.com/sjsrey/rio_grande_do_sul/archive/master.zip"
+    explain_url = (
+        "https://raw.githubusercontent.com/sjsrey/rio_grande_do_sul/master/README.md"
+    )
     datasets[name] = Example(name, description, n, k, download_url, explain_url)
 
     # nyc bikes
-    name = 'nyc_bikes'
-    description = 'New York City Bike Trips'
+    name = "nyc_bikes"
+    description = "New York City Bike Trips"
     n = 14042
     k = 27
-    download_url = 'https://github.com/sjsrey/nyc_bikes/archive/master.zip'
-    explain_url = 'https://raw.githubusercontent.com/sjsrey/nyc_bikes/master/README.md'
+    download_url = "https://github.com/sjsrey/nyc_bikes/archive/master.zip"
+    explain_url = "https://raw.githubusercontent.com/sjsrey/nyc_bikes/master/README.md"
     datasets[name] = Example(name, description, n, k, download_url, explain_url)
 
     # taz
-    name = 'taz'
-    description = 'Traffic Analysis Zones in So. California'
+    name = "taz"
+    description = "Traffic Analysis Zones in So. California"
     n = 4109
     k = 14
-    download_url = 'https://github.com/sjsrey/taz/archive/master.zip'
-    explain_url = 'https://raw.githubusercontent.com/sjsrey/taz/master/README.md'
+    download_url = "https://github.com/sjsrey/taz/archive/master.zip"
+    explain_url = "https://raw.githubusercontent.com/sjsrey/taz/master/README.md"
     datasets[name] = Example(name, description, n, k, download_url, explain_url)
 
     # clearwater
-    name = 'clearwater'
-    description = 'mgwr testing dataset'
+    name = "clearwater"
+    description = "mgwr testing dataset"
     n = 239
     k = 14
-    download_url = 'https://github.com/sjsrey/clearwater/archive/master.zip'
-    explain_url = 'https://raw.githubusercontent.com/sjsrey/clearwater/master/README.md'
+    download_url = "https://github.com/sjsrey/clearwater/archive/master.zip"
+    explain_url = "https://raw.githubusercontent.com/sjsrey/clearwater/master/README.md"
     datasets[name] = Example(name, description, n, k, download_url, explain_url)
 
     # newHaven
-    name = 'newHaven'
-    description = 'Network testing dataset'
+    name = "newHaven"
+    description = "Network testing dataset"
     n = 3293
     k = 5
-    download_url = 'https://github.com/sjsrey/newHaven/archive/master.zip'
-    explain_url = 'https://raw.githubusercontent.com/sjsrey/newHaven/master/README.md'
+    download_url = "https://github.com/sjsrey/newHaven/archive/master.zip"
+    explain_url = "https://raw.githubusercontent.com/sjsrey/newHaven/master/README.md"
     datasets[name] = Example(name, description, n, k, download_url, explain_url)
 
-
     # remove Cars dataset as it is broken
-    datasets.pop('Cars')
+    datasets.pop("Cars")
 
     return datasets
 
+
 datasets = poll_remotes()
 
+
 def download(datasets=datasets):
-    '''
+    """
     Download all known remotes
-    '''
+    """
     names = list(datasets.keys())
     names.sort()
     for name in names:
@@ -105,4 +105,4 @@ def download(datasets=datasets):
         try:
             example.download()
         except:
-            print('Example not downloaded: {}'.format(name))
+            print("Example not downloaded: {}".format(name))

--- a/libpysal/examples/remotes.py
+++ b/libpysal/examples/remotes.py
@@ -1,6 +1,6 @@
+"""Handle remote datasets.
 """
-Handle remote datasets
-"""
+
 from bs4 import BeautifulSoup
 import requests
 import warnings
@@ -8,13 +8,17 @@ from .base import PYSALDATA, Example, get_list_of_files, get_data_home
 
 
 def poll_remotes():
-
-    # Geoda Center Data Sets
-
+    """Fetch remote data and generate example datasets.
+    
+    Returns
+    -------
+    datasets : dict
+        Example datasets keyed by the dataset name.
+        
+    """
+    
+    # Geoda Center Datasets
     url = "https://geodacenter.github.io/data-and-lab//"
-
-    # requests.exceptions.ConnectionError
-
     try:
         page = requests.get(url)
     except:
@@ -35,8 +39,7 @@ def poll_remotes():
         explain_url = targets[0].attrs["href"]
         datasets[name] = Example(name, description, n, k, download_url, explain_url)
 
-    # Other Remotes
-
+    # Other Remote Datasets
     # rio
     name = "Rio Grande do Sul"
     description = "Cities of the Brazilian State of Rio Grande do Sul"


### PR DESCRIPTION
See #290 

This PR adds type hints and standardizes the following docstrings:
 * `libpysal/examples/__init__.py`
 * `libpysal/examples/base.py`
 * `libpysal/examples/builtin.py`
 * `libpysal/examples/remotes.py`