### PR TITLE
Troubleshoot release GHA

### DIFF
--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -51,20 +51,20 @@
          draft: false
          prerelease: false
      - name: Get Asset name
-       run: |
-         export PKG=$(ls dist/)
-         set -- $PKG
-         echo "name=whl_path" >> $GITHUB_ENV
+      run: |
+        export PKG=$(ls dist/)
+        set -- $PKG
+        echo "name=$1" >> $GITHUB_ENV
      - name: Upload Release Asset
-       id: upload-release-asset
-       uses: actions/upload-release-asset@v1
-       env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-       with:
-         upload_url: ${{ steps.create_release.outputs.upload_url }}
-         asset_path: dist/${{ env.whl_path }}
-         asset_name: ${{ env.whl_path }}
-         asset_content_type: application/zip
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+        asset_path: dist/${{ env.name }}
+        asset_name: ${{ env.name }}
+        asset_content_type: application/zip
      - name: Publish distribution 📦 to PyPI
        uses: pypa/gh-action-pypi-publish@master
        with:

--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -51,20 +51,20 @@
          draft: false
          prerelease: false
      - name: Get Asset name
-      run: |
-        export PKG=$(ls dist/)
-        set -- $PKG
-        echo "name=$1" >> $GITHUB_ENV
+       run: |
+         export PKG=$(ls dist/)
+         set -- $PKG
+         echo "name=$1" >> $GITHUB_ENV
      - name: Upload Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: dist/${{ env.name }}
-        asset_name: ${{ env.name }}
-        asset_content_type: application/zip
+       id: upload-release-asset
+       uses: actions/upload-release-asset@v1
+       env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+       with:
+         upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+         asset_path: dist/${{ env.name }}
+         asset_name: ${{ env.name }}
+         asset_content_type: application/zip
      - name: Publish distribution 📦 to PyPI
        uses: pypa/gh-action-pypi-publish@master
        with:

--- a/libpysal/__init__.py
+++ b/libpysal/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.3.2"
+__version__ = "4.3.3"
 
 # __version__ has to be define in the first line
 


### PR DESCRIPTION
This PR corrects workflow updates in `release_and_publish.yml` and bumps the version to `v4.3.3` for the next iteration of the release to PyPI.