### PR TITLE
Move WSP2W into weights.py

### DIFF
--- a/libpysal/weights/contiguity.py
+++ b/libpysal/weights/contiguity.py
@@ -1,6 +1,7 @@
 import itertools
 
 import numpy
+import warnings
 
 from ..cg import voronoi_frames
 from ..io.fileio import FileIO
@@ -96,6 +97,10 @@ class Rook(W):
         :class:`libpysal.weights.weights.W`
         :class:`libpysal.weights.contiguity.Rook`
         """
+        warnings.warn(
+            "`from_shapefile` will be deprecated in" "a future version of libpysal.",
+            FutureWarning,
+        )
         sparse = kwargs.pop("sparse", False)
         if idVariable is not None:
             ids = get_ids(filepath, idVariable)
@@ -158,7 +163,7 @@ class Rook(W):
                       an ordered list of ids to use to index the spatial weights
                       object. If used, the resulting weights object will iterate
                       over results in the order of the names provided in this
-                      argument. 
+                      argument.
 
         See Also
         --------
@@ -227,7 +232,7 @@ class Rook(W):
         Returns
         -------
         w : libpysal.weights.W/libpysal.weights.WSP
-            instance of spatial weights class W or WSP with an index attribute 
+            instance of spatial weights class W or WSP with an index attribute
 
         Notes
         -----
@@ -322,6 +327,10 @@ class Queen(W):
         :class:`libpysal.weights.weights.W`
         :class:`libpysal.weights.contiguity.Queen`
         """
+        warnings.warn(
+            "`from_shapefile` will be deprecated in" "a future version of libpysal.",
+            FutureWarning,
+        )
         sparse = kwargs.pop("sparse", False)
         if idVariable is not None:
             ids = get_ids(filepath, idVariable)
@@ -382,7 +391,7 @@ class Queen(W):
                       an ordered list of ids to use to index the spatial weights
                       object. If used, the resulting weights object will iterate
                       over results in the order of the names provided in this
-                      argument. 
+                      argument.
 
         See Also
         --------
@@ -457,7 +466,7 @@ class Queen(W):
         Returns
         -------
         w : libpysal.weights.W/libpysal.weights.WSP
-            instance of spatial weights class W or WSP with an index attribute 
+            instance of spatial weights class W or WSP with an index attribute
 
         Notes
         -----
@@ -526,17 +535,17 @@ def Voronoi(points, criterion="rook", clip="ahull", **kwargs):
 
 def _from_dataframe(df, **kwargs):
     """
-    Construct a voronoi contiguity weight directly from a dataframe. 
+    Construct a voronoi contiguity weight directly from a dataframe.
     Note that if criterion='rook', this is identical to the delaunay
-    graph for the points. 
+    graph for the points.
 
     If the input dataframe is of any other geometry type than "Point",
-    a value error is raised. 
+    a value error is raised.
 
     Parameters
     ----------
     df          :   pandas.DataFrame
-                    dataframe containing point geometries for a 
+                    dataframe containing point geometries for a
                     voronoi diagram.
 
     Returns
@@ -561,14 +570,14 @@ Voronoi.from_dataframe = _from_dataframe
 
 def _build(polygons, criterion="rook", ids=None):
     """
-    This is a developer-facing function to construct a spatial weights object. 
+    This is a developer-facing function to construct a spatial weights object.
 
     Parameters
     ----------
     polygons    : list
                   list of pysal polygons to use to build contiguity
     criterion   : string
-                  option of which kind of contiguity to build. Is either "rook" or "queen" 
+                  option of which kind of contiguity to build. Is either "rook" or "queen"
     ids         : list
                   list of ids to use to index the neighbor dictionary
 
@@ -576,12 +585,12 @@ def _build(polygons, criterion="rook", ids=None):
     -------
     tuple containing (neighbors, ids), where neighbors is a dictionary
     describing contiguity relations and ids is the list of ids used to index
-    that dictionary. 
+    that dictionary.
 
     NOTE: this is different from the prior behavior of buildContiguity, which
           returned an actual weights object. Since this just dispatches for the
           classes above, this returns the raw ingredients for a spatial weights
-          object, not the object itself. 
+          object, not the object itself.
     """
     if ids and len(ids) != len(set(ids)):
         raise ValueError(
@@ -621,7 +630,7 @@ def buildContiguity(polygons, criterion="rook", ids=None):
     This is a deprecated function.
 
     It builds a contiguity W from the polygons provided. As such, it is now
-    identical to calling the class constructors for Rook or Queen. 
+    identical to calling the class constructors for Rook or Queen.
     """
     # Warn('This function is deprecated. Please use the Rook or Queen classes',
     #        UserWarning)

--- a/libpysal/weights/distance.py
+++ b/libpysal/weights/distance.py
@@ -16,6 +16,7 @@ from warnings import warn as Warn
 from scipy.spatial import distance_matrix
 import scipy.sparse as sp
 import numpy as np
+import warnings
 
 
 def knnW(data, k=2, p=2, ids=None, radius=None, distance_metric="euclidean"):
@@ -83,20 +84,20 @@ class KNN(W):
     Notes
     -----
 
-    Ties between neighbors of equal distance are arbitrarily broken. 
+    Ties between neighbors of equal distance are arbitrarily broken.
 
-    Further, if many points occupy the same spatial location (i.e. observations are 
-    coincident), then you may need to increase k for those observations to 
+    Further, if many points occupy the same spatial location (i.e. observations are
+    coincident), then you may need to increase k for those observations to
     acquire neighbors at different spatial locations. For example, if five
     points are coincident, then their four nearest neighbors will all
     occupy the same spatial location; only the fifth nearest neighbor will
     result in those coincident points becoming connected to the graph as a
-    whole. 
+    whole.
 
     Solutions to this problem include jittering the points (by adding
-    a small random value to each observation's location) or by adding 
+    a small random value to each observation's location) or by adding
     higher-k neighbors only to the coincident points, using the
-    weights.w_sets.w_union() function. 
+    weights.w_sets.w_union() function.
 
     See Also
     --------
@@ -214,6 +215,10 @@ class KNN(W):
         --------
         :class:`libpysal.weights.weights.W`
         """
+        warnings.warn(
+            "`from_shapefile` will be deprecated in" "a future version of libpysal.",
+            FutureWarning,
+        )
         return cls(get_points_array_from_shapefile(filepath), *args, **kwargs)
 
     @classmethod
@@ -583,6 +588,10 @@ class Kernel(W):
         ---------
         :class:`libpysal.weights.weights.W`
         """
+        warnings.warn(
+            "`from_shapefile` will be deprecated in" "a future version of libpysal.",
+            FutureWarning,
+        )
         points = get_points_array_from_shapefile(filepath)
         if idVariable is not None:
             ids = get_ids(filepath, idVariable)
@@ -691,13 +700,13 @@ class Kernel(W):
         elif self.function == "uniform":
             self.kernel = [np.ones(zi.shape) * 0.5 for zi in zs]
         elif self.function == "quadratic":
-            self.kernel = [(3.0 / 4) * (1 - zi ** 2) for zi in zs]
+            self.kernel = [(3.0 / 4) * (1 - zi**2) for zi in zs]
         elif self.function == "quartic":
-            self.kernel = [(15.0 / 16) * (1 - zi ** 2) ** 2 for zi in zs]
+            self.kernel = [(15.0 / 16) * (1 - zi**2) ** 2 for zi in zs]
         elif self.function == "gaussian":
             c = np.pi * 2
             c = c ** (-0.5)
-            self.kernel = [c * np.exp(-(zi ** 2) / 2.0) for zi in zs]
+            self.kernel = [c * np.exp(-(zi**2) / 2.0) for zi in zs]
         else:
             print(("Unsupported kernel function", self.function))
 
@@ -864,6 +873,10 @@ class DistanceBand(W):
         Kernel Weights Object
 
         """
+        warnings.warn(
+            "`from_shapefile` will be deprecated in" "a future version of libpysal.",
+            FutureWarning,
+        )
         points = get_points_array_from_shapefile(filepath)
         if idVariable is not None:
             ids = get_ids(filepath, idVariable)

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -24,6 +24,7 @@ except ImportError:
 
 try:
     from shapely.geometry.base import BaseGeometry
+
     HAS_SHAPELY = True
 except ImportError:
     HAS_SHAPELY = False
@@ -38,7 +39,6 @@ __all__ = [
     "remap_ids",
     "full2W",
     "full",
-    "WSP2W",
     "insert_diagonal",
     "fill_diagonal",
     "get_ids",
@@ -534,17 +534,17 @@ def higher_order_sp(
         )
 
     if lower_order:
-        wk = sum(map(lambda x: w ** x, range(2, k + 1)))
+        wk = sum(map(lambda x: w**x, range(2, k + 1)))
         shortest_path = False
     else:
-        wk = w ** k
+        wk = w**k
 
     rk, ck = wk.nonzero()
     sk = set(zip(rk, ck))
 
     if shortest_path:
         for j in range(1, k):
-            wj = w ** j
+            wj = w**j
             rj, cj = wj.nonzero()
             sj = set(zip(rj, cj))
             sk.difference_update(sj)
@@ -785,72 +785,6 @@ def full2W(m, ids=None, **kwargs):
     return W(neighbors, weights, id_order=ids, **kwargs)
 
 
-def WSP2W(wsp, **kwargs):
-
-    """
-    Convert a pysal WSP object (thin weights matrix) to a pysal W object.
-
-    Parameters
-    ----------
-    wsp                     : WSP
-                              PySAL sparse weights object
-    **kwargs                : keyword arguments
-                              optional arguments for :class:`pysal.weights.W`
-
-    Returns
-    -------
-    w       : W
-              PySAL weights object
-
-    Examples
-    --------
-    >>> from libpysal.weights import lat2W, WSP, WSP2W
-
-    Build a 10x10 scipy.sparse matrix for a rectangular 2x5 region of cells
-    (rook contiguity), then construct a PySAL sparse weights object (wsp).
-
-    >>> sp = lat2SW(2, 5)
-    >>> wsp = WSP(sp)
-    >>> wsp.n
-    10
-    >>> wsp.sparse[0].todense()
-    matrix([[0, 1, 0, 0, 0, 1, 0, 0, 0, 0]], dtype=int8)
-
-    Convert this sparse weights object to a standard PySAL weights object.
-
-    >>> w = WSP2W(wsp)
-    >>> w.n
-    10
-    >>> print(w.full()[0][0])
-    [0. 1. 0. 0. 0. 1. 0. 0. 0. 0.]
-
-
-    """
-    wsp.sparse
-    indices = wsp.sparse.indices
-    data = wsp.sparse.data
-    indptr = wsp.sparse.indptr
-    id_order = wsp.id_order
-    if id_order:
-        # replace indices with user IDs
-        indices = [id_order[i] for i in indices]
-    else:
-        id_order = list(range(wsp.n))
-    neighbors, weights = {}, {}
-    start = indptr[0]
-    for i in range(wsp.n):
-        oid = id_order[i]
-        end = indptr[i + 1]
-        neighbors[oid] = indices[start:end]
-        weights[oid] = data[start:end]
-        start = end
-    ids = copy.copy(wsp.id_order)
-    w = W(neighbors, weights, ids, **kwargs)
-    w._sparse = copy.deepcopy(wsp.sparse)
-    w._cache["sparse"] = w._sparse
-    return w
-
-
 def insert_diagonal(w, val=1.0, wsp=False):
     warn("This function is deprecated. Use fill_diagonal instead.")
     return fill_diagonal(w, val=val, wsp=wsp)
@@ -1086,12 +1020,7 @@ def get_points_array(iterable):
                 ]
             )
         else:
-            data = np.vstack(
-                [
-                    np.array(shape.centroid)
-                    for shape in first_choice
-                ]
-            )
+            data = np.vstack([np.array(shape.centroid) for shape in first_choice])
     except AttributeError:
         data = np.vstack([shape for shape in backup])
     return data

--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -41,8 +41,8 @@ class W(object):
        This can be set after creation by setting the ``id_order`` property.
     silence_warnings : bool
        By default ``libpysal`` will print a warning if the dataset contains
-       any disconnected components or islands. To silence this warning set this
-       parameter to ``True``.
+       any disconnected components or isolates. To silence this
+       warning set this parameter to ``True``.
     ids : list
         Values to use for keys of the neighbors and weights ``dict`` objects.
 
@@ -59,7 +59,7 @@ class W(object):
     id2i
     id_order
     id_order_set
-    islands
+    isolates
     max_neighbors
     mean_neighbors
     min_neighbors
@@ -83,13 +83,17 @@ class W(object):
     --------
 
     >>> from libpysal.weights import W
-    >>> neighbors = {0: [3, 1], 1: [0, 4, 2], 2: [1, 5], 3: [0, 6, 4], 4: [1, 3, 7, 5], 5: [2, 4, 8], 6: [3, 7], 7: [4, 6, 8], 8: [5, 7]}
-    >>> weights = {0: [1, 1], 1: [1, 1, 1], 2: [1, 1], 3: [1, 1, 1], 4: [1, 1, 1, 1], 5: [1, 1, 1], 6: [1, 1], 7: [1, 1, 1], 8: [1, 1]}
+    >>> neighbors = {0: [3, 1], 1: [0, 4, 2], 2: [1, 5], 3: [0, 6, 4],
+                     4: [1, 3, 7, 5], 5: [2, 4, 8], 6: [3, 7],
+                     7: [4, 6, 8], 8: [5, 7]}
+    >>> weights = {0: [1, 1], 1: [1, 1, 1], 2: [1, 1], 3: [1, 1, 1],
+                   4: [1, 1, 1, 1], 5: [1, 1, 1], 6: [1, 1], 7: [1, 1, 1],
+                   8: [1, 1]}
     >>> w = W(neighbors, weights)
     >>> "%.3f"%w.pct_nonzero
     '29.630'
 
-    Read from external `.gal file <https://geodacenter.github.io/workbook/4a_contig_weights/lab4a.html#gal-weights-file>`_.
+    Read from external .gal file
 
     >>> import libpysal
     >>> w = libpysal.io.open(libpysal.examples.get_path("stl.gal")).read()
@@ -100,7 +104,9 @@ class W(object):
 
     Set weights implicitly.
 
-    >>> neighbors = {0: [3, 1], 1: [0, 4, 2], 2: [1, 5], 3: [0, 6, 4], 4: [1, 3, 7, 5], 5: [2, 4, 8], 6: [3, 7], 7: [4, 6, 8], 8: [5, 7]}
+    >>> neighbors = {0: [3, 1], 1: [0, 4, 2], 2: [1, 5], 3: [0, 6, 4],
+                     4: [1, 3, 7, 5], 5: [2, 4, 8], 6: [3, 7], 7: [4, 6, 8],
+                     8: [5, 7]}
     >>> w = W(neighbors)
     >>> round(w.pct_nonzero,3)
     29.63
@@ -121,14 +127,14 @@ class W(object):
     >>> w.histogram
     [(2, 4), (3, 392), (4, 9604)]
 
-    Disconnected observations (islands):
+    Disconnected observations (isolates):
 
     >>> from libpysal.weights import W
     >>> w = W({1:[0],0:[1],2:[], 3:[]})
 
     UserWarning: The weights matrix is not fully connected:
     There are 3 disconnected components.
-    There are 2 islands with ids: 2, 3.
+    There are 2 isolates with ids: 2, 3.
 
     """
 
@@ -221,13 +227,16 @@ class W(object):
 
     @classmethod
     def from_shapefile(cls, *args, **kwargs):
-        # we could also just "do the right thing," but I think it'd make sense to
-        # try and get people to use `Rook.from_shapefile(shapefile)` rather than
-        # W.from_shapefile(shapefile, type=`rook`), otherwise we'd need to build
-        # a type dispatch table. Generic W should be for stuff we don't know
-        # anything about.
+        # we could also just "do the right thing," but I think it'd
+        # make sense to try and get people to use
+        # `Rook.from_shapefile(shapefile)` rather than
+        # W.from_shapefile(shapefile, type=`rook`), otherwise we'd
+        # need to build a type dispatch table. Generic W should be for
+        # stuff we don't know anything about.
+
         raise NotImplementedError(
-            "Use type-specific constructors, like Rook, Queen, DistanceBand, or Kernel"
+            "Use type-specific constructors, like Rook, \
+             DistanceBand, or Kernel"
         )
 
     @classmethod
@@ -313,12 +322,17 @@ class W(object):
             )
         if (drop_islands is None) and not (self.silence_warnings):
             warnings.warn(
-                "In the next version of libpysal, observations with no neighbors will be included in adjacency lists as loops (row with the same focal and neighbor) with zero weight. In the current version, observations with no neighbors are dropped. If you would like to keep the current behavior, use drop_islands=True in this function",
+                "In the next version of libpysal, observations with no \
+                neighbors will be included in adjacency lists as loops \
+                (row with the same focal and neighbor) with zero \
+                weight. In the current version, observations with no \
+                neighbors are dropped. If you would like to keep the \
+                current behavior, use drop_islands=True in this \
+                function",
                 DeprecationWarning,
             )
             drop_islands = True
 
-        links = []
         focal_ix, neighbor_ix = self.sparse.nonzero()
         names = np.asarray(self.id_order)
         focal = names[focal_ix]
@@ -346,7 +360,10 @@ class W(object):
         try:
             import networkx as nx
         except ImportError:
-            raise ImportError("NetworkX 2.7+ is required to use this function.")
+            raise ImportError(
+                "NetworkX 2.7+ is required to \
+            use this function."
+            )
         G = nx.DiGraph() if len(self.asymmetries) > 0 else nx.Graph()
         return nx.from_scipy_sparse_array(self.sparse, create_using=G)
 
@@ -370,7 +387,10 @@ class W(object):
         try:
             import networkx as nx
         except ImportError:
-            raise ImportError("NetworkX 2.7+ is required to use this function.")
+            raise ImportError(
+                "NetworkX 2.7+ is required to \
+            use this function."
+            )
         sparse_array = nx.to_scipy_sparse_array(graph)
         w = WSP(sparse_array).to_W()
         return w
@@ -648,12 +668,21 @@ class W(object):
         return self._asymmetries
 
     @property
-    def islands(self):
+    def islands(self):  # remove in meta 23.06
         """List of ids without any neighbors."""
+        warnings.warn("islands is deprecated. Use isolates.")
         if "islands" not in self._cache:
             self._islands = [i for i, c in list(self.cardinalities.items()) if c == 0]
             self._cache["islands"] = self._islands
         return self._islands
+
+    @property
+    def isolates(self):
+        """List of ids without any neighbors."""
+        if "isolates" not in self._cache:
+            self._isolates = [i for i, c in list(self.cardinalities.items()) if c == 0]
+            self._cache["isolates"] = self._isolates
+        return self._isolates
 
     @property
     def histogram(self):
@@ -741,8 +770,8 @@ class W(object):
         old_ids = self._id_order
         if len(old_ids) != len(new_ids):
             raise Exception(
-                "W.remap_ids: length of `old_ids` does not match             that of"
-                " new_ids"
+                "W.remap_ids: length of `old_ids` does not match \
+                that of new_ids"
             )
         if len(set(new_ids)) != len(new_ids):
             raise Exception("W.remap_ids: list `new_ids` contains duplicates")
@@ -973,7 +1002,7 @@ class W(object):
                     row_sum = sum(wijs) * 1.0
                     if row_sum == 0.0:
                         if not self.silence_warnings:
-                            print(("WARNING: ", i, " is an island (no neighbors)"))
+                            print(("WARNING: ", i, " is an isolate."))
                     weights[i] = [wij / row_sum for wij in wijs]
                 weights = weights
                 self.transformations[value] = weights
@@ -1009,7 +1038,6 @@ class W(object):
                 # variance stabilizing
                 weights = {}
                 q = {}
-                k = self.cardinalities
                 s = {}
                 Q = 0.0
                 self.weights = self.transformations["O"]
@@ -1072,7 +1100,10 @@ class W(object):
         []
         >>> w.transform='r'
         >>> w.asymmetry()
-        [(0, 1), (0, 3), (1, 0), (1, 2), (1, 4), (2, 1), (2, 5), (3, 0), (3, 4), (3, 6), (4, 1), (4, 3), (4, 5), (4, 7), (5, 2), (5, 4), (5, 8), (6, 3), (6, 7), (7, 4), (7, 6), (7, 8), (8, 5), (8, 7)]
+        [(0, 1), (0, 3), (1, 0), (1, 2), (1, 4), (2, 1), (2, 5), (3,
+        0), (3, 4), (3, 6), (4, 1), (4, 3), (4, 5), (4, 7), (5, 2),
+        (5, 4), (5, 8), (6, 3), (6, 7), (7, 4), (7, 6), (7, 8), (8,
+        5), (8, 7)]
         >>> result = w.asymmetry(intrinsic=False)
         >>> result
         []
@@ -1138,7 +1169,8 @@ class W(object):
         Examples
         --------
         >>> from libpysal.weights import W, full
-        >>> neighbors = {'first':['second'],'second':['first','third'],'third':['second']}
+        >>> neighbors = {'first':['second'],'second':['first','third'],
+        'third':['second']}
         >>> weights = {'first':[1],'second':[1,1],'third':[1]}
         >>> w = W(neighbors, weights)
         >>> wf, ids = full(w)
@@ -1168,7 +1200,8 @@ class W(object):
         Examples
         --------
         >>> from libpysal.weights import W, WSP
-        >>> neighbors={'first':['second'],'second':['first','third'],'third':['second']}
+        >>> neighbors={'first':['second'],'second':['first','third'],
+        'third':['second']}
         >>> weights={'first':[1],'second':[1,1],'third':[1]}
         >>> w=W(neighbors,weights)
         >>> wsp=w.to_WSP()
@@ -1219,7 +1252,8 @@ class W(object):
         Parameters
         ----------
         gdf : geopandas.GeoDataFrame
-            The original shapes whose topological relations are modelled in ``W``.
+            The original shapes whose topological relations are modelled
+            in ``W``.
         indexed_on : str
             Column of ``geopandas.GeoDataFrame`` that the weights object uses
             as an index. Default is ``None``, so the index of the
@@ -1261,7 +1295,8 @@ class W(object):
         >>> import geopandas
         >>> gdf = geopandas.read_file(lp.examples.get_path("columbus.shp"))
         >>> weights = Queen.from_dataframe(gdf)
-        >>> tmp = weights.plot(gdf, color='firebrickred', node_kws=dict(marker='*', color='k'))
+        >>> tmp = weights.plot(gdf, color='firebrickred',
+                               node_kws=dict(marker='*', color='k'))
         """
         try:
             import matplotlib.pyplot as plt
@@ -1373,17 +1408,25 @@ class WSP(object):
 
         if index is not None:
             if not isinstance(index, (pd.Index, pd.MultiIndex, pd.RangeIndex)):
-                raise TypeError("index must be an instance of pandas.Index dtype")
+                raise TypeError(
+                    "index must be an instance of \
+                pandas.Index dtype"
+                )
             if len(index) != self.n:
-                raise ValueError("Number of values in index must match shape of sparse")
+                raise ValueError(
+                    "Number of values in index must \
+                match shape of sparse"
+                )
         else:
             index = pd.RangeIndex(self.n)
         self.index = index
 
     @property
     def id_order(self):
-        """An ordered list of ids, assumed to match the ordering in ``sparse``."""
+        """An ordered list of ids, assumed to match the ordering
+        in ``sparse``."""
         # Temporary solution until the refactoring is finished
+
         if "id_order" not in self._cache:
             if hasattr(self, "index"):
                 self._id_order = self.index.tolist()
@@ -1504,3 +1547,69 @@ class WSP(object):
         w._sparse = copy.deepcopy(self.sparse)
         w._cache["sparse"] = w._sparse
         return w
+
+
+def WSP2W(wsp, **kwargs):
+
+    """
+    Convert a pysal WSP object (thin weights matrix) to a pysal W object.
+
+    Parameters
+    ----------
+    wsp                     : WSP
+                              PySAL sparse weights object
+    **kwargs                : keyword arguments
+                              optional arguments for :class:`pysal.weights.W`
+
+    Returns
+    -------
+    w       : W
+              PySAL weights object
+
+    Examples
+    --------
+    >>> from libpysal.weights import lat2W, WSP, WSP2W
+
+    Build a 10x10 scipy.sparse matrix for a rectangular 2x5 region of cells
+    (rook contiguity), then construct a PySAL sparse weights object (wsp).
+
+    >>> sp = lat2SW(2, 5)
+    >>> wsp = WSP(sp)
+    >>> wsp.n
+    10
+    >>> wsp.sparse[0].todense()
+    matrix([[0, 1, 0, 0, 0, 1, 0, 0, 0, 0]], dtype=int8)
+
+    Convert this sparse weights object to a standard PySAL weights object.
+
+    >>> w = WSP2W(wsp)
+    >>> w.n
+    10
+    >>> print(w.full()[0][0])
+    [0. 1. 0. 0. 0. 1. 0. 0. 0. 0.]
+
+
+    """
+    wsp.sparse
+    indices = wsp.sparse.indices
+    data = wsp.sparse.data
+    indptr = wsp.sparse.indptr
+    id_order = wsp.id_order
+    if id_order:
+        # replace indices with user IDs
+        indices = [id_order[i] for i in indices]
+    else:
+        id_order = list(range(wsp.n))
+    neighbors, weights = {}, {}
+    start = indptr[0]
+    for i in range(wsp.n):
+        oid = id_order[i]
+        end = indptr[i + 1]
+        neighbors[oid] = indices[start:end]
+        weights[oid] = data[start:end]
+        start = end
+    ids = copy.copy(wsp.id_order)
+    w = W(neighbors, weights, ids, **kwargs)
+    w._sparse = copy.deepcopy(wsp.sparse)
+    w._cache["sparse"] = w._sparse
+    return w


### PR DESCRIPTION
`WSP2W` was not imported so https://github.com/pysal/libpysal/blob/master/libpysal/weights/weights.py#L235 would fail. However, importing results in problems with circular imports. So the solution here is to add that function to `weights.py`.

This also starts some deprecation.