### PR TITLE
TST: Remove unneeded calls to pysal_examples.get_path.

### DIFF
--- a/libpysal/io/iohandlers/tests/test_arcgis_dbf.py
+++ b/libpysal/io/iohandlers/tests/test_arcgis_dbf.py
@@ -41,8 +41,7 @@ class test_ArcGISDbfIO(unittest.TestCase):
             if len(warn) > 0:
                 assert issubclass(warn[0].category, RuntimeWarning)
                 assert "Missing Value Found, setting value to pysal.MISSINGVALUE" in str(warn[0].message)
-        f = tempfile.NamedTemporaryFile(
-            suffix='.dbf', dir=pysal_examples.get_path(''))
+        f = tempfile.NamedTemporaryFile(suffix='.dbf')
         fname = f.name
         f.close()
         o = psopen(fname, 'w', 'arcgis_dbf')

--- a/libpysal/io/iohandlers/tests/test_arcgis_swm.py
+++ b/libpysal/io/iohandlers/tests/test_arcgis_swm.py
@@ -30,8 +30,7 @@ class test_ArcGISSwmIO(unittest.TestCase):
 
     def test_write(self):
         w = self.obj.read()
-        f = tempfile.NamedTemporaryFile(
-            suffix='.swm', dir=pysal_examples.get_path(''))
+        f = tempfile.NamedTemporaryFile(suffix='.swm')
         fname = f.name
         f.close()
         o = psopen(fname, 'w')

--- a/libpysal/io/iohandlers/tests/test_arcgis_txt.py
+++ b/libpysal/io/iohandlers/tests/test_arcgis_txt.py
@@ -41,8 +41,7 @@ class test_ArcGISTextIO(unittest.TestCase):
             if len(warn) > 0:
                 assert issubclass(warn[0].category, RuntimeWarning)
                 assert "DBF relating to ArcGIS TEXT was not found, proceeding with unordered string ids." in str(warn[0].message)
-        f = tempfile.NamedTemporaryFile(
-            suffix='.txt', dir=pysal_examples.get_path(''))
+        f = tempfile.NamedTemporaryFile(suffix='.txt')
         fname = f.name
         f.close()
         o = psopen(fname, 'w', 'arcgis_text')

--- a/libpysal/io/iohandlers/tests/test_dat.py
+++ b/libpysal/io/iohandlers/tests/test_dat.py
@@ -30,8 +30,7 @@ class test_DatIO(unittest.TestCase):
 
     def test_write(self):
         w = self.obj.read()
-        f = tempfile.NamedTemporaryFile(
-            suffix='.dat', dir=pysal_examples.get_path(''))
+        f = tempfile.NamedTemporaryFile(suffix='.dat')
         fname = f.name
         f.close()
         o = psopen(fname, 'w')

--- a/libpysal/io/iohandlers/tests/test_geobugs_txt.py
+++ b/libpysal/io/iohandlers/tests/test_geobugs_txt.py
@@ -43,8 +43,7 @@ class test_GeoBUGSTextIO(unittest.TestCase):
     def test_write(self):
         for obj in [self.obj_scot, self.obj_col]:
             w = obj.read()
-            f = tempfile.NamedTemporaryFile(
-                suffix='', dir=pysal_examples.get_path(''))
+            f = tempfile.NamedTemporaryFile(suffix='')
             fname = f.name
             f.close()
             o = psopen(fname, 'w', 'geobugs_text')

--- a/libpysal/io/iohandlers/tests/test_gwt.py
+++ b/libpysal/io/iohandlers/tests/test_gwt.py
@@ -35,8 +35,7 @@ class test_GwtIO(unittest.TestCase):
     # Added back by CRS,
     def test_write(self):
         w = self.obj.read()
-        f = tempfile.NamedTemporaryFile(
-            suffix='.gwt', dir=pysal_examples.get_path(''))
+        f = tempfile.NamedTemporaryFile(suffix='.gwt')
         fname = f.name
         f.close()
         o = psopen(fname, 'w')

--- a/libpysal/io/iohandlers/tests/test_mat.py
+++ b/libpysal/io/iohandlers/tests/test_mat.py
@@ -31,8 +31,7 @@ class test_MatIO(unittest.TestCase):
 
     def test_write(self):
         w = self.obj.read()
-        f = tempfile.NamedTemporaryFile(
-            suffix='.mat', dir=pysal_examples.get_path(''))
+        f = tempfile.NamedTemporaryFile(suffix='.mat')
         fname = f.name
         f.close()
         o = psopen(fname, 'w')

--- a/libpysal/io/iohandlers/tests/test_mtx.py
+++ b/libpysal/io/iohandlers/tests/test_mtx.py
@@ -40,8 +40,7 @@ class test_MtxIO(unittest.TestCase):
         for i in [False, True]:
             self.obj.seek(0)
             w = self.obj.read(sparse=i)
-            f = tempfile.NamedTemporaryFile(
-                suffix='.mtx', dir=pysal_examples.get_path(''))
+            f = tempfile.NamedTemporaryFile(suffix='.mtx')
             fname = f.name
             f.close()
             o = psopen(fname, 'w')

--- a/libpysal/io/iohandlers/tests/test_stata_txt.py
+++ b/libpysal/io/iohandlers/tests/test_stata_txt.py
@@ -44,8 +44,7 @@ class test_StataTextIO(unittest.TestCase):
     def test_write(self):
         for obj in [self.obj_sparse, self.obj_full]:
             w = obj.read()
-            f = tempfile.NamedTemporaryFile(
-                suffix='.txt', dir=pysal_examples.get_path(''))
+            f = tempfile.NamedTemporaryFile(suffix='.txt')
             fname = f.name
             f.close()
             o = psopen(fname, 'w', 'stata_text')

--- a/libpysal/io/iohandlers/tests/test_wk1.py
+++ b/libpysal/io/iohandlers/tests/test_wk1.py
@@ -30,8 +30,7 @@ class test_Wk1IO(unittest.TestCase):
 
     def test_write(self):
         w = self.obj.read()
-        f = tempfile.NamedTemporaryFile(
-            suffix='.wk1', dir=pysal_examples.get_path(''))
+        f = tempfile.NamedTemporaryFile(suffix='.wk1')
         fname = f.name
         f.close()
         o = psopen(fname, 'w')

--- a/libpysal/io/util/tests/test_weight_converter.py
+++ b/libpysal/io/util/tests/test_weight_converter.py
@@ -11,7 +11,6 @@ from .... import examples as pysal_examples
 @unittest.skip('This function is deprecated')
 class test_WeightConverter(unittest.TestCase):
     def setUp(self):
-        self.base_dir = pysal_examples.get_path('')
         test_files = ['arcgis_ohio.dbf', 'arcgis_txt.txt', 'ohio.swm',
                            'wmat.dat', 'wmat.mtx', 'sids2.gal', 'juvenile.gwt',
                            'geobugs_scot', 'stata_full.txt', 'stata_sparse.txt',
@@ -50,8 +49,7 @@ class test_WeightConverter(unittest.TestCase):
             for ext, dataformat in self.fileformats:
                 if f.lower().endswith(ext):
                     continue
-                temp_f = tempfile.NamedTemporaryFile(
-                    suffix='.%s' % ext, dir=self.base_dir)
+                temp_f = tempfile.NamedTemporaryFile(suffix='.%s' % ext)
                 temp_fname = temp_f.name
                 temp_f.close()
 
@@ -105,8 +103,7 @@ class test_WeightConverter(unittest.TestCase):
             for ext, dataformat in self.fileformats:
                 if f.lower().endswith(ext):
                     continue
-                temp_f = tempfile.NamedTemporaryFile(
-                    suffix='.%s' % ext, dir=self.base_dir)
+                temp_f = tempfile.NamedTemporaryFile(suffix='.%s' % ext)
                 outFile = temp_f.name
                 temp_f.close()
                 outDataFormat, useIdIndex, matrix_form = dataformat, False, False


### PR DESCRIPTION
1. [x] You have run tests on this submission, either by using [Travis Continuous Integration testing](https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures#automated-testing-w-travis-ci) testing or running `nosetests` on your changes?
2. [x] This pull request is directed to the `pysal/master` branch.
3. [N/A] This pull introduces new functionality covered by [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [N/A] You have [assigned a reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [x] The justification for this PR is: 

A filename of `''` will never match anything, so this will always return `None`, and put the temporary files in the default temporary directory anyway.