### PR TITLE
Bug fix for parallel execution environments

### DIFF
--- a/libpysal/examples/base.py
+++ b/libpysal/examples/base.py
@@ -39,7 +39,7 @@ def get_data_home():
     data_home = environ.get("PYSALDATA", join("~", PYSALDATA))
     data_home = expanduser(data_home)
     if not exists(data_home):
-        makedirs(data_home)
+        makedirs(data_home, exist_ok=True)
     return data_home
 
 


### PR DESCRIPTION
1. [No] Don't have dev environment setup, but tested functionality locally.
5. [Yes] The justification for this PR is: Have been hitting a rare bug here when deploying applications with many worker processes in a Kubernetes environment.  A bit of a race condition exists here where multiple workers attempt to create the directory but fail because another worker already created it, resulting in a crash loop.

