### PR TITLE
ENH: include lower order contiguities in higher_order_sp

### DIFF
--- a/libpysal/weights/tests/test_util.py
+++ b/libpysal/weights/tests/test_util.py
@@ -99,6 +99,15 @@ class Testutil(unittest.TestCase):
         w5_20 = {2: 1.0, 10: 1.0, 6: 1.0}
         self.assertEqual(w5_20, w5_2[0])
 
+    def test_higher_order_sp(self):
+        w10 = lat2W(10, 10)
+        w10_3 = util.higher_order_sp(w10, 3)
+        w10_30 = {30: 1.0, 21: 1.0, 12: 1.0, 3: 1.0}
+        self.assertEqual(w10_30, w10_3[0])
+        w10_3 = util.higher_order_sp(w10, 3, lower_order=True)
+        w10_30 = {20: 1.0, 30: 1.0, 21: 1.0, 10: 1.0, 1: 1.0, 11: 1.0, 2: 1.0, 12: 1.0, 3: 1.0}
+        self.assertEqual(w10_30, w10_3[0])
+
     def test_higher_order_classes(self):
         wdb = DistanceBand.from_shapefile(examples.get_path('baltim.shp'), 34)
         wknn = KNN.from_shapefile(examples.get_path('baltim.shp'), 10)

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -428,9 +428,9 @@ def higher_order(w, k=2, **kwargs):
     return higher_order_sp(w, k, **kwargs)
 
 
-def higher_order_sp(w, k=2, shortest_path=True, diagonal=False, **kwargs):
+def higher_order_sp(w, k=2, shortest_path=True, diagonal=False, lower_order=False, **kwargs):
     """
-    Contiguity weights for either a sparse W or W  for order k.
+    Contiguity weights for either a sparse W or W for order k.
 
     Parameters
     ----------
@@ -447,6 +447,9 @@ def higher_order_sp(w, k=2, shortest_path=True, diagonal=False, **kwargs):
     diagonal      : boolean
                     True:  keep k-order (i,j) joins when i==j
                     False: remove k-order (i,j) joins when i==j
+    lower_order   : boolean
+                    True: include lower order contiguities
+                    False: return only weights of order k
     **kwargs      : keyword arguments
                     optional arguments for :class:`pysal.weights.W`
 
@@ -455,9 +458,6 @@ def higher_order_sp(w, k=2, shortest_path=True, diagonal=False, **kwargs):
     wk : W
 	     WSP, type matches type of w argument
 
-    Notes
-    -----
-    Lower order contiguities are removed.
 
     Examples
     --------
@@ -480,6 +480,9 @@ def higher_order_sp(w, k=2, shortest_path=True, diagonal=False, **kwargs):
     >>> w25_3 = higher_order_sp(w25, 3, shortest_path=False)
     >>> w25_3[0] == {1: 1.0, 3: 1.0, 5: 1.0, 7: 1.0, 11: 1.0, 15: 1.0}
     True
+    >>> w25_3 = higher_order_sp(w25, 3, lower_order=True)
+    >>> w25_3[0] == {5: 1.0, 7: 1.0, 11: 1.0, 2: 1.0, 15: 1.0, 6: 1.0, 10: 1.0, 1: 1.0, 3: 1.0}
+    True
 
     """
     id_order = None
@@ -496,7 +499,12 @@ def higher_order_sp(w, k=2, shortest_path=True, diagonal=False, **kwargs):
         raise TypeError("Weights provided are neither a binary W object nor "
                         "a scipy.sparse.csr_matrix")
 
-    wk = w**k
+    if lower_order:
+        wk = sum(map(lambda x: w ** x, range(2, k + 1)))
+        shortest_path = False
+    else:
+        wk = w**k
+
     rk, ck = wk.nonzero()
     sk = set(zip(rk, ck))
 


### PR DESCRIPTION
Closes #313 

Implements an option to include lower order contiguities in the result of `higher_order_sp`. 
