### PR TITLE
removing setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[nosetests]
-ignore-files=collection
-
-[wheel]
-universal=1


### PR DESCRIPTION
This PR removes `setup.cfg` as it appears to no longer be used.