### PR TITLE
Fix warnings from Sphinx

### DIFF
--- a/libpysal/weights/contiguity.py
+++ b/libpysal/weights/contiguity.py
@@ -38,7 +38,7 @@ class Rook(W):
                 optional arguments for :class:`pysal.weights.W`
 
     See Also
-    ---------
+    --------
     :class:`libpysal.weights.weights.W`
     """
 

--- a/libpysal/weights/distance.py
+++ b/libpysal/weights/distance.py
@@ -580,7 +580,7 @@ class Kernel(W):
         Kernel Weights Object
 
         See Also
-        ---------
+        --------
         :class:`libpysal.weights.weights.W`
         """
         points = get_points_array_from_shapefile(filepath)
@@ -860,7 +860,7 @@ class DistanceBand(W):
                       name of column in shapefile's DBF to use for ids
 
         Returns
-        --------
+        -------
         Kernel Weights Object
 
         """

--- a/libpysal/weights/gabriel.py
+++ b/libpysal/weights/gabriel.py
@@ -23,8 +23,8 @@ class Delaunay(W):
     a graph from the input set of points. Will be slower without numba,
     and will warn if this is missing. 
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     coordinates :   array of points, (N,2)
         numpy array of coordinates containing locations to compute the
         delaunay triangulation
@@ -79,8 +79,8 @@ class Delaunay(W):
         Polygons or lines must be converted to points (e.g. using 
         df.geometry.centroid).
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         df  :   geopandas.GeoDataFrame
             GeoDataFrame containing points to construct the Delaunay 
             Triangulation. 
@@ -114,13 +114,14 @@ class Gabriel(Delaunay):
 
     For a link (i,j) connecting node i to j in the Delaunay triangulation
     to be retained in the Gabriel graph, it must pass a point set exclusion test:
+
     1. Construct the circle C_ij containing link (i,j) as its diameter
     2. If any other node k is contained within C_ij, then remove link (i,j) 
        from the graph. 
     3. Once all links are evaluated, the remaining graph is the Gabriel graph. 
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     coordinates :   array of points, (N,2)
         numpy array of coordinates containing locations to compute the
         delaunay triangulation
@@ -159,8 +160,8 @@ class Relative_Neighborhood(Delaunay):
     This means that the points are at least as close to one another 
     as they are to any other point. 
     
-    Arguments
-    ---------
+    Parameters
+    ----------
     coordinates :   array of points, (N,2)
         numpy array of coordinates containing locations to compute the
         delaunay triangulation

--- a/libpysal/weights/spintW.py
+++ b/libpysal/weights/spintW.py
@@ -211,7 +211,7 @@ def vecW(
 
 
     Returns
-    ------
+    -------
     W           : DistanceBand W object that uses 4-dimenional distances between
                   vectors origin and destination coordinates.
 


### PR DESCRIPTION
1. [x] You have run tests on this submission locally using `pytest` on your changes. Continuous integration will be run on all PRs with [GitHub Actions](https://github.com/pysal/libpysal/blob/master/.github/workflows/unittests.yml), but it is good practice to test changes locally prior to a making a PR.
2. [x] This pull request is directed to the `pysal/master` branch.
3. [n/a] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [n/a] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [x] The justification for this PR is: 
Sphinx warns about incorrect underlines and unknown section names.