### PR TITLE
Coindicent tests

### DIFF
--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -230,7 +230,6 @@ def _distance_band(coordinates, threshold, ids=None):
     tree = spatial.KDTree(coordinates)
     dist = tree.sparse_distance_matrix(tree, threshold, output_type="ndarray")
     sp = sparse.csr_array((dist["v"], (dist["i"], dist["j"])))
-    sp.eliminate_zeros()
     return sp
 
     # TODO: handle co-located points

--- a/libpysal/graph/_triangulation.py
+++ b/libpysal/graph/_triangulation.py
@@ -111,8 +111,12 @@ def _validate_coincident(triangulator):
             adjtable = _induce_cliques(adjtable, coincident_lut, fill_value=fill_value)
 
         # ensure proper sorting
-        mapping = dict(zip(ids, range(len(ids))))
-        sorted_index = adjtable.focal.map(mapping).sort_values().index
+        sorted_index = (
+            adjtable[["focal", "neighbor"]]
+            .applymap(list(ids).index)
+            .sort_values(["focal", "neighbor"])
+            .index
+        )
 
         # return data for Graph.from_arrays
         return heads[sorted_index], tails[sorted_index], weights[sorted_index]

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -309,8 +309,13 @@ class TestBase:
             ],
             np.ones(10),
         )
-        assert G == expected, "sparse csr nybb with ids does not match arrays constructor"
+        assert (
+            G == expected
+        ), "sparse csr nybb with ids does not match arrays constructor"
         np.testing.assert_array_equal(G.sparse.todense(), sp.todense())
+
+        with pytest.raises(ValueError, match="The length of ids "):
+            graph.Graph.from_sparse(sp, ids=["staten_island", "queens"])
 
     def test_from_arrays(self):
         focal_ids = np.arange(9)

--- a/libpysal/graph/tests/test_triangulation.py
+++ b/libpysal/graph/tests/test_triangulation.py
@@ -234,7 +234,7 @@ class Test_Coincident:
             [0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5]
         )
         exp_tails = numpy.array(
-            [1, 2, 4, 0, 2, 3, 4, 5, 3, 1, 0, 1, 2, 5, 0, 1, 5, 1, 3, 4]
+            [1, 2, 4, 0, 2, 3, 4, 5, 0, 1, 3, 1, 2, 5, 0, 1, 5, 1, 3, 4]
         )
         exp_w = numpy.ones(exp_heads.shape, dtype="int8")
 
@@ -259,9 +259,8 @@ class Test_Coincident:
         exp_heads = numpy.array(
             [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5]
         )
-        # the order may be different in the end but observations not
         exp_tails = numpy.array(
-            [1, 2, 5, 4, 0, 2, 3, 5, 0, 1, 3, 1, 2, 5, 0, 1, 2, 5, 0, 1, 3]
+            [1, 2, 4, 5, 0, 2, 3, 5, 0, 1, 3, 1, 2, 5, 0, 1, 2, 5, 0, 1, 3]
         )
         exp_w = numpy.ones(exp_heads.shape, dtype="int8")
 
@@ -289,7 +288,7 @@ class Test_Coincident:
         heads, tails, weights = _gabriel(self.df_int, coincident="jitter", seed=0)
 
         exp_heads = numpy.array([0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5])
-        exp_tails = numpy.array([4, 2, 2, 5, 3, 4, 1, 0, 3, 1, 2, 5, 0, 1, 1, 3])
+        exp_tails = numpy.array([2, 4, 2, 3, 4, 5, 0, 1, 3, 1, 2, 5, 0, 1, 1, 3])
         exp_w = numpy.ones(exp_heads.shape, dtype="int8")
 
         numpy.testing.assert_array_equal(heads, exp_heads)
@@ -313,9 +312,8 @@ class Test_Coincident:
         exp_heads = numpy.array(
             [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5]
         )
-        # the order may be different in the end but observations not
         exp_tails = numpy.array(
-            [1, 2, 5, 4, 0, 2, 3, 5, 0, 1, 3, 1, 2, 5, 0, 1, 2, 5, 0, 1, 3]
+            [1, 2, 4, 5, 0, 2, 3, 5, 0, 1, 3, 1, 2, 5, 0, 1, 2, 5, 0, 1, 3]
         )
         exp_w = numpy.ones(exp_heads.shape, dtype="int8")
 
@@ -345,7 +343,7 @@ class Test_Coincident:
         )
 
         exp_heads = numpy.array([0, 0, 0, 1, 1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5])
-        exp_tails = numpy.array([1, 2, 4, 0, 3, 4, 5, 3, 0, 1, 2, 5, 0, 1, 5, 3, 1, 4])
+        exp_tails = numpy.array([1, 2, 4, 0, 3, 4, 5, 0, 3, 1, 2, 5, 0, 1, 5, 1, 3, 4])
         exp_w = numpy.ones(exp_heads.shape, dtype="int8")
 
         numpy.testing.assert_array_equal(heads, exp_heads)
@@ -373,9 +371,8 @@ class Test_Coincident:
         exp_heads = numpy.array(
             [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5]
         )
-        # the order may be different in the end but observations not
         exp_tails = numpy.array(
-            [1, 2, 5, 4, 0, 2, 3, 5, 0, 1, 3, 1, 2, 5, 0, 1, 2, 5, 0, 1, 3]
+            [1, 2, 4, 5, 0, 2, 3, 5, 0, 1, 3, 1, 2, 5, 0, 1, 2, 5, 0, 1, 3]
         )
         exp_w = numpy.ones(exp_heads.shape, dtype="int8")
 
@@ -405,7 +402,7 @@ class Test_Coincident:
         heads, tails, weights = _voronoi(self.df_int, coincident="jitter", seed=0)
 
         exp_heads = numpy.array([0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5])
-        exp_tails = numpy.array([1, 2, 4, 0, 2, 3, 4, 5, 3, 0, 1, 1, 2, 5, 0, 1, 1, 3])
+        exp_tails = numpy.array([1, 2, 4, 0, 2, 3, 4, 5, 0, 1, 3, 1, 2, 5, 0, 1, 1, 3])
         exp_w = numpy.ones(exp_heads.shape, dtype="int8")
 
         numpy.testing.assert_array_equal(heads, exp_heads)
@@ -427,7 +424,6 @@ class Test_Coincident:
         heads, tails, weights = _voronoi(self.df_int, coincident="clique", seed=0)
 
         exp_heads = numpy.array([0, 0, 1, 1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 5, 5])
-        # the order may be different in the end but observations not
         exp_tails = numpy.array([1, 4, 0, 2, 3, 5, 1, 3, 1, 2, 5, 0, 1, 1, 3])
         exp_w = numpy.ones(exp_heads.shape, dtype="int8")
 


### PR DESCRIPTION
This includes proper sorting within triangulation and tests for that.

I believe that we need to sort only by focal and only in cases where the constructor has a tendency to mess up the order. The rest shall always give equal results, so no more sorting shall be needed.

@ljwolf are cliques finished? The implementation does not seem to work, the resulting adjacency is always much shorter than it should be (even shorter than the one before inducing cliques, so something is wrong).

I have also included tests for cliques but since those are failing, they're now marked with xfail. When the implementation is fixed, they should pass (maybe a minor reorder of expected tails will be needed).


@knaaptime on the sorting, I will need to be convinced that we always need to sort by the use case where not sorting everything by default causes trouble. 