### PR TITLE
BUG: fix Graph.to_W

### DIFF
--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -147,29 +147,20 @@ class Graph(_Set_Mixin):
         libpysal.weights.W
             representation of graph as a weights.W object
         """
-        neighbors = (
-            self._adjacency.groupby(level=0)
-            .apply(
-                lambda group: list(
-                    group[
-                        ~((group.index == group.neighbor) & (group.weight == 0))
-                    ].neighbor
-                )
+        ids, labels = pd.factorize(self._adjacency.index, sort=False)
+        neighbors = self._adjacency.groupby(ids).apply(
+            lambda group: list(
+                group[~((group.index == group.neighbor) & (group.weight == 0))].neighbor
             )
-            .to_dict()
         )
-        weights = (
-            self._adjacency.groupby(level=0)
-            .apply(
-                lambda group: list(
-                    group[
-                        ~((group.index == group.neighbor) & (group.weight == 0))
-                    ].weight
-                )
+        neighbors.index = labels[neighbors.index]
+        weights = self._adjacency.groupby(ids).apply(
+            lambda group: list(
+                group[~((group.index == group.neighbor) & (group.weight == 0))].weight
             )
-            .to_dict()
         )
-        return W(neighbors, weights)
+        weights.index = labels[weights.index]
+        return W(neighbors.to_dict(), weights.to_dict(), id_order=labels)
 
     @classmethod
     def from_sparse(cls, sparse, ids=None):

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -80,6 +80,14 @@ class TestBase:
         }
         self.G_int = graph.Graph.from_weights_dict(self.W_dict_int)
         self.G_str = graph.Graph.from_weights_dict(self.W_dict_str)
+        rng = np.random.default_rng(seed=0)
+        self.letters = np.asarray(list(string.ascii_letters[:26]))
+        rng.shuffle(self.letters)
+        self.W_dict_str_unordered = {
+            self.letters[k]: {self.letters[k_]: v_ for k_, v_ in v.items()}
+            for k, v in self.W_dict_int.items()
+        }
+        self.G_str_unodered = graph.Graph.from_weights_dict(self.W_dict_str_unordered)
 
     def test_init(self):
         G = graph.Graph(self.adjacency_int_binary)
@@ -217,6 +225,10 @@ class TestBase:
         W_isolate = G_isolate.to_W()
         assert W.neighbors == W_isolate.neighbors
         assert W.weights == W_isolate.weights
+
+        W = self.G_str_unodered.to_W()
+        assert W.id_order_set
+        np.testing.assert_array_equal(W.id_order, self.letters[:10])
 
     def test_from_sparse(self):
         row = np.array([0, 3, 1, 0])


### PR DESCRIPTION
I've noticed that when ids are not ordered, they get ordered within groupby which messes up the conversion to `W`. This seems to fix it.