### PR TITLE
Add missing endianness in WK1 reader.

### DIFF
--- a/libpysal/io/iohandlers/wk1.py
+++ b/libpysal/io/iohandlers/wk1.py
@@ -227,7 +227,7 @@ class Wk1IO(fileio.FileIO):
 
             if dtype in [13, 14, 16]:
                 self.file.read(1)
-                row, column = struct.unpack("2H", self.file.read(4))
+                row, column = struct.unpack("<2H", self.file.read(4))
                 format, length = "<d", 8
 
                 if dtype == 13:


### PR DESCRIPTION
1. [x] You have run tests on this submission locally using `pytest` on your changes. Continuous integration will be run on all PRs with [GitHub Actions](https://github.com/pysal/libpysal/blob/master/.github/workflows/unittests.yml), but it is good practice to test changes locally prior to a making a PR.
2. [x] This pull request is directed to the `pysal/master` branch.
3. [n/a] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [not possible] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [x] The justification for this PR is: 

Everything else unpacks in little-endian, except this one call. This breaks reading on big-endian systems.