### PR TITLE
update unittests.yml

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,27 +20,34 @@
          exclude:
            - environment-file: ci/36.yaml
              os: windows-latest
+     defaults:
+       run:
+         shell: bash -l {0}
      steps:
        - uses: actions/checkout@v2
+       - uses: actions/cache@v2
+         env:
+           CACHE_NUMBER: 0
+         with:
+           path: ~/conda_pkgs_dir
+           key: ${{ matrix.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles(matrix.environment-file) }}
        - uses: conda-incubator/setup-miniconda@v2
          with:
             miniconda-version: 'latest'
-            auto-update-conda: true
+            mamba-version: '*'
+            channels: conda-forge
+            channel-priority: true
+            auto-update-conda: false
             auto-activate-base: false
             environment-file: ${{ matrix.environment-file }}
             activate-environment: test
-       - shell: bash -l {0}
-         run: conda info --all
-       - shell: bash -l {0}
-         run: conda list
-       - shell: bash -l {0}
-         run: conda config --show-sources
-       - shell: bash -l {0}
-         run: conda config --show
-       - shell: bash -l {0}
-         run: python -c 'import libpysal; libpysal.examples.fetch_all()'
-       - shell: bash -l {0}
-         run: py.test -v libpysal --cov=libpysal --cov-report=xml
+            use-only-tar-bz2: true
+       - run: mamba info --all
+       - run: mamba list
+       - run: conda config --show-sources
+       - run: conda config --show
+       - run: python -c 'import libpysal; libpysal.examples.fetch_all()'
+       - run: py.test -v libpysal --cov=libpysal --cov-report=xml
        - name: codecov (${{ matrix.os }}, ${{ matrix.environment-file }})
          uses: codecov/codecov-action@v1
          with:


### PR DESCRIPTION
This PR updates and streamlines `unittests.yml`, and is based on [`spaghetti/.github/workflows/unittests.yml`](https://github.com/pysal/spaghetti/blob/main/.github/workflows/unittests.yml).

* streamlines command line calls
* makes use of caching environments
* uses `mamba` where possible