### PR TITLE
[WIP]: id_order as a property of WSP class

### DIFF
--- a/libpysal/weights/raster.py
+++ b/libpysal/weights/raster.py
@@ -268,7 +268,7 @@ def da2WSP(
         sw.eliminate_zeros()
         sw.data[:] = np.ones_like(sw.data, dtype=np.int8)
     index = ser.index
-    wsp = WSP(sw, index=index, id_order=index.tolist())
+    wsp = WSP(sw, index=index)
     return wsp
 
 

--- a/libpysal/weights/raster.py
+++ b/libpysal/weights/raster.py
@@ -107,9 +107,11 @@ def da2W(
     :class:`libpysal.weights.weights.W`
     """
     warn(
-        "It is best to use the WSP object when building weights"
-        " from a raster, as the da2WSP method is much faster"
-        " and far more memory efficient than the da2W method."
+        "You are trying to build a full W object from "
+        "xarray.DataArray (raster) object. This computation "
+        "can be very slow and not scale well. It is recommended, "
+        "if possible, to instead build WSP object, which is more "
+        "efficient and faster. You can do this by using da2WSP method."
     )
     wsp = da2WSP(da, criterion, z_value, coords_labels, k, include_nodata, n_jobs)
     w = wsp.to_W(**kwargs)
@@ -273,6 +275,7 @@ def da2WSP(
         sw.setdiag(0)
         sw.eliminate_zeros()
         sw.data[:] = np.ones_like(sw.data, dtype=np.int8)
+
     index = ser.index
     wsp = WSP(sw, index=index)
     return wsp

--- a/libpysal/weights/raster.py
+++ b/libpysal/weights/raster.py
@@ -6,16 +6,18 @@ import os
 import sys
 from scipy import sparse
 
-if os.path.basename(sys.argv[0]) in ('pytest', 'py.test'):
+if os.path.basename(sys.argv[0]) in ("pytest", "py.test"):
 
     def jit(*dec_args, **dec_kwargs):
         """
         decorator mimicking numba.jit
         """
+
         def intercepted_function(f, *f_args, **f_kwargs):
             return f
 
         return intercepted_function
+
 
 else:
     from ..common import jit
@@ -104,8 +106,12 @@ def da2W(
     --------
     :class:`libpysal.weights.weights.W`
     """
-    wsp = da2WSP(da, criterion, z_value, coords_labels, k, include_nodata,
-                 n_jobs)
+    warn(
+        "It is best to use the WSP object when building weights"
+        " from a raster, as the da2WSP method is much faster"
+        " and far more memory efficient than the da2W method."
+    )
+    wsp = da2WSP(da, criterion, z_value, coords_labels, k, include_nodata, n_jobs)
     w = wsp.to_W(**kwargs)
 
     # temp addition of index attribute
@@ -200,7 +206,7 @@ def da2WSP(
         da = da[slice_dict]
 
     ser = da.to_series()
-    dtype = np.int32 if (shape[0] * shape[1]) < 46340**2 else np.int64
+    dtype = np.int32 if (shape[0] * shape[1]) < 46340 ** 2 else np.int64
     if "nodatavals" in da.attrs and da.attrs["nodatavals"]:
         mask = (ser != da.attrs["nodatavals"][0]).to_numpy()
         ids = np.where(mask)[0]
@@ -215,9 +221,11 @@ def da2WSP(
     try:
         import numba
     except (ModuleNotFoundError, ImportError):
-        warn("numba cannot be imported, parallel processing "
-             "and include_nodata functionality will be disabled. "
-             "falling back to slower method")
+        warn(
+            "numba cannot be imported, parallel processing "
+            "and include_nodata functionality will be disabled. "
+            "falling back to slower method"
+        )
         include_nodata = False
         # Fallback method to build sparse matrix
         sw = lat2SW(*shape, criterion)
@@ -241,20 +249,18 @@ def da2WSP(
                 n_jobs = 1
 
         if n_jobs == 1:
-            sw_tup = _SWbuilder(*shape, ids, id_map, criterion, k_nas,
-                                dtype)  # -> (data, (row, col))
+            sw_tup = _SWbuilder(
+                *shape, ids, id_map, criterion, k_nas, dtype
+            )  # -> (data, (row, col))
         else:
             if n_jobs == -1:
                 n_jobs = os.cpu_count()
             # Parallel implementation
-            sw_tup = _parSWbuilder(*shape, ids, id_map, criterion, k_nas,
-                                   dtype, n_jobs)  # -> (data, (row, col))
+            sw_tup = _parSWbuilder(
+                *shape, ids, id_map, criterion, k_nas, dtype, n_jobs
+            )  # -> (data, (row, col))
 
-        sw = sparse.csr_matrix(
-            sw_tup,
-            shape=(n, n),
-            dtype=np.int8,
-        )
+        sw = sparse.csr_matrix(sw_tup, shape=(n, n), dtype=np.int8,)
 
     # Higher_order functionality, this uses idea from
     # libpysal#313 for adding higher order neighbors.
@@ -263,7 +269,7 @@ def da2WSP(
     # then eliminate zeros from the data. This changes the
     # sparcity of the csr_matrix !!
     if k > 1 and not include_nodata:
-        sw = sum(map(lambda x: sw**x, range(1, k + 1)))
+        sw = sum(map(lambda x: sw ** x, range(1, k + 1)))
         sw.setdiag(0)
         sw.eliminate_zeros()
         sw.data[:] = np.ones_like(sw.data, dtype=np.int8)
@@ -385,8 +391,7 @@ def testDataArray(shape=(3, 4, 4), time=False, rand=False, missing_vals=True):
     try:
         from xarray import DataArray
     except ImportError:
-        raise ModuleNotFoundError(
-            "xarray must be installed to use this functionality")
+        raise ModuleNotFoundError("xarray must be installed to use this functionality")
     if not rand:
         np.random.seed(12345)
     coords = {}
@@ -395,9 +400,9 @@ def testDataArray(shape=(3, 4, 4), time=False, rand=False, missing_vals=True):
         layer = "time" if time else "band"
         dims = (layer, "y", "x")
         if time:
-            layers = np.arange(np.datetime64("2020-07-30"),
-                               shape[0],
-                               dtype="datetime64[D]")
+            layers = np.arange(
+                np.datetime64("2020-07-30"), shape[0], dtype="datetime64[D]"
+            )
         else:
             layers = np.arange(1, shape[0] + 1)
         coords[dims[-3]] = layers
@@ -408,7 +413,7 @@ def testDataArray(shape=(3, 4, 4), time=False, rand=False, missing_vals=True):
     data = np.random.randint(0, 255, shape)
     attrs = {}
     if missing_vals:
-        attrs["nodatavals"] = (-32768.0, )
+        attrs["nodatavals"] = (-32768.0,)
         miss_ids = np.where(np.random.randint(2, size=shape) == 1)
         data[miss_ids] = attrs["nodatavals"][0]
     da = DataArray(data, coords, dims, attrs=attrs)
@@ -441,31 +446,34 @@ def _da_checker(da, z_value, coords_labels):
     try:
         from xarray import DataArray
     except ImportError:
-        raise ModuleNotFoundError(
-            "xarray must be installed to use this functionality")
+        raise ModuleNotFoundError("xarray must be installed to use this functionality")
 
     if not isinstance(da, DataArray):
         raise TypeError("da must be an instance of xarray.DataArray")
     if da.ndim not in [2, 3]:
         raise ValueError("da must be 2D or 3D")
-    if not (np.issubdtype(da.values.dtype, np.integer)
-            or np.issubdtype(da.values.dtype, np.floating)):
+    if not (
+        np.issubdtype(da.values.dtype, np.integer)
+        or np.issubdtype(da.values.dtype, np.floating)
+    ):
         raise ValueError("da must be an array of integers or float")
 
     # default dimensions
     def_labels = {
-        "x_label":
-        coords_labels["x_label"] if "x_label" in coords_labels else
-        ("x" if hasattr(da, "x") else "lon"),
-        "y_label":
-        coords_labels["y_label"] if "y_label" in coords_labels else
-        ("y" if hasattr(da, "y") else "lat"),
+        "x_label": coords_labels["x_label"]
+        if "x_label" in coords_labels
+        else ("x" if hasattr(da, "x") else "lon"),
+        "y_label": coords_labels["y_label"]
+        if "y_label" in coords_labels
+        else ("y" if hasattr(da, "y") else "lat"),
     }
 
     if da.ndim == 3:
-        def_labels["z_label"] = (coords_labels["z_label"]
-                                 if "z_label" in coords_labels else
-                                 ("band" if hasattr(da, "band") else "time"))
+        def_labels["z_label"] = (
+            coords_labels["z_label"]
+            if "z_label" in coords_labels
+            else ("band" if hasattr(da, "band") else "time")
+        )
 
         z_id = 1
         if z_value is None:
@@ -501,8 +509,7 @@ def _index2da(data, index, attrs, coords):
     try:
         from xarray import DataArray
     except ImportError:
-        raise ModuleNotFoundError(
-            "xarray must be installed to use this functionality")
+        raise ModuleNotFoundError("xarray must be installed to use this functionality")
 
     data = np.array(data).flatten()
     idx = index
@@ -562,13 +569,7 @@ def _idmap(ids, mask, dtype):
 
 @jit(nopython=True, fastmath=True)
 def _SWbuilder(
-    nrows,
-    ncols,
-    ids,
-    id_map,
-    criterion,
-    k,
-    dtype,
+    nrows, ncols, ids, id_map, criterion, k, dtype,
 ):
     """
     Computes data and orders rows, cols, data for a single chunk
@@ -608,13 +609,7 @@ def _SWbuilder(
 
 @jit(nopython=True, fastmath=True, nogil=True)
 def _compute_chunk(
-    nrows,
-    ncols,
-    ids,
-    id_map,
-    criterion,
-    k,
-    dtype,
+    nrows, ncols, ids, id_map, criterion, k, dtype,
 ):
     """
     Computes rows cols for a single chunk
@@ -656,8 +651,11 @@ def _compute_chunk(
     cols = np.empty_like(rows)
     ni = 0  # -> Pointer to store rows and cols in array
     for order in range(1, k + 1):
-        condition = ((order - 1) if criterion == "queen" else
-                     ((k - order) if ((k - order) < order) else (order - 1)))
+        condition = (
+            (order - 1)
+            if criterion == "queen"
+            else ((k - order) if ((k - order) < order) else (order - 1))
+        )
         for i in range(n):
             id_i = ids[i]
             og_id = id_map[id_i]
@@ -734,9 +732,7 @@ def _compute_chunk(
 
 @jit(nopython=True, fastmath=True)
 def _chunk_generator(
-    n_jobs,
-    starts,
-    ids,
+    n_jobs, starts, ids,
 ):
     """
     Construct chunks to iterate over within numba in parallel
@@ -759,19 +755,12 @@ def _chunk_generator(
     chunk_size = starts[1] - starts[0]
     for i in range(n_jobs):
         start = starts[i]
-        ids_chunk = ids[start:(start + chunk_size)]
-        yield (ids_chunk, )
+        ids_chunk = ids[start : (start + chunk_size)]
+        yield (ids_chunk,)
 
 
 def _parSWbuilder(
-    nrows,
-    ncols,
-    ids,
-    id_map,
-    criterion,
-    k,
-    dtype,
-    n_jobs,
+    nrows, ncols, ids, id_map, criterion, k, dtype, n_jobs,
 ):
     """
     Computes data and orders rows, cols, data in parallel using numba
@@ -814,8 +803,10 @@ def _parSWbuilder(
     starts = np.arange(n_jobs + 1) * chunk_size
     chunk = _chunk_generator(n_jobs, starts, ids)
     with parallel_backend("threading"):
-        worker_out = Parallel(n_jobs=n_jobs)(delayed(_compute_chunk)(
-            nrows, ncols, *ids, id_map, criterion, k, dtype) for ids in chunk)
+        worker_out = Parallel(n_jobs=n_jobs)(
+            delayed(_compute_chunk)(nrows, ncols, *ids, id_map, criterion, k, dtype)
+            for ids in chunk
+        )
     rows, cols = zip(*worker_out)
     rows = np.concatenate(rows)
     cols = np.concatenate(cols)

--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -1318,9 +1318,6 @@ class WSP(object):
     sparse : scipy.sparse.{matrix-type}
         NxN object from ``scipy.sparse``
 
-    id_order : list
-        An ordered list of ids, assumed to match the ordering in ``sparse``.
-
     Attributes
     ----------
 
@@ -1360,12 +1357,15 @@ class WSP(object):
             raise ValueError("Weights object must be square")
         self.sparse = sparse.tocsr()
         self.n = sparse.shape[0]
+        self._cache = {}
         if id_order:
             if len(id_order) != self.n:
                 raise ValueError(
                     "Number of values in id_order must match shape of sparse"
                 )
-        self.id_order = id_order
+            else:
+                self._id_order = id_order
+                self._cache["id_order"] = self._id_order
         # temp addition of index attribute
         import pandas as pd  # will be removed after refactoring is done
         if index is not None:
@@ -1378,7 +1378,19 @@ class WSP(object):
         else:
             index = pd.RangeIndex(self.n)
         self.index = index
-        self._cache = {}
+
+    @property
+    def id_order(self):
+        """An ordered list of ids, assumed to match the ordering in ``sparse``.
+        """
+        # Temporary solution until the refactoring is finished
+        if "id_order" not in self._cache:
+            if hasattr(self, "index"):
+                self._id_order = self.index.tolist()
+            else:
+                self._id_order = list(range(self.n))
+            self._cache["id_order"] = self._id_order
+        return self._id_order
 
     @property
     def s0(self):


### PR DESCRIPTION
This pull request adds the `id_order` as a property of the `WSP` class. It is complementary to the work added in [libpysal#343](https://github.com/pysal/libpysal/pull/343).

Background details of raster interface:

1. Earlier, `id_order` was used to map coordinate values (stored in `index` attribute) and the neighbors. It contained the list of indices (basically, `list(range(len(index)))`) in the int format to make the `W` object more memory efficient.
2. After some discussion, we decided to make it more backward compatible with the traditional model used in the libpysal. Therefore, `id_order` now holds the values of the `index` attribute in the form of a list (`index.tolist()`).
3. But after assigning `index.tolist()` to `id_order`, we observed that there was a significant performance loss when creating weights object (memory also takes a hit especially, when building `W` object) since the coordinates are stored as a list of tuples.

Making `id_order` as a property of the `WSP` class solved this problem to some extent since sparse weights only require `id_order` when building the `W` object. Though, it did not bring any improvements when creating a `W` object, which will be unusable when dealing with a large dataset.

Currently, I've added a warning when building the `W` object from raster. Until the refactoring is completed, maybe we can add a condition that allows `da2W` to continue its computation if the estimated memory usage of the function fits within the free memory.