### PR TITLE
Fix Linux user path test

### DIFF
--- a/libpysal/examples/tests/test_available.py
+++ b/libpysal/examples/tests/test_available.py
@@ -23,10 +23,12 @@ class Testexamples(unittest.TestCase):
         head, tail = os.path.split(pth)
         self.assertEqual(tail, "pysal")
         if os_name == "Linux":
-            heads = head.split("/")
-            self.assertEqual(heads[1], "home")
-            self.assertEqual(heads[-1], "share")
-            self.assertEqual(heads[-2], ".local")
+            if "XDG_DATA_HOME" in os.environ:
+                self.assertEqual(head, os.environ["XDG_DATA_HOME"])
+            else:
+                heads = head.split("/")
+                self.assertEqual(heads[-1], "share")
+                self.assertEqual(heads[-2], ".local")
         elif os_name == "Darwin":
             heads = head.split("/")
             self.assertEqual(heads[1], "Users")


### PR DESCRIPTION
1. [x] You have run tests on this submission locally using `pytest` on your changes. Continuous integration will be run on all PRs with [GitHub Actions](https://github.com/pysal/libpysal/blob/master/.github/workflows/unittests.yml), but it is good practice to test changes locally prior to a making a PR.
2. [x] This pull request is directed to the `pysal/master` branch.
3. [n/a] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [ ] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [ ] The justification for this PR is: 

There is no requirement that user directories start with `/home`. In
fact, if `XDG_DATA_HOME` is set, there's no guarantee of anything
checked in this test.