### PR TITLE
[DO NOT MERGE] Change to the new sparse arrays and see what breaks

### DIFF
--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -731,9 +731,7 @@ def _filter_holes(geoms, points):
         #   plus some number of intermediate exterior-hole pairs. Therefore, the polygon is a hole.
         # In general, an odd z-order means that there is an uneven number of exteriors.
         #   This means the polygon is not a hole.
-        zorder = sparse.csc_matrix((np.ones_like(inside), (inside, outside))).sum(
-            axis=1
-        )
+        zorder = sparse.csc_array((np.ones_like(inside), (inside, outside))).sum(axis=1)
         zorder = np.asarray(zorder).flatten()
         # Keep only the odd z-orders
         to_include = (zorder % 2).astype(bool)

--- a/libpysal/cg/kdtree.py
+++ b/libpysal/cg/kdtree.py
@@ -311,4 +311,4 @@ class Arc_KDTree(temp_KDTree):
         # print D.data
         a2l = lambda x: sphere.linear2arcdist(x, self.radius)
         # print map(a2l,D.data)
-        return scipy.sparse.coo_matrix((list(map(a2l, D.data)), (D.row, D.col))).todok()
+        return scipy.sparse.coo_array((list(map(a2l, D.data)), (D.row, D.col))).todok()

--- a/libpysal/io/iohandlers/gal.py
+++ b/libpysal/io/iohandlers/gal.py
@@ -148,7 +148,7 @@ class GalIO(fileio.FileIO):
             ids = np.unique(row)
             row = np.array([np.where(ids == j)[0] for j in row]).flatten()
             col = np.array([np.where(ids == j)[0] for j in col]).flatten()
-            spmat = sparse.csr_matrix((data, (row, col)), shape=(n, n))
+            spmat = sparse.csr_array((data, (row, col)), shape=(n, n))
 
             w = WSP(spmat)
 

--- a/libpysal/weights/distance.py
+++ b/libpysal/weights/distance.py
@@ -894,7 +894,6 @@ class DistanceBand(W):
     def from_dataframe(
         cls, df, threshold, geom_col=None, ids=None, use_index=True, **kwargs
     ):
-
         """
         Make DistanceBand weights from a dataframe.
 
@@ -970,7 +969,7 @@ class DistanceBand(W):
         if threshold is not None:
             zeros = dist > threshold
             dist[zeros] = 0
-        return sp.csr_matrix(dist)
+        return sp.csr_array(dist)
 
 
 def _test():

--- a/libpysal/weights/gabriel.py
+++ b/libpysal/weights/gabriel.py
@@ -206,11 +206,11 @@ class Relative_Neighborhood(Delaunay):
     the Minimum Spanning Tree, with additional "relative neighbors"
     introduced.
 
-    A relative neighbor pair of points i,j must be closer than the 
-    maximum distance between i (or j) and each other point k. 
-    This means that the points are at least as close to one another 
-    as they are to any other point. 
-    
+    A relative neighbor pair of points i,j must be closer than the
+    maximum distance between i (or j) and each other point k.
+    This means that the points are at least as close to one another
+    as they are to any other point.
+
     Parameters
     ----------
     coordinates :   array of points, (N,2)
@@ -234,7 +234,7 @@ class Relative_Neighborhood(Delaunay):
         row, col, data = zip(*output)
         if binary:
             data = numpy.ones_like(col, dtype=float)
-        sp = sparse.csc_matrix((data, (row, col)))  # TODO: faster way than this?
+        sp = sparse.csc_array((data, (row, col)))  # TODO: faster way than this?
         ids = kwargs.get("ids")
         if ids is None:
             ids = numpy.arange(sp.shape[0])

--- a/libpysal/weights/raster.py
+++ b/libpysal/weights/raster.py
@@ -18,7 +18,6 @@ if os.path.basename(sys.argv[0]) in ("pytest", "py.test"):
 
         return intercepted_function
 
-
 else:
     from ..common import jit
 
@@ -225,7 +224,7 @@ def da2WSP(
         da = da[slice_dict]
 
     ser = da.to_series()
-    dtype = np.int32 if (shape[0] * shape[1]) < 46340 ** 2 else np.int64
+    dtype = np.int32 if (shape[0] * shape[1]) < 46340**2 else np.int64
     if "nodatavals" in da.attrs and da.attrs["nodatavals"]:
         mask = (ser != da.attrs["nodatavals"][0]).to_numpy()
         ids = np.where(mask)[0]
@@ -279,7 +278,7 @@ def da2WSP(
                 *shape, ids, id_map, criterion, k_nas, dtype, n_jobs
             )  # -> (data, (row, col))
 
-        sw = sparse.csr_matrix(
+        sw = sparse.csr_array(
             sw_tup,
             shape=(n, n),
             dtype=np.int8,
@@ -290,9 +289,9 @@ def da2WSP(
     # Since diagonal elements are also added in the result,
     # this method set the diagonal elements to zero and
     # then eliminate zeros from the data. This changes the
-    # sparcity of the csr_matrix !!
+    # sparcity of the csr_array !!
     if k > 1 and not include_nodata:
-        sw = sum(map(lambda x: sw ** x, range(1, k + 1)))
+        sw = sum(map(lambda x: sw**x, range(1, k + 1)))
         sw.setdiag(0)
         sw.eliminate_zeros()
         sw.data[:] = np.ones_like(sw.data, dtype=np.int8)

--- a/libpysal/weights/set_operations.py
+++ b/libpysal/weights/set_operations.py
@@ -6,7 +6,7 @@ __author__ = "Sergio J. Rey <srey@asu.edu>, Charles Schmidt <schmidtc@gmail.com>
 
 import copy
 from .weights import W, WSP
-from scipy.sparse import isspmatrix_csr
+from scipy.sparse import issparse
 from numpy import ones
 
 __all__ = [
@@ -407,11 +407,11 @@ def w_clip(w1, w2, outSP=True, **kwargs):
     Parameters
     ----------
     w1                      : W
-                              W, scipy.sparse.csr.csr_matrix
+                              W, scipy.sparse.csr.csr_array
                               Potentially continuous weights matrix to be clipped. The clipped
                               matrix wc will have at most the same elements as w1.
     w2                      : W
-                              W, scipy.sparse.csr.csr_matrix
+                              W, scipy.sparse.csr.csr_array
                               Weights matrix to use as shell to clip w1. Automatically
                               converted to binary format. Only non-zero elements in w2 will be
                               kept non-zero in wc. NOTE: assumed to be of the same shape as w1
@@ -424,7 +424,7 @@ def w_clip(w1, w2, outSP=True, **kwargs):
     Returns
     -------
     wc      : W
-              W, scipy.sparse.csr.csr_matrix
+              W, scipy.sparse.csr.csr_array
               Clipped W object (sparse if outSP=Ture). It inherits ``id_order`` from w1.
 
     Examples
@@ -510,9 +510,9 @@ def w_clip(w1, w2, outSP=True, **kwargs):
     if not w1.id_order:
         w1.id_order = None
     id_order = w1.id_order
-    if not isspmatrix_csr(w1):
+    if not issparse(w1):
         w1 = w1.sparse
-    if not isspmatrix_csr(w2):
+    if not issparse(w2):
         w2 = w2.sparse
     w2.data = ones(w2.data.shape)
     wc = w1.multiply(w2)

--- a/libpysal/weights/user.py
+++ b/libpysal/weights/user.py
@@ -19,7 +19,7 @@ __all__ = [
 
 def spw_from_gal(galfile):
     """
-    Sparse scipy matrix for w from a gal file.
+    Sparse scipy array for w from a gal file.
 
     Parameters
     ----------
@@ -30,8 +30,8 @@ def spw_from_gal(galfile):
     Returns
     -------
 
-    spw      : sparse_matrix
-               scipy sparse matrix in CSR format
+    spw      : sparse array
+               scipy sparse array in CSR format
 
     ids      : array
                identifiers for rows/cols of spw

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -466,7 +466,7 @@ def higher_order_sp(
     Parameters
     ----------
     w             : W
-                            sparse_matrix, spatial weights object or
+                            sparse array, spatial weights object or
                             scipy.sparse.csr.csr_instance
     k             : int
                     Order of contiguity
@@ -523,7 +523,9 @@ def higher_order_sp(
             w = w.sparse
         else:
             raise ValueError("Weights are not binary (0,1)")
-    elif scipy.sparse.isspmatrix_csr(w):
+    elif scipy.sparse.issparse(w):
+        if w.format != "csr":
+            w = w.tocsr()
         if not np.unique(w.data) == np.array([1.0]):
             raise ValueError(
                 "Sparse weights matrix is not binary (0,1) weights matrix."
@@ -531,7 +533,7 @@ def higher_order_sp(
     else:
         raise TypeError(
             "Weights provided are neither a binary W object nor "
-            "a scipy.sparse.csr_matrix"
+            "a scipy.sparse.csr_array"
         )
 
     if lower_order:
@@ -787,7 +789,6 @@ def full2W(m, ids=None, **kwargs):
 
 
 def WSP2W(wsp, **kwargs):
-
     """
     Convert a pysal WSP object (thin weights matrix) to a pysal W object.
 
@@ -1201,8 +1202,8 @@ def lat2SW(nrows=3, ncols=5, criterion="rook", row_st=False):
     Returns
     -------
 
-    w : scipy.sparse.dia_matrix
-        instance of a scipy sparse matrix
+    w : scipy.sparse.dia_array
+        instance of a scipy sparse array
 
     Notes
     -----
@@ -1252,7 +1253,7 @@ def lat2SW(nrows=3, ncols=5, criterion="rook", row_st=False):
         offsets.append(-(ncols + 1))
     data = np.concatenate(diagonals)
     offsets = np.array(offsets)
-    m = sparse.dia_matrix((data, offsets), shape=(n, n), dtype=np.int8)
+    m = sparse.dia_array((data, offsets), shape=(n, n), dtype=np.int8)
     m = m + m.T
     if row_st:
         m = sparse.spdiags(1.0 / m.sum(1).T, 0, *m.shape) * m
@@ -1686,7 +1687,6 @@ def fuzzy_contiguity(
 
 
 if __name__ == "__main__":
-
     from libpysal.weights import lat2W
 
     assert (lat2W(5, 5).sparse.todense() == lat2SW(5, 5).todense()).all()

--- a/libpysal/weights/weights.py
+++ b/libpysal/weights/weights.py
@@ -608,7 +608,7 @@ class W(object):
         row = np.array(row)
         col = np.array(col)
         data = np.array(data)
-        s = scipy.sparse.csr_matrix((data, (row, col)), shape=(self.n, self.n))
+        s = scipy.sparse.csr_array((data, (row, col)), shape=(self.n, self.n))
         return s
 
     @property
@@ -1526,7 +1526,7 @@ class WSP(object):
     >>> rows = [0, 1, 1, 2, 2, 3]
     >>> cols = [1, 0, 2, 1, 3, 3]
     >>> weights =  [1, 0.75, 0.25, 0.9, 0.1, 1]
-    >>> sparse = scipy.sparse.csr_matrix((weights, (rows, cols)), shape=(4,4))
+    >>> sparse = scipy.sparse.csr_array((weights, (rows, cols)), shape=(4,4))
     >>> w = WSP(sparse)
     >>> w.s0
     4.0


### PR DESCRIPTION
scipy is [moving to a new sparse array type](https://docs.scipy.org/doc/scipy/reference/sparse.html), and eventually deprecating the sparse matrix type. We need to check what breaks when we use it. Right now, I see a few failures locally, so I want to get this online for others to see. 