### PR TITLE
REF: update for shapely 2.0

### DIFF
--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -257,7 +257,7 @@ def build_faces(faces, triangles_is, num_triangles, num_faces_single):
 
 @jit
 def nb_mask_faces(mask, faces):
-    """ Run over each row in `faces`, if the face in the following row is the
+    """Run over each row in `faces`, if the face in the following row is the
     same, then mark both as False on `mask`
 
     Parameters
@@ -472,7 +472,7 @@ def alpha_shape(xys, alpha):
     if xys.shape[0] < 4:
         from shapely import ops, geometry as geom
 
-        return ops.cascaded_union([geom.Point(xy) for xy in xys]).convex_hull.buffer(0)
+        return ops.unary_union([geom.Point(xy) for xy in xys]).convex_hull.buffer(0)
     triangulation = spat.Delaunay(xys)
     triangles = xys[triangulation.simplices]
     a_pts = triangles[:, 0, :]

--- a/libpysal/cg/shapely_ext.py
+++ b/libpysal/cg/shapely_ext.py
@@ -51,14 +51,14 @@ SHAPE_TYPE_ERR = "%r does not appear to be a shape."
 def to_wkb(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     return o.to_wkb()
 
 
 def to_wkt(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     return o.to_wkt()
 
 
@@ -67,7 +67,7 @@ def to_wkt(shape):
 def area(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     return o.area
 
 
@@ -76,15 +76,15 @@ def distance(shape, other):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     return o.distance(o2)
 
 
 def length(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     return o.length
 
 
@@ -93,7 +93,7 @@ def length(shape):
 def boundary(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     res = o.boundary
     return asShape(res)
 
@@ -101,14 +101,14 @@ def boundary(shape):
 def bounds(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     return o.bounds
 
 
 def centroid(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     res = o.centroid
     return asShape(res)
 
@@ -116,7 +116,7 @@ def centroid(shape):
 def representative_point(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     res = o.representative_point()
     return asShape(res)
 
@@ -124,7 +124,7 @@ def representative_point(shape):
 def convex_hull(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     res = o.convex_hull
     return asShape(res)
 
@@ -132,7 +132,7 @@ def convex_hull(shape):
 def envelope(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     res = o.envelope
     return asShape(res)
 
@@ -140,7 +140,7 @@ def envelope(shape):
 def buffer(shape, radius, resolution=16):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     res = o.buffer(radius, resolution)
     return asShape(res)
 
@@ -148,7 +148,7 @@ def buffer(shape, radius, resolution=16):
 def simplify(shape, tolerance, preserve_topology=True):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     res = o.simplify(tolerance, preserve_topology)
     return asShape(res)
 
@@ -160,8 +160,8 @@ def difference(shape, other):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     res = o.difference(o2)
     return asShape(res)
 
@@ -171,8 +171,8 @@ def intersection(shape, other):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     res = o.intersection(o2)
     return asShape(res)
 
@@ -182,8 +182,8 @@ def symmetric_difference(shape, other):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     res = o.symmetric_difference(o2)
     return asShape(res)
 
@@ -193,8 +193,8 @@ def union(shape, other):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     res = o.union(o2)
     return asShape(res)
 
@@ -204,8 +204,8 @@ def cascaded_union(shapes):
     for shape in shapes:
         if not hasattr(shape, GEO_INTERFACE_ATTR):
             raise TypeError(SHAPE_TYPE_ERR % shape)
-        o.append(geom.asShape(shape))
-    res = shops.cascaded_union(o)
+        o.append(geom.shape(shape))
+    res = shops.unary_union(o)
     return asShape(res)
 
 
@@ -219,7 +219,7 @@ def unary_union(shapes):
     for shape in shapes:
         if not hasattr(shape, GEO_INTERFACE_ATTR):
             raise TypeError(SHAPE_TYPE_ERR % shape)
-        o.append(geom.asShape(shape))
+        o.append(geom.shape(shape))
     res = shops.unary_union(o)
     return asShape(res)
 
@@ -229,35 +229,35 @@ def unary_union(shapes):
 def has_z(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     return o.has_z
 
 
 def is_empty(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     return o.is_empty
 
 
 def is_ring(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     return o.is_ring
 
 
 def is_simple(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     return o.is_simple
 
 
 def is_valid(shape):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     return o.is_valid
 
 
@@ -268,8 +268,8 @@ def relate(shape, other):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     return o.relate(o2)
 
 
@@ -278,8 +278,8 @@ def contains(shape, other):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     return o.contains(o2)
 
 
@@ -288,8 +288,8 @@ def crosses(shape, other):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     return o.crosses(o2)
 
 
@@ -298,8 +298,8 @@ def disjoint(shape, other):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     return o.disjoint(o2)
 
 
@@ -308,8 +308,8 @@ def equals(shape, other):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     return o.equals(o2)
 
 
@@ -318,8 +318,8 @@ def intersects(shape, other):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     return o.intersects(o2)
 
 
@@ -328,8 +328,8 @@ def overlaps(shape, other):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     return o.overlaps(o2)
 
 
@@ -338,8 +338,8 @@ def touches(shape, other):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     return o.touches(o2)
 
 
@@ -348,8 +348,8 @@ def within(shape, other):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     return o.within(o2)
 
 
@@ -358,8 +358,8 @@ def equals_exact(shape, other, tolerance):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     return o.equals_exact(o2, tolerance)
 
 
@@ -368,8 +368,8 @@ def almost_equals(shape, other, decimal=6):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     return o.almost_equals(o2, decimal)
 
 
@@ -380,15 +380,15 @@ def project(shape, other, normalized=False):
         raise TypeError(SHAPE_TYPE_ERR % shape)
     if not hasattr(other, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
-    o2 = geom.asShape(other)
+    o = geom.shape(shape)
+    o2 = geom.shape(other)
     return o.project(o2, normalized)
 
 
 def interpolate(shape, distance, normalized=False):
     if not hasattr(shape, GEO_INTERFACE_ATTR):
         raise TypeError(SHAPE_TYPE_ERR % shape)
-    o = geom.asShape(shape)
+    o = geom.shape(shape)
     res = o.interpolate(distance, normalized)
     return asShape(res)
 

--- a/libpysal/io/geotable/utils.py
+++ b/libpysal/io/geotable/utils.py
@@ -6,7 +6,7 @@ from warnings import warn
 @_requires("geopandas")
 def to_df(df, geom_col="geometry", **kw):
     """Convert a ``geopandas.GeoDataFrame`` into a normal
-    ``pandas.DataFrame`` with a column containing PySAL shapes. 
+    ``pandas.DataFrame`` with a column containing PySAL shapes.
 
     Parameters
     ----------
@@ -22,12 +22,12 @@ def to_df(df, geom_col="geometry", **kw):
     -------
     df : pandas.DataFrame
         The data converted into a ``pandas.DataFrame`` object.
-    
+
     See Also
     --------
-    
+
     pandas.DataFrame
-    
+
     """
 
     import pandas as pd
@@ -54,23 +54,23 @@ def to_gdf(df, geom_col="geometry", **kw):
         The column name in ``df`` contains the geometry. Default is ``'geometry'``.
     **kw : dict
         Optional keyword arguments for ``geopandas.GeoDataFrame()``.
-    
+
     Returns
     -------
     gdf : geopandas.GeoDataFrame
         The data converted into a ``geopandas.GeoDataFrame`` object.
-    
+
     See Also
     --------
-    
+
     geopandas.GeoDataFrame
-    
+
     """
 
     from geopandas import GeoDataFrame
-    from shapely.geometry import asShape as sShape
+    from shapely.geometry import shape
 
-    df[geom_col] = df[geom_col].apply(sShape)
+    df[geom_col] = df[geom_col].apply(shape)
 
     gdf = GeoDataFrame(df, geometry=geom_col, **kw)
 

--- a/libpysal/weights/_contW_lists.py
+++ b/libpysal/weights/_contW_lists.py
@@ -18,7 +18,7 @@ def _get_verts(shape):
 def _get_boundary_points(shape):
     """
     Recursively handle polygons vs. multipolygons to
-    extract the boundary point set from each. 
+    extract the boundary point set from each.
     """
     if shape.type.lower() == "polygon":
         shape = shape.boundary
@@ -26,9 +26,9 @@ def _get_boundary_points(shape):
     elif shape.type.lower() == "linestring":
         return list(map(tuple, list(zip(*shape.coords.xy))))
     elif shape.type.lower() == "multilinestring":
-        return list(it.chain(*(list(zip(*shape.coords.xy)) for shape in shape)))
+        return list(it.chain(*(list(zip(*shape.coords.xy)) for shape in shape.geoms)))
     elif shape.type.lower() == "multipolygon":
-        return list(it.chain(*(_get_boundary_points(part.boundary) for part in shape)))
+        return list(it.chain(*(_get_boundary_points(part.boundary) for part in shape.geoms)))
     else:
         raise TypeError(
             "Input shape must be a Polygon, Multipolygon, LineString, "

--- a/libpysal/weights/tests/test_weights.py
+++ b/libpysal/weights/tests/test_weights.py
@@ -1,3 +1,6 @@
+import os
+import tempfile
+
 import unittest
 from ..weights import W, WSP
 from .. import util
@@ -346,8 +349,10 @@ class TestW(unittest.TestCase):
         assert disco.n_components == 2
 
     def test_roundtrip_write(self):
-        self.w.to_file("./tmp.gal")
-        new = W.from_file("./tmp.gal")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(str(tmpdir), "tmp.gal")
+            self.w.to_file(path)
+            new = W.from_file(path)
         np.testing.assert_array_equal(self.w.sparse.toarray(), new.sparse.toarray())
 
 

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -1,3 +1,4 @@
+from shapely.geometry.base import BaseGeometry
 from ..io.fileio import FileIO as psopen
 from .weights import W, WSP
 from .set_operations import w_subset
@@ -1070,7 +1071,14 @@ def get_points_array(iterable):
     """
     first_choice, backup = tee(iterable)
     try:
-        data = np.vstack([np.array(shape.centroid) for shape in first_choice])
+        data = np.vstack(
+            [
+                np.array(shape.centroid.coords)[0]
+                if isinstance(shape, BaseGeometry)
+                else np.array(shape.centroid)
+                for shape in first_choice
+            ]
+        )
     except AttributeError:
         data = np.vstack([shape for shape in backup])
     return data


### PR DESCRIPTION
This PR adapts the code to the upcoming shapely 2.0, which in practice means eliminating deprecation warnings coming from shapely 1.8rc1.

See the migration guide for details - https://shapely.readthedocs.io/en/latest/migration.html. My guess is that we will have to do similar actions in other repositories as well.

You can install shapely 1.8rc1 from conda-forge:

```
mamba update -c conda-forge/label/shapely_dev shapely
```