### PR TITLE
Reverting w.id_order

### DIFF
--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -437,12 +437,13 @@ class W(object):
 
         links = []
         focal_ix, neighbor_ix = self.sparse.nonzero()
+        names = np.asarray(self.id_order)
+        focal = names[focal_ix]
+        neighbor = names[neighbor_ix]
         idxs = np.array(list(self.neighbors.keys()))
-        focal_ix = idxs[focal_ix]
-        neighbor_ix = idxs[neighbor_ix]
         weights = self.sparse.data
         adjlist = pandas.DataFrame(
-            {focal_col: focal_ix, neighbor_col: neighbor_ix, weight_col: weights}
+            {focal_col: focal, neighbor_col: neighbor, weight_col: weights}
         )
         if remove_symmetric:
             adjlist = adjtools.filter_adjlist(adjlist)


### PR DESCRIPTION
#510 appears to result in several [esda failures](https://github.com/pysal/esda/issues/239) when `shapely>=2.0b1`.

This reverts #510 to make debugging those failures more transparent.