### PR TITLE
[WIP] Filter holes from alpha shape returns

### DIFF
--- a/ci/37.yaml
+++ b/ci/37.yaml
@@ -15,6 +15,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
+  - networkx=2.6
   # optional
   - geopandas>=0.7.0
   - joblib

--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -427,7 +427,7 @@ def alpha_geoms(alpha, triangles, radii, xys):
 
 
 @requires("geopandas", "shapely")
-def alpha_shape(xys, alpha, filter_holes=True):
+def alpha_shape(xys, alpha):
     """Alpha-shape delineation (Edelsbrunner, Kirkpatrick & Seidel, 1983) from a collection of points
 
     Parameters
@@ -483,8 +483,7 @@ def alpha_shape(xys, alpha, filter_holes=True):
     radii = r_circumcircle_triangle(a_pts, b_pts, c_pts)
     del triangles, a_pts, b_pts, c_pts
     geoms = alpha_geoms(alpha, triangulation.simplices, radii, xys)
-    if filter_holes:
-        geoms = _filter_holes(geoms, xys)
+    geoms = _filter_holes(geoms, xys)
     return geoms
 
 

--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -481,7 +481,7 @@ def alpha_shape(xys, alpha):
     radii = r_circumcircle_triangle(a_pts, b_pts, c_pts)
     del triangles, a_pts, b_pts, c_pts
     geoms = alpha_geoms(alpha, triangulation.simplices, radii, xys)
-    return geoms
+    return _filter_holes(geoms, xys)
 
 
 def _valid_hull(geoms, points):
@@ -703,6 +703,12 @@ def _construct_centers(a, b, radius):
     else:
         return down_x, down_y
 
+def _filter_holes(geoms, points):
+    if (geoms.interiors.apply(len) > 0).any():
+        from geopandas import points_from_xy
+        has_points, _ = points_from_xy(*points.T).sindex.query_bulk(geoms.values.data, predicate='contains')
+        geoms = geoms[geoms.index.isin(has_points)]
+    return geoms
 
 if __name__ == "__main__":
 

--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -6,10 +6,12 @@ by Tim Kittel (@timkittel) available at:
 
 Author(s):
     Dani Arribas-Bel daniel.arribas.bel@gmail.com
+    Levi John Wolf levi.john.wolf@gmail.com
 """
 
 import numpy as np
 import scipy.spatial as spat
+from scipy import sparse
 
 from ..common import requires, jit, HAS_JIT
 
@@ -380,7 +382,8 @@ def alpha_geoms(alpha, triangles, radii, xys):
     geoms : GeoSeries
         Polygon(s) resulting from the alpha shape algorithm. The GeoSeries
         object remains so even if only a single polygon is returned. There is
-        no CRS included in the object.
+        no CRS included in the object. Also note that holes are included in addition
+        to exteriors. 
 
     Examples
     --------
@@ -424,7 +427,7 @@ def alpha_geoms(alpha, triangles, radii, xys):
 
 
 @requires("geopandas", "shapely")
-def alpha_shape(xys, alpha):
+def alpha_shape(xys, alpha, filter_holes=True):
     """Alpha-shape delineation (Edelsbrunner, Kirkpatrick & Seidel, 1983) from a collection of points
 
     Parameters
@@ -481,7 +484,9 @@ def alpha_shape(xys, alpha):
     radii = r_circumcircle_triangle(a_pts, b_pts, c_pts)
     del triangles, a_pts, b_pts, c_pts
     geoms = alpha_geoms(alpha, triangulation.simplices, radii, xys)
-    return _filter_holes(geoms, xys)
+    if filter_holes:
+        geoms = _filter_holes(geoms, xys)
+    return geoms
 
 
 def _valid_hull(geoms, points):
@@ -704,11 +709,32 @@ def _construct_centers(a, b, radius):
         return down_x, down_y
 
 def _filter_holes(geoms, points):
+    """
+    Filter hole polygons using a computational geometry solution
+    """
     if (geoms.interiors.apply(len) > 0).any():
-        from geopandas import points_from_xy
-        has_points, _ = points_from_xy(*points.T).sindex.query_bulk(geoms.values.data, predicate='contains')
-        geoms = geoms[geoms.index.isin(has_points)]
+        from shapely.geometry import Polygon
+        # Extract the "shell", or outer ring of the polygon. 
+        shells = geoms.exterior.apply(Polygon)
+        # Compute which original geometries are within each shell, self-inclusive
+        inside, outside = shells.sindex.query_bulk(geoms, predicate='within')
+        # Now, create the sparse matrix relating the inner geom (rows) 
+        # to the outer shell (cols) and take the sum. 
+        # A z-order of 1 means the polygon is only inside if its own exterior. This means it's a polygon.
+        # A z-order of 2 means the polygon is inside of exactly one other exterior. Because
+        #   the hull generation method is restricted to be planar, this means the polygon is a hole. 
+        # In general, an even z-order means that the polygon is always exactly matched to one exterior. 
+        #   This means that the polygon forms the exterior of a hole. 
+        # In general, an odd z-order means that there is an uneven number of exteriors. 
+        #   This means the polygon is filled. 
+        zorder = sparse.csc_matrix((np.ones_like(inside), (inside, outside))).sum(axis=1)
+        zorder = np.asarray(zorder).flatten()
+        # Keep only the odd z-orders
+        to_include = (zorder % 2).astype(bool)
+        geoms = geoms[to_include]
     return geoms
+
+
 
 if __name__ == "__main__":
 

--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -474,7 +474,6 @@ def alpha_shape(xys, alpha, filter_holes=True):
         warn(NUMBA_WARN)
     if xys.shape[0] < 4:
         from shapely import ops, geometry as geom
-
         return ops.unary_union([geom.Point(xy) for xy in xys]).convex_hull.buffer(0)
     triangulation = spat.Delaunay(xys)
     triangles = xys[triangulation.simplices]

--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -356,7 +356,7 @@ def get_single_faces(triangles_is):
 
 
 @requires("geopandas", "shapely")
-def alpha_geoms(alpha, triangles, radii, xys):
+def _alpha_geoms(alpha, triangles, radii, xys):
     """Generate alpha-shape polygon(s) from `alpha` value, vertices of
     `triangles`, the `radii` for all points, and the points themselves
 
@@ -380,10 +380,9 @@ def alpha_geoms(alpha, triangles, radii, xys):
     -------
 
     geoms : GeoSeries
-        Polygon(s) resulting from the alpha shape algorithm. The GeoSeries
-        object remains so even if only a single polygon is returned. There is
-        no CRS included in the object. Also note that holes are included in addition
-        to exteriors. 
+        Polygon(s) resulting from the alpha shape algorithm, in a GeoSeries.
+        The output is a GeoSeries even if only a single polygon is returned. There is
+        no CRS included in the returned GeoSeries.
 
     Examples
     --------
@@ -446,7 +445,8 @@ def alpha_shape(xys, alpha):
     shapes : GeoSeries
          Polygon(s) resulting from the alpha shape algorithm. The GeoSeries
          object remains so even if only a single polygon is returned. There is
-         no CRS included in the object.
+         no CRS included in the object. Note that the returned shape(s) may
+         have holes, as per the definition of the shape in Edselbrunner et al. (1983)
 
     Examples
     --------
@@ -474,6 +474,7 @@ def alpha_shape(xys, alpha):
         warn(NUMBA_WARN)
     if xys.shape[0] < 4:
         from shapely import ops, geometry as geom
+
         return ops.unary_union([geom.Point(xy) for xy in xys]).convex_hull.buffer(0)
     triangulation = spat.Delaunay(xys)
     triangles = xys[triangulation.simplices]
@@ -482,7 +483,7 @@ def alpha_shape(xys, alpha):
     c_pts = triangles[:, 2, :]
     radii = r_circumcircle_triangle(a_pts, b_pts, c_pts)
     del triangles, a_pts, b_pts, c_pts
-    geoms = alpha_geoms(alpha, triangulation.simplices, radii, xys)
+    geoms = _alpha_geoms(alpha, triangulation.simplices, radii, xys)
     geoms = _filter_holes(geoms, xys)
     return geoms
 
@@ -529,12 +530,12 @@ def alpha_shape_auto(
 
     This method uses the algorithm proposed by  Edelsbrunner, Kirkpatrick &
     Seidel (1983) to return the tightest polygon that contains all points in
-    `xys`. The algorithm ranks every point based on its radious and iterates
+    `xys`. The algorithm ranks every point based on its radius and iterates
     over each point, checking whether the maximum alpha that would keep the
     point and all the other ones in the set with smaller radii results in a
     single polygon. If that is the case, it moves to the next point;
     otherwise, it retains the previous alpha value and returns the polygon
-    as `shapely` geometry.
+    as `shapely` geometry. Note that this geometry may have holes.
 
     Parameters
     ----------
@@ -619,7 +620,7 @@ def alpha_shape_auto(
     radii_sorted_i = radii.argsort()
     triangles = triangulation.simplices[radii_sorted_i][::-1]
     radii = radii[radii_sorted_i][::-1]
-    geoms_prev = alpha_geoms((1 / radii.max()) - EPS, triangles, radii, xys)
+    geoms_prev = _alpha_geoms((1 / radii.max()) - EPS, triangles, radii, xys)
     if HAS_PYGEOS:
         points = pygeos.points(xys)
     else:
@@ -631,7 +632,7 @@ def alpha_shape_auto(
         alpha = (1 / radi) - EPS
         if verbose:
             print("%.2f%% | Trying a = %f" % ((i + 1) / radii.shape[0], alpha))
-        geoms = alpha_geoms(alpha, triangles, radii, xys)
+        geoms = _alpha_geoms(alpha, triangles, radii, xys)
         if _valid_hull(geoms, points):
             geoms_prev = geoms
             radi_prev = radi
@@ -706,32 +707,35 @@ def _construct_centers(a, b, radius):
     else:
         return down_x, down_y
 
+
 def _filter_holes(geoms, points):
     """
     Filter hole polygons using a computational geometry solution
     """
     if (geoms.interiors.apply(len) > 0).any():
         from shapely.geometry import Polygon
-        # Extract the "shell", or outer ring of the polygon. 
+
+        # Extract the "shell", or outer ring of the polygon.
         shells = geoms.exterior.apply(Polygon)
         # Compute which original geometries are within each shell, self-inclusive
-        inside, outside = shells.sindex.query_bulk(geoms, predicate='within')
-        # Now, create the sparse matrix relating the inner geom (rows) 
-        # to the outer shell (cols) and take the sum. 
+        inside, outside = shells.sindex.query_bulk(geoms, predicate="within")
+        # Now, create the sparse matrix relating the inner geom (rows)
+        # to the outer shell (cols) and take the sum.
         # A z-order of 1 means the polygon is only inside if its own exterior. This means it's not a hole.
         # A z-order of 2 means the polygon is inside of exactly one other exterior. Because
-        #   the hull generation method is restricted to be planar, this means the polygon is a hole. 
-        # In general, an even z-order means that the polygon is always exactly matched to one exterior, 
+        #   the hull generation method is restricted to be planar, this means the polygon is a hole.
+        # In general, an even z-order means that the polygon is always exactly matched to one exterior,
         #   plus some number of intermediate exterior-hole pairs. Therefore, the polygon is a hole.
-        # In general, an odd z-order means that there is an uneven number of exteriors. 
-        #   This means the polygon is not a hole. 
-        zorder = sparse.csc_matrix((np.ones_like(inside), (inside, outside))).sum(axis=1)
+        # In general, an odd z-order means that there is an uneven number of exteriors.
+        #   This means the polygon is not a hole.
+        zorder = sparse.csc_matrix((np.ones_like(inside), (inside, outside))).sum(
+            axis=1
+        )
         zorder = np.asarray(zorder).flatten()
-        # Keep only the odd z-orders
+        # Keep only the odd z-orders
         to_include = (zorder % 2).astype(bool)
         geoms = geoms[to_include]
     return geoms
-
 
 
 if __name__ == "__main__":

--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -719,13 +719,13 @@ def _filter_holes(geoms, points):
         inside, outside = shells.sindex.query_bulk(geoms, predicate='within')
         # Now, create the sparse matrix relating the inner geom (rows) 
         # to the outer shell (cols) and take the sum. 
-        # A z-order of 1 means the polygon is only inside if its own exterior. This means it's a polygon.
+        # A z-order of 1 means the polygon is only inside if its own exterior. This means it's not a hole.
         # A z-order of 2 means the polygon is inside of exactly one other exterior. Because
         #   the hull generation method is restricted to be planar, this means the polygon is a hole. 
-        # In general, an even z-order means that the polygon is always exactly matched to one exterior. 
-        #   This means that the polygon forms the exterior of a hole. 
+        # In general, an even z-order means that the polygon is always exactly matched to one exterior, 
+        #   plus some number of intermediate exterior-hole pairs. Therefore, the polygon is a hole.
         # In general, an odd z-order means that there is an uneven number of exteriors. 
-        #   This means the polygon is filled. 
+        #   This means the polygon is not a hole. 
         zorder = sparse.csc_matrix((np.ones_like(inside), (inside, outside))).sum(axis=1)
         zorder = np.asarray(zorder).flatten()
         # Keep only the odd z-orders

--- a/libpysal/cg/tests/test_ashapes.py
+++ b/libpysal/cg/tests/test_ashapes.py
@@ -100,10 +100,10 @@ class Test_Alpha_Shapes(TestCase):
         np.testing.assert_allclose(centers, self.circle_verts)
     
     def test_holes(self):
-        numpy.random.seed(seed=100)
-        points = numpy.random.rand(1000, 2)*100
+        np.random.seed(seed=100)
+        points = np.random.rand(1000, 2)*100
         inv_alpha = 3.5
-        geoms = libpysal.cg.alpha_shape(points, 1/inv_alpha)
+        geoms = alpha_shape(points, 1/inv_alpha)
         assert len(geoms) == 1
         holes = geopandas.GeoSeries(geoms.interiors.explode()).reset_index(drop=True)
         assert len(holes) == 30

--- a/libpysal/cg/tests/test_ashapes.py
+++ b/libpysal/cg/tests/test_ashapes.py
@@ -98,3 +98,20 @@ class Test_Alpha_Shapes(TestCase):
         ashape, radius, centers = alpha_shape_auto(self.vertices, return_circles=True)
         np.testing.assert_allclose(radius, self.circle_radii)
         np.testing.assert_allclose(centers, self.circle_verts)
+    
+    def test_holes(self):
+        numpy.random.seed(seed=100)
+        points = numpy.random.rand(1000, 2)*100
+        inv_alpha = 3.5
+        geoms = libpysal.cg.alpha_shape(points, 1/inv_alpha)
+        assert len(geoms) == 1
+        holes = geopandas.GeoSeries(geoms.interiors.explode()).reset_index(drop=True)
+        assert len(holes) == 30
+        # No holes are within the shape (shape has holes already)
+        result = geoms.sindex.query_bulk(holes.centroid, predicate='within')
+        assert result.shape == (2,0)
+        # All holes are within the exterior
+        shell = geopandas.GeoSeries(geoms.exterior.apply(geometry.Polygon))
+        within, outside = shell.sindex.query_bulk(holes.centroid, predicate='within')
+        assert (outside == 0).all()
+        np.testing.assert_array_equal(within, np.arange(30))


### PR DESCRIPTION
Noted by @cornhundred in #456, we've got some surprising behavior for alpha shapes with holes. This attempts to fix this in the `alpha_shape()` function by (1) checking if there are any "holes" in the shapely polygons and, if there are, (2) we only keep polygons that contain an input point. 

This solves the problem OK, but I think there's a bit of an issue: 
![Figure_1](https://user-images.githubusercontent.com/2250995/152013682-dde961c5-46f4-4144-818b-a8b00b385647.png)

Note that this results in two separate polygons-with-holes on the left, but on the right, we retain one of the holes because a point falls within it... I think this happens because the "correct" polygon for that hole would have a zero-area "cut in" that only includes that point. When we use `shapely.ops.polygonize`, we lose that cut in, and thus omit the vertex from the alpha shape. 

Consider this box with a "cut in" from [1,1] to [.5,.5]:

```python
lines = [
         LineString([[0, 0], [0, 1]]), # 1
         LineString([[0, 1], [1, 1]]), # 2
         LineString([[0, 0], [1, 0]]), # 6
         LineString([[1, 0], [1, 1]]), # 3
         LineString([[1, 1], [0.5, 0.5]]), # 4 
         LineString([[0.5, 0.5], [1, 1]]), # 5
        ]
```
upon polygonization, we lose that cut-in:
```python
from shapely.ops import polygonize
geom = polygonize(lines)
geom.wkt
```
`geom` is now `'POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'` with no mention of the cut-in. 
This is good, since a polygon with this kind of cut-in is an invalid polygon, but it complicates our testing here... not all holes are empty. 

The other way to do this would be to do an all-pairs `within` check for the polygons using `geoms.sindex.query_bulk()`. I was hoping the point-in-poly woudl be faster, but... but you never know. I'll check that & re-submit. 