### PR TITLE
CI/COMPAT: update CI actions and dev channel setup, fix scipy compatibility 

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -25,20 +25,20 @@
      defaults:
        run:
          shell: bash -l {0}
-     
+
      steps:
        - name: Checkout repo
          uses: actions/checkout@v3
-       
+
        - name: Setup micromamba
-         uses: mamba-org/provision-with-micromamba@main
+         uses: mamba-org/setup-micromamba@v1
          with:
            environment-file: ${{ matrix.environment-file }}
            micromamba-version: 'latest'
-       
+
        - name: Make Docs
          run: cd docs; make html
-       
+
        - name: Commit Docs
          run: |
            git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages
@@ -50,7 +50,7 @@
            git commit -m "Update documentation" -a || true
            # The above command will fail if no changes were present,
            # so we ignore the return code.
-       
+
        - name: push to gh-pages
          uses: ad-m/github-push-action@master
          with:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,6 +16,9 @@
        FETCH_EXAMPLES: python -c 'import libpysal; libpysal.examples.fetch_all()'
        RUN_TEST: pytest -v -n auto libpysal --cov libpysal --cov-config .coveragerc --cov-report xml --color yes --cov-append --cov-report term-missing
      #timeout-minutes: 25
+     defaults:
+      run:
+        shell: bash -l {0}
      strategy:
        matrix:
          os: ['ubuntu-latest']
@@ -43,19 +46,10 @@
            environment-file: ${{ matrix.environment-file }}
            micromamba-version: 'latest'
 
-       - name: run tests - bash
-         shell: bash -l {0}
+       - name: run tests
          run: |
            ${{ env.FETCH_EXAMPLES }}
            ${{ env.RUN_TEST }}
-         if: matrix.os != 'windows-latest'
-
-       - name: run tests - powershell
-         shell: powershell
-         run: |
-           ${{ env.FETCH_EXAMPLES }}
-           ${{ env.RUN_TEST }}
-         if: matrix.os == 'windows-latest'
 
        - name: codecov
          uses: codecov/codecov-action@v3

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -38,11 +38,10 @@
          uses: actions/checkout@v3
 
        - name: setup micromamba
-         uses: mamba-org/provision-with-micromamba@main
+         uses: mamba-org/setup-micromamba@v1
          with:
            environment-file: ${{ matrix.environment-file }}
            micromamba-version: 'latest'
-           channel-priority: 'flexible'
 
        - name: run tests - bash
          shell: bash -l {0}

--- a/ci/311-dev.yaml
+++ b/ci/311-dev.yaml
@@ -6,9 +6,6 @@ dependencies:
   - platformdirs
   - beautifulsoup4
   - jinja2
-  - pandas
-  - scipy
-  - xarray
   # testing
   - codecov
   - matplotlib
@@ -16,7 +13,9 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   # optional
-  - geopandas
+  - geos
+  - pyproj
+  - fiona
   - joblib
   - networkx
   - packaging
@@ -25,7 +24,7 @@ dependencies:
   - pip
   - pip:
       # dev versions of packages
-      - --pre --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
+      - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
       - scipy
       - pandas
       - xarray

--- a/ci/311-dev.yaml
+++ b/ci/311-dev.yaml
@@ -24,10 +24,10 @@ dependencies:
   - Cython
   - pip
   - pip:
-    # dev versions of packages
-    - --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple
-    - scipy
-    - pandas
-    - git+https://github.com/shapely/shapely.git@main
-    - git+https://github.com/geopandas/geopandas.git@main
-    - git+https://github.com/pydata/xarray.git@main
+      # dev versions of packages
+      - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
+      - scipy
+      - pandas
+      - xarray
+      - git+https://github.com/shapely/shapely.git@main
+      - git+https://github.com/geopandas/geopandas.git@main

--- a/ci/311-dev.yaml
+++ b/ci/311-dev.yaml
@@ -25,7 +25,7 @@ dependencies:
   - pip
   - pip:
       # dev versions of packages
-      - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
+      - --pre --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
       - scipy
       - pandas
       - xarray

--- a/libpysal/cg/kdtree.py
+++ b/libpysal/cg/kdtree.py
@@ -6,7 +6,7 @@ Adds support for Arc Distance to scipy.spatial.KDTree.
 import math
 import scipy.spatial
 import numpy
-from scipy import inf
+from numpy import inf
 from . import sphere
 from .sphere import RADIUS_EARTH_KM
 


### PR DESCRIPTION
Update dev config and fix compatibility with latest scipy which no longer import numpy namespace. (https://github.com/pysal/libpysal/actions/runs/5936839744/job/16098081313)

I also think I have accidentally pushed the first commit straight to main...