### PR TITLE
test against shapely prerelease

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,7 +19,7 @@
      strategy:
        matrix:
          os: ['ubuntu-latest']
-         environment-file: [ci/37-minimal.yaml, ci/37.yaml, ci/38.yaml, ci/39.yaml, ci/310.yaml]
+         environment-file: [ci/37-minimal.yaml, ci/37.yaml, ci/38.yaml, ci/39.yaml, ci/310.yaml, ci/310_shapely20b1.yaml]
          include:
            - environment-file: ci/310.yaml
              os: macos-latest
@@ -35,6 +35,7 @@
          with:
            environment-file: ${{ matrix.environment-file }}
            micromamba-version: 'latest'
+           channel-priority: 'flexible'
 
        - name: run tests - bash
          shell: bash -l {0}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,12 +19,13 @@
      strategy:
        matrix:
          os: ['ubuntu-latest']
-         environment-file: [ci/37-minimal.yaml, ci/37.yaml, ci/38.yaml, ci/39.yaml, ci/310.yaml, ci/310_shapely20b1.yaml]
+         environment-file: [ci/37-minimal.yaml, ci/37.yaml, ci/38.yaml, ci/39.yaml, ci/310.yaml, ci/310_shapely_dev.yaml]
          include:
            - environment-file: ci/310.yaml
              os: macos-latest
            - environment-file: ci/310.yaml
              os: windows-latest
+       fail-fast: false
 
      steps:
        - name: checkout repo

--- a/ci/310_shapely20b1.yaml
+++ b/ci/310_shapely20b1.yaml
@@ -1,0 +1,33 @@
+name: test
+channels:
+  - conda-forge
+  - conda-forge/label/shapely_dev
+dependencies:
+  - python=3.10
+  - platformdirs
+  - beautifulsoup4
+  - jinja2
+  - pandas>=1.0
+  - scipy>=1.0
+  - xarray
+  # testing
+  - codecov
+  - matplotlib
+  - pytest
+  - pytest-cov
+  - pytest-xdist
+  # optional
+  - geopandas>=0.12.0
+  - joblib
+  - networkx
+  - numba
+  - packaging
+  - shapely==2.0b1
+  - xarray
+  - zstd
+  # for docs build action (this env only)
+  - nbsphinx
+  - numpydoc
+  - sphinx
+  - sphinxcontrib-bibtex
+  - sphinx_bootstrap_theme

--- a/ci/310_shapely_dev.yaml
+++ b/ci/310_shapely_dev.yaml
@@ -22,7 +22,7 @@ dependencies:
   - networkx
   - numba
   - packaging
-  - shapely==2.0b1
+  - shapely>=2.0b1
   - xarray
   - zstd
   # for docs build action (this env only)


### PR DESCRIPTION
This PR tests against `shapely==2.0b1` while excluding `pygeos`

xref https://github.com/pysal/spaghetti/issues/678, https://github.com/pysal/spaghetti/issues/679