### PR TITLE
BUG: fix graph kernel builder when kernel returns zero

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -52,7 +52,7 @@
            ${{ env.RUN_TEST }}
 
        - name: codecov
-         uses: codecov/codecov-action@v4
+         uses: codecov/codecov-action@v3
          with:
            token: ${{ secrets.CODECOV_TOKEN }}
            file: ./coverage.xml

--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -68,7 +68,6 @@ def _kernel(
     k=None,
     ids=None,
     p=2,
-    taper=True,
 ):
     """
     Compute a kernel function over a distance matrix.
@@ -144,9 +143,6 @@ def _kernel(
         D.data = kernel(D.data, bandwidth)
     else:
         D.data = _kernel_functions[kernel](D.data, bandwidth)
-
-    if taper:
-        D.eliminate_zeros()
 
     return _sparse_to_arrays(D, ids=ids)
 

--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -68,6 +68,7 @@ def _kernel(
     k=None,
     ids=None,
     p=2,
+    taper=False,
 ):
     """
     Compute a kernel function over a distance matrix.
@@ -111,6 +112,8 @@ def _kernel(
         from the input coordinates will be used.
     p : int (default: 2)
         parameter for minkowski metric, ignored if metric != "minkowski".
+    taper : bool (default: False)
+        remove links with a weight equal to zero
     """
     if metric != "precomputed":
         coordinates, ids, _ = _validate_geometry_input(
@@ -143,6 +146,9 @@ def _kernel(
         D.data = kernel(D.data, bandwidth)
     else:
         D.data = _kernel_functions[kernel](D.data, bandwidth)
+
+    if taper:
+        raise NotImplementedError("taper is not yet implemented.")
 
     return _sparse_to_arrays(D, ids=ids)
 

--- a/libpysal/graph/_triangulation.py
+++ b/libpysal/graph/_triangulation.py
@@ -95,7 +95,6 @@ def _validate_coincident(triangulator):
                 metric="precomputed",
                 kernel=kernel,
                 bandwidth=bandwidth,
-                taper=False,
             )
         # create adjacency
         adjtable = pandas.DataFrame.from_dict(

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -19,7 +19,7 @@ from ._parquet import _read_parquet, _to_parquet
 from ._set_ops import _Set_Mixin
 from ._spatial_lag import _lag_spatial
 from ._triangulation import _delaunay, _gabriel, _relative_neighborhood, _voronoi
-from ._utils import _evaluate_index, _neighbor_dict_to_edges
+from ._utils import _evaluate_index, _neighbor_dict_to_edges, _sparse_to_arrays
 
 ALLOWED_TRANSFORMATIONS = ("O", "B", "R", "D", "V")
 
@@ -248,26 +248,8 @@ class Graph(_Set_Mixin):
         Graph
             libpysal.graph.Graph based on sparse
         """
-        sparse = sparse.tocoo(copy=False)
-        if ids is not None:
-            ids = np.asarray(ids)
-            if sparse.shape[0] != ids.shape[0]:
-                raise ValueError(
-                    f"The length of ids ({ids.shape[0]}) does not match "
-                    f"the shape of sparse {sparse.shape}."
-                )
 
-            sorter = sparse.row.argsort()
-            head = ids[sparse.row][sorter]
-            tail = ids[sparse.col][sorter]
-            data = sparse.data[sorter]
-        else:
-            sorter = sparse.row.argsort()
-            head = sparse.row[sorter]
-            tail = sparse.col[sorter]
-            data = sparse.data[sorter]
-
-        return cls.from_arrays(head, tail, weight=data)
+        return cls.from_arrays(*_sparse_to_arrays(sparse, ids))
 
     @classmethod
     def from_arrays(cls, focal_ids, neighbor_ids, weight):

--- a/libpysal/graph/tests/test_kernel.py
+++ b/libpysal/graph/tests/test_kernel.py
@@ -9,6 +9,10 @@ For completeness, we need to test a shuffled dataframe
 - check two tree types
 - scikit/no scikit
 """
+
+import numpy as np
+from libpysal.graph._kernel import _kernel
+
 # import pandas, geopandas, geodatasets, pytest, shapely, numpy
 # from libpysal.weights.experimental._kernel import (
 #     kernel,
@@ -98,3 +102,15 @@ For completeness, we need to test a shuffled dataframe
 # @parametrize_data
 # def test_coincident(data):
 #     raise NotImplementedError()
+
+
+def test_shape_preservation():
+    coordinates = np.vstack(
+        [np.repeat(np.arange(10), 10), np.tile(np.arange(10), 10)]
+    ).T
+    head, tail, weight = _kernel(
+        coordinates, k=3, metric="euclidean", p=2, kernel="boxcar", bandwidth=0.5
+    )
+    np.testing.assert_array_equal(head, np.repeat(np.arange(100), 3))
+    assert tail.shape == head.shape, "shapes of head and tail do not match"
+    np.testing.assert_array_equal(weight, np.zeros((300,), dtype=int))


### PR DESCRIPTION
When the kernel function returns zeros, the conversion of sparse to arrays drops observations causing a mismatch in the shape of Graph.sparse and original input.

We simply cannot use `taper`. If there is a good use case for calling `eliminate_zeros()`, we may revise that but with a smarter implementation to avoid this issue. See the test for reproducible example.