### PR TITLE
set nopython=True in jit in alpha shapes

### DIFF
--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -38,7 +38,7 @@ EPS = np.finfo(float).eps
 __all__ = ["alpha_shape", "alpha_shape_auto"]
 
 
-@jit(nopython=False)
+@jit(nopython=True)
 def nb_dist(x, y):
     """numba implementation of distance between points `x` and `y`
 
@@ -164,7 +164,7 @@ def r_circumcircle_triangle(a_s, b_s, c_s):
     return r2
 
 
-@jit(nopython=False)
+@jit(nopython=True)
 def get_faces(triangle):
     """Extract faces from a single triangle
 
@@ -198,7 +198,7 @@ def get_faces(triangle):
     return faces
 
 
-@jit(nopython=False)
+@jit(nopython=True)
 def build_faces(faces, triangles_is, num_triangles, num_faces_single):
     """Build facing triangles
 
@@ -260,7 +260,7 @@ def build_faces(faces, triangles_is, num_triangles, num_faces_single):
     return faces
 
 
-@jit(nopython=False)
+@jit(nopython=True)
 def nb_mask_faces(mask, faces):
     """Run over each row in `faces`, if the face in the following row is the
     same, then mark both as False on `mask`


### PR DESCRIPTION
A follow-up on #535 trying to eliminate warnings emitted by numba. Locally, this causes no issue, let's see what CI will say.