### PR TITLE
update nx conversions to be 3.0 compatible

### DIFF
--- a/libpysal/weights/tests/test_nx.py
+++ b/libpysal/weights/tests/test_nx.py
@@ -13,17 +13,17 @@ except ImportError:
 class Test_NetworkXConverter(ut.TestCase):
     def setUp(self):
         self.known_nx = nx.random_regular_graph(4, 10, seed=8879)
-        self.known_amat = np.array(nx.to_numpy_matrix(self.known_nx))
+        self.known_amat = nx.to_numpy_array(self.known_nx)
         self.known_W = lat2W(5, 5)
 
     def test_round_trip(self):
         W_ = W.from_networkx(self.known_nx)
         np.testing.assert_allclose(W_.sparse.toarray(), self.known_amat)
         nx2 = W_.to_networkx()
-        np.testing.assert_allclose(nx.to_numpy_matrix(nx2), self.known_amat)
+        np.testing.assert_allclose(nx.to_numpy_array(nx2), self.known_amat)
         nxsquare = self.known_W.to_networkx()
         np.testing.assert_allclose(
-            self.known_W.sparse.toarray(), nx.to_numpy_matrix(nxsquare)
+            self.known_W.sparse.toarray(), nx.to_numpy_array(nxsquare)
         )
         W_square = W.from_networkx(nxsquare)
         np.testing.assert_allclose(

--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -348,7 +348,7 @@ class W(object):
         except ImportError:
             raise ImportError("NetworkX is required to use this function.")
         G = nx.DiGraph() if len(self.asymmetries) > 0 else nx.Graph()
-        return nx.from_scipy_sparse_matrix(self.sparse, create_using=G)
+        return nx.from_scipy_sparse_array(self.sparse, create_using=G)
 
     @classmethod
     def from_networkx(cls, graph, weight_col="weight"):
@@ -371,8 +371,8 @@ class W(object):
             import networkx as nx
         except ImportError:
             raise ImportError("NetworkX is required to use this function.")
-        sparse_matrix = nx.to_scipy_sparse_matrix(graph)
-        w = WSP(sparse_matrix).to_W()
+        sparse_array = nx.to_scipy_sparse_array(graph)
+        w = WSP(sparse_array).to_W()
         return w
 
     @property
@@ -584,7 +584,7 @@ class W(object):
     def pct_nonzero(self):
         """Percentage of nonzero weights."""
         if "pct_nonzero" not in self._cache:
-            self._pct_nonzero = 100.0 * self.sparse.nnz / (1.0 * self._n ** 2)
+            self._pct_nonzero = 100.0 * self.sparse.nnz / (1.0 * self._n**2)
             self._cache["pct_nonzero"] = self._pct_nonzero
         return self._pct_nonzero
 


### PR DESCRIPTION
Greeting! I am one of the NetworkX core developers. We are preparing to move to NetworkX 3.0 soon and that mostly involves removing a lot of deprecated code. As part of this update, we are dropping support for numpy matrices and scipy sparse matrices in favor of numpy arrays and scipy sparse arrays. While removing the old code from our own repo we discovered that some of our examples, which use libpysal, weren't working since functions such as `nx.from_scipy_sparse_matrix` and `nx.to_numpy_matrix` were still being used internally to libpysal. 

I've composed a simple PR which should ensure that libpysal remains compatible with networkx 3.0 by using the drop-in replacements for the removed functions. All of the tests are passing for me locally, so the changes don't seem to cause any issues. 

If you have any more questions about the upcoming networkx 3.0 update please ask myself, @rossbar, @dschult or @jarrodmillman.