### PR TITLE
minor cleanups of geographs

### DIFF
--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -757,42 +757,6 @@ class Graph(_Set_Mixin):
             .to_dict()
         )
 
-    def get_neighbors(self, ix):
-        """Get neighbors for a set focal object
-
-        Parameters
-        ----------
-        ix : hashable
-            index of focal object
-
-        Returns
-        -------
-        array
-            array of indices of neighbor objects
-        """
-        if ix in self.isolates:
-            return np.array([], dtype=self._adjacency.index.dtypes["neighbor"])
-
-        return self._adjacency.loc[ix].index.get_level_values("neighbor")
-
-    def get_weights(self, ix):
-        """Get weights for a set focal object
-
-        Parameters
-        ----------
-        ix : hashable
-            index of focal object
-
-        Returns
-        -------
-        array
-            array of weights of neighbor object
-        """
-        if ix in self.isolates:
-            return np.array([], dtype=self._adjacency.dtype)
-
-        return self._adjacency.loc[ix].values
-
     @cached_property
     def sparse(self):
         """Return a scipy.sparse array (COO)
@@ -806,12 +770,6 @@ class Graph(_Set_Mixin):
         return sparse.coo_array(
             self._adjacency.astype("Sparse[float]").sparse.to_coo(sort_labels=True)[0]
         )
-
-    @cached_property
-    def _id2i(self):
-        """Mapping of index to integer position in sparse"""
-        ix = np.arange(self.unique_ids.shape[0])
-        return dict(zip(self.unique_ids, ix))
 
     def transform(self, transformation):
         """Transformation of weights
@@ -1008,13 +966,13 @@ class Graph(_Set_Mixin):
             return pd.Series(
                 index=pd.Index([], name="focal"),
                 name="neighbor",
-                dtype=self._adjacency.index.dtypes[0],
+                dtype=self._adjacency.index.dtypes["focal"],
             )
         else:
-            i2id = {v: k for k, v in self._id2i.items()}
+            i2id = dict(zip(np.arange(self.unique_ids.shape[0]), self.unique_ids))
             focal, neighbor = np.nonzero(wd)
-            focal = focal.astype(self._adjacency.index.dtypes[0])
-            neighbor = neighbor.astype(self._adjacency.index.dtypes[0])
+            focal = focal.astype(self._adjacency.index.dtypes["focal"])
+            neighbor = neighbor.astype(self._adjacency.index.dtypes["focal"])
             for i in i2id:
                 focal[focal == i] = i2id[i]
                 neighbor[neighbor == i] = i2id[i]

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -499,30 +499,6 @@ class TestBase:
         }
         assert self.G_str.weights == expected
 
-    def test_get_neighbors(self):
-        for i in range(10):
-            np.testing.assert_array_equal(
-                np.sort(self.G_int.get_neighbors(i)),
-                np.sort(np.asarray(list(self.W_dict_int[i]))),
-            )
-        for i in range(10):
-            i = string.ascii_letters[i]
-            np.testing.assert_array_equal(
-                np.sort(self.G_str.get_neighbors(i)),
-                np.sort(np.asarray(list(self.W_dict_str[i]))),
-            )
-
-    def test_get_weights(self):
-        for i in range(10):
-            np.testing.assert_array_equal(
-                self.G_int.get_weights(i), np.asarray(list(self.W_dict_int[i].values()))
-            )
-        for i in range(10):
-            i = string.ascii_letters[i]
-            np.testing.assert_array_equal(
-                self.G_str.get_weights(i), np.asarray(list(self.W_dict_str[i].values()))
-            )
-
     def test_sparse(self):
         sp = self.G_int.sparse
         expected = np.array(
@@ -872,18 +848,3 @@ class TestBase:
 
         with pytest.raises(ValueError, match="The length of `y`"):
             self.G_str.lag(list(range(1, 15)))
-
-    def test__id2i(self):
-        expected = {
-            "a": 0,
-            "b": 1,
-            "c": 2,
-            "d": 3,
-            "e": 4,
-            "f": 5,
-            "g": 6,
-            "h": 7,
-            "i": 8,
-            "j": 9,
-        }
-        assert expected == self.G_str._id2i

--- a/libpysal/graph/tests/test_builders.py
+++ b/libpysal/graph/tests/test_builders.py
@@ -21,59 +21,59 @@ class TestContiguity:
     def test_vertex_intids(self):
         G = graph.Graph.build_contiguity(self.gdf)
 
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_vertex_strids(self):
         G = graph.Graph.build_contiguity(self.gdf_str)
 
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_rook_intids(self):
         G = graph.Graph.build_contiguity(self.gdf, strict=True)
 
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_rook_strids(self):
         G = graph.Graph.build_contiguity(self.gdf_str, strict=True)
 
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_queen_intids(self):
         G = graph.Graph.build_contiguity(self.gdf, rook=False, strict=True)
 
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_queen_strids(self):
         G = graph.Graph.build_contiguity(self.gdf_str, rook=False, strict=True)
 
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_block_contiguity(self):
         regimes = ["n", "n", "s", "s", "e", "e", "w", "w", "e", "l"]
         G = graph.Graph.build_block_contiguity(regimes)
 
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
         regimes = pd.Series(
             regimes, index=["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
         )
         G = graph.Graph.build_block_contiguity(regimes)
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
 
@@ -89,16 +89,16 @@ class TestTriangulation:
     def test_triangulation_intids(self, method):
         G = graph.Graph.build_triangulation(self.gdf, method)
 
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     @pytest.mark.parametrize("method", TRIANGULATIONS)
     def test_triangulation_strids(self, method):
         G = graph.Graph.build_triangulation(self.gdf_str, method)
 
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     @pytest.mark.parametrize("method", TRIANGULATIONS)
@@ -106,8 +106,8 @@ class TestTriangulation:
         G = graph.Graph.build_triangulation(
             self.gdf, method, kernel="parabolic", bandwidth=7500
         )
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     @pytest.mark.parametrize("method", TRIANGULATIONS)
@@ -116,8 +116,8 @@ class TestTriangulation:
             self.gdf_str, method, kernel="parabolic", bandwidth=7500
         )
 
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_invalid_method(self):
@@ -137,29 +137,29 @@ class TestKernel:
     def test_kernel_intids(self):
         G = graph.Graph.build_kernel(self.gdf)
 
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_kernel_strids(self):
         G = graph.Graph.build_kernel(self.gdf_str)
 
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_knn_intids(self):
         G = graph.Graph.build_knn(self.gdf, k=3)
 
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_knn_strids(self):
         G = graph.Graph.build_kernel(self.gdf_str, k=3)
 
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
 
@@ -172,29 +172,29 @@ class TestDistanceBand:
     def test_distance_band_intids(self):
         G = graph.Graph.build_distance_band(self.gdf, 50000)
 
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_distance_band_strids(self):
         G = graph.Graph.build_distance_band(self.gdf_str, 50000)
 
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_distance_band_intids_weighted(self):
         G = graph.Graph.build_distance_band(self.gdf, 50000, binary=False)
 
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_distance_band_strids_weighted(self):
         G = graph.Graph.build_distance_band(self.gdf_str, 50000, binary=False)
 
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_distance_band_intids_kernel(self):
@@ -202,8 +202,8 @@ class TestDistanceBand:
             self.gdf, 50000, binary=False, kernel="gaussian"
         )
 
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_distance_band_strids_kernel(self):
@@ -211,8 +211,8 @@ class TestDistanceBand:
             self.gdf_str, 50000, binary=False, kernel="gaussian"
         )
 
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
 
@@ -312,8 +312,8 @@ class TestAdjacency:
             self.expected_adjacency_intid,
         )
 
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_numeric_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_adjacency_strids(self):
@@ -321,8 +321,8 @@ class TestAdjacency:
             self.expected_adjacency_strid,
         )
 
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[0])
-        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes[1])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_string_dtype(G._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(G._adjacency.dtype)
 
     def test_adjacency_rename(self):
@@ -341,12 +341,10 @@ class TestAdjacency:
             pass
 
     def test_adjacency_match_contiguity(self):
-        contiguity_adj = graph.Graph.build_contiguity(self.gdf).adjacency
-        built_adj = graph.Graph.from_adjacency(self.expected_adjacency_intid).adjacency
-        assert contiguity_adj.equals(built_adj)
+        contiguity = graph.Graph.build_contiguity(self.gdf)
+        built = graph.Graph.from_adjacency(self.expected_adjacency_intid)
+        assert contiguity == built
 
-        contiguity_adj_str = graph.Graph.build_contiguity(self.gdf_str).adjacency
-        built_adj_str = graph.Graph.from_adjacency(
-            self.expected_adjacency_strid
-        ).adjacency
-        assert contiguity_adj_str.equals(built_adj_str)
+        contiguity_str = graph.Graph.build_contiguity(self.gdf_str)
+        built_str = graph.Graph.from_adjacency(self.expected_adjacency_strid)
+        assert contiguity_str == built_str


### PR DESCRIPTION
- removing `get_neighbors` and `get_weights` which are not needed anymore since we have `__getitem__` implemented
- removing `_id2i` as it is unnecessary in sorted adjacency (and we don't need to keep anything in sync, yay!)
- updating indexing to eliminate pandas deprecation warnings
- fixing `from_adjacency` test to pass on windows