### PR TITLE
Platformdirs

### DIFF
--- a/ci/310.yaml
+++ b/ci/310.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.10
-  - appdirs
+  - platformdirs
   - beautifulsoup4
   - jinja2
   - pandas>=1.0

--- a/ci/37-minimal.yaml
+++ b/ci/37-minimal.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - appdirs
+  - platformdirs
   - beautifulsoup4
   - jinja2
   - pandas>=1.0

--- a/ci/37.yaml
+++ b/ci/37.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - appdirs
+  - platformdirs
   - beautifulsoup4
   - jinja2
   - pandas>=1.0

--- a/ci/38.yaml
+++ b/ci/38.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
-  - appdirs
+  - platformdirs
   - beautifulsoup4
   - jinja2
   - pandas>=1.0

--- a/ci/39.yaml
+++ b/ci/39.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
-  - appdirs
+  - platformdirs
   - beautifulsoup4
   - jinja2
   - pandas>=1.0

--- a/libpysal/examples/base.py
+++ b/libpysal/examples/base.py
@@ -10,7 +10,7 @@ import os
 import webbrowser
 from os import environ, makedirs
 from os.path import exists, expanduser, join
-from appdirs import user_data_dir
+from platformdirs import user_data_dir
 import zipfile
 import requests
 import pandas

--- a/libpysal/examples/tests/test_available.py
+++ b/libpysal/examples/tests/test_available.py
@@ -34,8 +34,8 @@ class Testexamples(unittest.TestCase):
         elif os_name == 'Windows':
             heads = head.split("\\")
             self.assertEqual(heads[1], 'Users')
-            self.assertEqual(heads[-1], 'Local')
-            self.assertEqual(heads[-2], 'AppData')
+            self.assertEqual(heads[-2], 'Local')
+            self.assertEqual(heads[-3], 'AppData')
 
 suite = unittest.TestLoader().loadTestsFromTestCase(Testexamples)
 

--- a/libpysal/examples/tests/test_available.py
+++ b/libpysal/examples/tests/test_available.py
@@ -31,6 +31,11 @@ class Testexamples(unittest.TestCase):
             self.assertEqual(heads[1], 'Users')
             self.assertEqual(heads[-1], 'Application Support')
             self.assertEqual(heads[-2], 'Library')
+        elif os_name == 'Windows':
+            heads = head.split("\\")
+            self.assertEqual(heads[1], 'Users')
+            self.assertEqual(heads[-1], 'Local')
+            self.assertEqual(heads[-2], 'AppData')
 
 suite = unittest.TestLoader().loadTestsFromTestCase(Testexamples)
 

--- a/libpysal/examples/tests/test_available.py
+++ b/libpysal/examples/tests/test_available.py
@@ -1,20 +1,38 @@
 #!/usr/bin/env python3
 
 import os
+import platform
 import unittest
 import numpy as np
 import pandas
 
 from .. import available
+from ..base import get_data_home
 
-class Testavailable(unittest.TestCase):
+os_name = platform.system()
+
+class Testexamples(unittest.TestCase):
 
     def test_available(self):
         examples = available()
         self.assertEqual(type(examples), pandas.core.frame.DataFrame)
 
+    def test_data_home(self): 
+        pth = get_data_home()
+        head, tail = os.path.split(pth)
+        self.assertEqual(tail, 'pysal')
+        if os_name == 'Linux':
+            heads = head.split("/")
+            self.assertEqual(heads[1], 'home')
+            self.assertEqual(heads[-1], 'share')
+            self.assertEqual(heads[-2], '.local')
+        elif os_name == 'Darwin':
+            heads = head.split("/")
+            self.assertEqual(heads[1], 'Users')
+            self.assertEqual(heads[-1], 'Application Support')
+            self.assertEqual(heads[-2], 'Library')
 
-suite = unittest.TestLoader().loadTestsFromTestCase(Testavailable)
+suite = unittest.TestLoader().loadTestsFromTestCase(Testexamples)
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-appdirs
+platformdirs
 beautifulsoup4
 jinja2
 numpy>=1.3


### PR DESCRIPTION
`platformdirs` is the [apparent successor]( https://github.com/ActiveState/appdirs/issues/79) to `appdirs`.

This moves to `platformdirs` and adds test coverage.