### PR TITLE
Format UserWarning string in W.to_adjlist

### DIFF
--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -306,7 +306,7 @@ class W(object):
         n_islands = len(self.islands)
         if n_islands > 0 and (not self.silence_warnings):
             warnings.warn(
-                "{} islands in this weights matrix. Conversion to an "
+                f"{n_islands} islands in this weights matrix. Conversion to an "
                 "adjacency list will drop these observations!"
             )
         adjlist = pd.DataFrame(


### PR DESCRIPTION
Warning expects a number of islands, but the formatting is not there.