### PR TITLE
TEST: 3.11 dev coverage

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -24,6 +24,7 @@
             ci/39.yaml,
             ci/310.yaml,
             ci/310_shapely_dev.yaml
+            ci/311_shapely_dev.yaml
          ]
          include:
            - environment-file: ci/310.yaml

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -23,7 +23,7 @@
             ci/38.yaml,
             ci/39.yaml,
             ci/310.yaml,
-            ci/310_shapely_dev.yaml
+            ci/310_shapely_dev.yaml,
             ci/311_shapely_dev.yaml
          ]
          include:

--- a/ci/311_shapely_dev.yaml
+++ b/ci/311_shapely_dev.yaml
@@ -1,0 +1,33 @@
+name: test
+channels:
+  - conda-forge
+  - conda-forge/label/shapely_dev
+dependencies:
+  - python=3.11
+  - platformdirs
+  - beautifulsoup4
+  - jinja2
+  - pandas>=1.0
+  - scipy>=1.0
+  - xarray
+  # testing
+  - codecov
+  - matplotlib
+  - pytest
+  - pytest-cov
+  - pytest-xdist
+  # optional
+  - geopandas>=0.12.0
+  - joblib
+  - networkx
+  - numba
+  - packaging
+  - shapely>=2.0b1
+  - xarray
+  - zstd
+  # for docs build action (this env only)
+  - nbsphinx
+  - numpydoc
+  - sphinx
+  - sphinxcontrib-bibtex
+  - sphinx_bootstrap_theme

--- a/ci/311_shapely_dev.yaml
+++ b/ci/311_shapely_dev.yaml
@@ -1,7 +1,6 @@
 name: test
 channels:
   - conda-forge
-  - conda-forge/label/shapely_dev
 dependencies:
   - python=3.11
   - platformdirs

--- a/ci/311_shapely_dev.yaml
+++ b/ci/311_shapely_dev.yaml
@@ -20,7 +20,6 @@ dependencies:
   - geopandas>=0.12.0
   - joblib
   - networkx
-  - numba
   - packaging
   - shapely>=2.0b1
   - xarray


### PR DESCRIPTION
This adds testing for shapely_dev under 3.11 to help with debugging of:

- https://github.com/pysal/esda/issues/239
- https://github.com/pysal/spopt/issues/346