### PR TITLE
Fix test_voronoi on other architectures.

### DIFF
--- a/libpysal/cg/tests/test_voronoi.py
+++ b/libpysal/cg/tests/test_voronoi.py
@@ -1,6 +1,9 @@
+import unittest
+
+import numpy as np
+
 from ..voronoi import voronoi, voronoi_frames
 from ..shapes import Polygon, asShape
-import unittest
 
 
 class Voronoi(unittest.TestCase):
@@ -24,7 +27,7 @@ class Voronoi(unittest.TestCase):
         regions, vertices = voronoi(self.points)
         self.assertEqual(regions, [[1, 3, 2], [4, 5, 1, 0], [0, 1, 7, 6], [9, 0, 8]])
 
-        self.assertTrue(vertices.tolist() == self.vertices)
+        np.testing.assert_array_almost_equal(vertices, self.vertices)
 
     def test_voronoi_frames(self):
         r_df, p_df = voronoi_frames(self.points)


### PR DESCRIPTION
Floating point results shouldn't be checked exactly, as they might differ on other machines. This test currently fails on at least s390x and aarch64.