### PR TITLE
classify repo as Python

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-language=Python


### PR DESCRIPTION
This PR classifies the `libpysal` repo as Python for search search results.