### PR TITLE
Remove an undefined name

### DIFF
--- a/libpysal/cg/ops/_accessors.py
+++ b/libpysal/cg/ops/_accessors.py
@@ -1,17 +1,6 @@
 import functools as _f
 
-__all__ = [
-    "area",
-    "bbox",
-    "bounding_box",
-    "centroid",
-    "holes",
-    "len",
-    "parts",
-    "perimeter",
-    "segments",
-    "vertices",
-]
+__all__ = []
 
 
 def get_attr(df, geom_col="geometry", inplace=False, attr=None):


### PR DESCRIPTION
In file: _accessors.py, the list named `__all__` contains undefined names which can result in errors  when this module is imported. I removed the undefined names from the list. For more information regarding `__all__`, please read about [importing fields from a package](https://docs.python.org/3/tutorial/modules.html#importing-from-a-package).  

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.