### PR TITLE
MAINT: replace LooseVersion with packaging

### DIFF
--- a/ci/37.yaml
+++ b/ci/37.yaml
@@ -17,3 +17,4 @@ dependencies:
   - geopandas>=0.7.0
   - numba
   - zstd
+  - packaging

--- a/ci/38.yaml
+++ b/ci/38.yaml
@@ -19,10 +19,10 @@ dependencies:
   - xarray
   - joblib
   - zstd
+  - packaging
   # for docs build action (this env only)
   - nbsphinx
   - numpydoc
   - sphinx>=1.4.3
   - sphinxcontrib-bibtex<2.0.0
   - sphinx_bootstrap_theme
-  

--- a/ci/39.yaml
+++ b/ci/39.yaml
@@ -19,10 +19,10 @@ dependencies:
   - xarray
   - joblib
   - zstd
+  - packaging
   # for docs build action (this env only)
   - nbsphinx
   - numpydoc
   - sphinx>=1.4.3
   - sphinxcontrib-bibtex<2.0.0
   - sphinx_bootstrap_theme
-  

--- a/environment.yml
+++ b/environment.yml
@@ -32,3 +32,4 @@ dependencies:
   - pytest-cov
   - descartes
   - mapclassify
+  - packaging

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -14,12 +14,12 @@ import numbers
 from collections import defaultdict
 from itertools import tee
 from ..common import requires
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 try:
     import geopandas as gpd
 
-    GPD_08 = str(gpd.__version__) >= LooseVersion("0.8.0")
+    GPD_08 = Version(gpd.__version__) >= Version("0.8.0")
 except ImportError:
     warn("geopandas not available. Some functionality will be disabled.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy>=1.3
 pandas
 requests
 scipy>=0.11
+packaging


### PR DESCRIPTION
`LooseVersion` is now deprecated, Python 3.10 warns about that. Using `packaging.version.Version` instead as suggested in the warning.