### PR TITLE
Add ArcGIS API for Python Geometry Support to Weight Objects

### DIFF
--- a/libpysal/weights/_contW_lists.py
+++ b/libpysal/weights/_contW_lists.py
@@ -17,14 +17,21 @@ def _get_boundary_points(shape):
     Recursively handle polygons vs. multipolygons to
     extract the boundary point set from each. 
     """
-    if shape.type.lower() == 'polygon':
+    if shape.type.lower() == "polygon" and 'rings' in shape:
+        return _get_boundary_points(shape.boundary()) # returns a polyline (path)        
+    elif shape.type.lower() == 'polygon':
         shape = shape.boundary
         return _get_boundary_points(shape)
+    
     elif shape.type.lower() == 'linestring':
         return list(map(tuple, list(zip(*shape.coords.xy))))
     elif shape.type.lower() == 'multilinestring':
         return list(it.chain(*(list(zip(*shape.coords.xy))
                                  for shape in shape)))
+    elif shape.type.lower() == 'polyline':
+        coords = []
+        r = [coords.extend([tuple(p) for p in path]) for path in shape['paths']]   
+        return coords
     elif shape.type.lower() == 'multipolygon':
         return list(it.chain(*(_get_boundary_points(part.boundary) 
                                for part in shape)))


### PR DESCRIPTION
- adds support for ArcGIS API for Python's Polygon and Polyline Geometry objects.

- Point Geometry already works :)

Hello! Please make sure to check all these boxes before submitting a Pull Request
(PR). Once you have checked the boxes, feel free to remove all text except the
justification in point 5. 

1. [x] You have run tests on this submission, either by using [Travis Continuous Integration testing](https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures#automated-testing-w-travis-ci) testing or running `nosetests` on your changes?
2. [x] This pull request is directed to the `pysal/master` branch.
3. [x] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [x] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [ x] The justification for this PR is: Esri's ArcGIS API for Python provides a DataFrame data structure and Geometry object.  The Point geometry already work, but the Polygon (compares to Shapely's MultiPolygon) and Polyline (compares to LInestring and MultiLineString) are not supported.  This PR makes a small change to the `_get_boundary_points` method without adding any new dependencies or dangerous code.  Since the ArcGIS Python API allows for use of both shapely and/or arcpy as geometry engines this will allow users to leverage both OS and Esri technology next to `pysal`
