### PR TITLE
DOC: Fix several warnings during the build

### DIFF
--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -649,8 +649,8 @@ def construct_bounding_circles(alpha_shape, radius):
     """Construct the bounding circles for an alpha shape, given the radius
     computed from the `alpha_shape_auto` method.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     alpha_shape : shapely.Polygon
         An alpha-hull with the input radius.
 

--- a/libpysal/cg/ops/_accessors.py
+++ b/libpysal/cg/ops/_accessors.py
@@ -27,8 +27,8 @@ def get_attr(df, geom_col="geometry", inplace=False, attr=None):
 _doc_template = """
 Tabular accessor to grab a geometric object's {n} attribute.
 
-Arguments
----------
+Parameters
+----------
 df : pandas.DataFrame
     A pandas.Dataframe with a geometry column.
 geom_col : str

--- a/libpysal/cg/ops/_shapely.py
+++ b/libpysal/cg/ops/_shapely.py
@@ -56,8 +56,8 @@ def _atomic_op(df, geom_col="geometry", inplace=False, _func=None, **kwargs):
 _doc_template = """
 Tabular version of pysal.contrib.shapely_ext.{n}
 
-Arguments
----------
+Parameters
+----------
 df : pandas.DataFrame
     A pandas dataframe with a geometry column.
 geom_col : str

--- a/libpysal/weights/_contW_lists.py
+++ b/libpysal/weights/_contW_lists.py
@@ -45,8 +45,8 @@ class ContiguityWeightsLists:
 
     def __init__(self, collection, wttype=1):
         """
-        Arguments
-        =========
+        Parameters
+        ----------
 
         collection: PySAL PolygonCollection
 

--- a/libpysal/weights/contiguity.py
+++ b/libpysal/weights/contiguity.py
@@ -232,8 +232,8 @@ class Rook(W):
         Notes
         -----
         1. Lower order contiguities are also selected.
-        2. Returned object contains `index` attribute that includes a 
-        `Pandas.MultiIndex` object from the DataArray.
+        2. Returned object contains `index` attribute that includes a
+           `Pandas.MultiIndex` object from the DataArray.
 
         See Also
         --------
@@ -462,8 +462,8 @@ class Queen(W):
         Notes
         -----
         1. Lower order contiguities are also selected.
-        2. Returned object contains `index` attribute that includes a 
-        `Pandas.MultiIndex` object from the DataArray.
+        2. Returned object contains `index` attribute that includes a
+           `Pandas.MultiIndex` object from the DataArray.
 
         See Also
         --------

--- a/libpysal/weights/contiguity.py
+++ b/libpysal/weights/contiguity.py
@@ -533,8 +533,8 @@ def _from_dataframe(df, **kwargs):
     If the input dataframe is of any other geometry type than "Point",
     a value error is raised. 
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     df          :   pandas.DataFrame
                     dataframe containing point geometries for a 
                     voronoi diagram.
@@ -564,7 +564,7 @@ def _build(polygons, criterion="rook", ids=None):
     This is a developer-facing function to construct a spatial weights object. 
 
     Parameters
-    ---------
+    ----------
     polygons    : list
                   list of pysal polygons to use to build contiguity
     criterion   : string

--- a/libpysal/weights/raster.py
+++ b/libpysal/weights/raster.py
@@ -74,7 +74,7 @@ def da2W(
     -----
     1. Lower order contiguities are also selected.
     2. Returned object contains `index` attribute that includes a
-    `Pandas.MultiIndex` object from the DataArray.
+       `Pandas.MultiIndex` object from the DataArray.
 
     Examples
     --------
@@ -175,7 +175,7 @@ def da2WSP(
     -----
     1. Lower order contiguities are also selected.
     2. Returned object contains `index` attribute that includes a
-    `Pandas.MultiIndex` object from the DataArray.
+       `Pandas.MultiIndex` object from the DataArray.
 
     Examples
     --------

--- a/libpysal/weights/raster.py
+++ b/libpysal/weights/raster.py
@@ -307,7 +307,7 @@ def w2da(data, w, attrs={}, coords=None):
     Creates xarray.DataArray object from passed data aligned with W object.
 
     Parameters
-    ---------
+    ----------
     data : array/list/pd.Series
         1d array-like data with dimensionality conforming to w
     w : libpysal.weights.W
@@ -350,7 +350,7 @@ def wsp2da(data, wsp, attrs={}, coords=None):
     Creates xarray.DataArray object from passed data aligned with WSP object.
 
     Parameters
-    ---------
+    ----------
     data : array/list/pd.Series
         1d array-like data with dimensionality conforming to wsp
     wsp : libpysal.weights.WSP
@@ -393,7 +393,7 @@ def testDataArray(shape=(3, 4, 4), time=False, rand=False, missing_vals=True):
     Creates 2 or 3 dimensional test xarray.DataArray object
 
     Parameters
-    ---------
+    ----------
     shape : tuple
         Tuple containing shape of the DataArray aligned with
         following dimension = (lat, lon) or (layer, lat, lon)
@@ -515,7 +515,7 @@ def _index2da(data, index, attrs, coords):
     Creates xarray.DataArray object from passed data
 
     Parameters
-    ---------
+    ----------
     data : array/list/pd.Series
         1d array-like data with dimensionality conforming to index
     index : pd.MultiIndex

--- a/libpysal/weights/spatial_lag.py
+++ b/libpysal/weights/spatial_lag.py
@@ -194,8 +194,8 @@ def _resolve_ties(idx, normalized_labels, tally, neighbors, method, w):
     an attempt to break the tie, but if it fails, a random tiebreaker will be
     selected.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     idx                 : int
                           index (aligned with `normalized_labels`) of the 
                           current observation being resolved.

--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -182,8 +182,8 @@ class W(object):
 
         See libpysal.io.FileIO for more information. 
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         path    :   string
                     location to save the file
         format  :   string
@@ -203,8 +203,8 @@ class W(object):
         """
         Read a weights file into a W object. 
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         path    :   string
                     location to save the file
         format  :   string


### PR DESCRIPTION
Fixes these warnings during build:
```
libpysal-4.5.1.post2/libpysal/weights/contiguity.py:docstring of libpysal.weights.contiguity.Queen.from_xarray:61: WARNING: Enumerated list ends without a blank line; unexpected unindent.
libpysal-4.5.1.post2/libpysal/weights/contiguity.py:docstring of libpysal.weights.contiguity.Rook.from_xarray:61: WARNING: Enumerated list ends without a blank line; unexpected unindent.
libpysal-4.5.1.post2/libpysal/weights/raster.py:docstring of libpysal.weights.raster.da2W:59: WARNING: Enumerated list ends without a blank line; unexpected unindent.
libpysal-4.5.1.post2/libpysal/weights/raster.py:docstring of libpysal.weights.raster.da2WSP:56: WARNING: Enumerated list ends without a blank line; unexpected unindent.
```
and
```
/usr/lib/python3.10/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Arguments in the docstring of <bound method W.from_file of <class 'libpysal.weights.distance.DistanceBand'>> in /builddir/build/BUILD/libpysal-4.5.1.post2/libpysal/weights/weights.py.
  warn(msg)
/usr/lib/python3.10/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Arguments in the docstring of <function W.to_file at 0x7f4670c3cc10> in /builddir/build/BUILD/libpysal-4.5.1.post2/libpysal/weights/weights.py.
  warn(msg)
/usr/lib/python3.10/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Arguments in the docstring of <bound method W.from_file of <class 'libpysal.weights.distance.KNN'>> in /builddir/build/BUILD/libpysal-4.5.1.post2/libpysal/weights/weights.py.
  warn(msg)                                                                                                                                                                                  
/usr/lib/python3.10/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Arguments in the docstring of <function W.to_file at 0x7f4670c3cc10> in /builddir/build/BUILD/libpysal-4.5.1.post2/libpysal/weights/weights.py.
  warn(msg)
/usr/lib/python3.10/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Arguments in the docstring of <bound method W.from_file of <class 'libpysal.weights.distance.Kernel'>> in /builddir/build/BUILD/libpysal-4.5.1.post2/libpysal/weights/weights.py.
  warn(msg)
/usr/lib/python3.10/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Arguments in the docstring of <function W.to_file at 0x7f4670c3cc10> in /builddir/build/BUILD/libpysal-4.5.1.post2/libpysal/weights/weights.py.
  warn(msg)
/usr/lib/python3.10/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Arguments in the docstring of <bound method W.from_file of <class 'libpysal.weights.contiguity.Queen'>> in /builddir/build/BUILD/libpysal-4.5.1.post2/libpysal/weights/weights.py.
  warn(msg)
/usr/lib/python3.10/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Arguments in the docstring of <function W.to_file at 0x7f4670c3cc10> in /builddir/build/BUILD/libpysal-4.5.1.post2/libpysal/weights/weights.py.
  warn(msg)
/usr/lib/python3.10/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Arguments in the docstring of <bound method W.from_file of <class 'libpysal.weights.contiguity.Rook'>> in /builddir/build/BUILD/libpysal-4.5.1.post2/libpysal/weights/weights.py.
  warn(msg)
/usr/lib/python3.10/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Arguments in the docstring of <function W.to_file at 0x7f4670c3cc10> in /builddir/build/BUILD/libpysal-4.5.1.post2/libpysal/weights/weights.py.
  warn(msg)
/usr/lib/python3.10/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Arguments in the docstring of <bound method W.from_file of <class 'libpysal.weights.weights.W'>> in /builddir/build/BUILD/libpysal-4.5.1.post2/libpysal/weights/weights.py.
  warn(msg)
/usr/lib/python3.10/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Arguments in the docstring of <function W.to_file at 0x7f4670c3cc10> in /builddir/build/BUILD/libpysal-4.5.1.post2/libpysal/weights/weights.py.
  warn(msg)
/usr/lib/python3.10/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Arguments in the docstring of <bound method W.from_file of <class 'libpysal.weights.weights.W'>> in /builddir/build/BUILD/libpysal-4.5.1.post2/libpysal/weights/weights.py.
  warn(msg)
/usr/lib/python3.10/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Arguments in the docstring of <function W.to_file at 0x7f4670c3cc10> in /builddir/build/BUILD/libpysal-4.5.1.post2/libpysal/weights/weights.py.
  warn(msg)

libpysal-4.5.1.post2/libpysal/weights/raster.py:docstring of libpysal.weights.raster.testDataArray:5: WARNING: Title underline too short.
Parameters
---------
libpysal-4.5.1.post2/libpysal/weights/raster.py:docstring of libpysal.weights.raster.testDataArray:5: WARNING: Unexpected section title.
Parameters
---------
libpysal-4.5.1.post2/libpysal/weights/raster.py:docstring of libpysal.weights.raster.w2da:5: WARNING: Title underline too short.
Parameters
---------
libpysal-4.5.1.post2/libpysal/weights/raster.py:docstring of libpysal.weights.raster.w2da:5: WARNING: Unexpected section title.
Parameters
---------
libpysal-4.5.1.post2/libpysal/weights/raster.py:docstring of libpysal.weights.raster.wsp2da:5: WARNING: Title underline too short.
Parameters
---------
libpysal-4.5.1.post2/libpysal/weights/raster.py:docstring of libpysal.weights.raster.wsp2da:5: WARNING: Unexpected section title.
Parameters
---------
```