### PR TITLE
finalise kernel constructors in graph 

### DIFF
--- a/libpysal/graph/_contiguity.py
+++ b/libpysal/graph/_contiguity.py
@@ -6,7 +6,7 @@ import pandas
 import geopandas
 from packaging.version import Version
 
-from ._utils import _neighbor_dict_to_edges, _validate_geometry_input
+from ._utils import _neighbor_dict_to_edges, _validate_geometry_input, _resolve_islands
 
 GPD_013 = Version(geopandas.__version__) >= Version("0.13")
 
@@ -205,29 +205,6 @@ def _perimeter_weights(geoms, heads, tails):
         )
 
     return shapely.length(intersection)
-
-
-def _resolve_islands(heads, tails, ids, weights):
-    """
-    Induce self-loops for a collection of ids and links describing a
-    contiguity graph. Induced self-loops will have zero weight.
-    """
-    islands = numpy.setdiff1d(ids, heads)
-    if islands.shape != (0,):
-        heads = numpy.hstack((heads, islands))
-        tails = numpy.hstack((tails, islands))
-        weights = numpy.hstack((weights, numpy.zeros_like(islands, dtype=int)))
-
-    # ensure proper order after adding isolates to the end
-    adjacency = pandas.Series(
-        weights, index=pandas.MultiIndex.from_arrays([heads, tails])
-    )
-    adjacency = adjacency.reindex(ids, level=0).reindex(ids, level=1)
-    return (
-        adjacency.index.get_level_values(0),
-        adjacency.index.get_level_values(1),
-        adjacency.values,
-    )
 
 
 def _block_contiguity(regimes, ids=None):

--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -17,8 +17,6 @@ try:
 except ImportError:
     HAS_SKLEARN = False
 
-HAS_SKLEARN = False
-
 _VALID_GEOMETRY_TYPES = ["Point"]
 
 

--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -167,7 +167,7 @@ def _kernel(
                         f"metric {metric} is not supported by scipy, and scikit-learn "
                         "could not be imported."
                     )
-                D = spatial.distance.pdist(coordinates, metric=metric)
+                D = spatial.distance.pdist(coordinates, metric=metric, p=p)
                 sq = spatial.distance.squareform(D)
 
             # ensure that self-distance is dropped but 0 between co-located pts not

--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -155,7 +155,12 @@ def _kernel(
     else:
         if metric != "precomputed":
             if HAS_SKLEARN:
-                sq = metrics.pairwise_distances(coordinates, coordinates, metric=metric)
+                dist_kwds = {}
+                if metric == "minkowski":
+                    dist_kwds["p"] = p
+                sq = metrics.pairwise_distances(
+                    coordinates, coordinates, metric=metric, **dist_kwds
+                )
             else:
                 if metric not in ("euclidean", "manhattan", "cityblock", "minkowski"):
                     raise ValueError(

--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -17,6 +17,8 @@ try:
 except ImportError:
     HAS_SKLEARN = False
 
+HAS_SKLEARN = False
+
 _VALID_GEOMETRY_TYPES = ["Point"]
 
 
@@ -154,10 +156,10 @@ def _kernel(
             D = coordinates * (coordinates.argsort(axis=1, kind="stable") < (k + 1))
     else:
         if metric != "precomputed":
+            dist_kwds = {}
+            if metric == "minkowski":
+                dist_kwds["p"] = p
             if HAS_SKLEARN:
-                dist_kwds = {}
-                if metric == "minkowski":
-                    dist_kwds["p"] = p
                 sq = metrics.pairwise_distances(
                     coordinates, coordinates, metric=metric, **dist_kwds
                 )
@@ -167,7 +169,7 @@ def _kernel(
                         f"metric {metric} is not supported by scipy, and scikit-learn "
                         "could not be imported."
                     )
-                D = spatial.distance.pdist(coordinates, metric=metric, p=p)
+                D = spatial.distance.pdist(coordinates, metric=metric, **dist_kwds)
                 sq = spatial.distance.squareform(D)
 
             # ensure that self-distance is dropped but 0 between co-located pts not

--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -290,11 +290,14 @@ def _prepare_tree_query(coordinates, metric, p=2):
     Prefer scikit-learn trees if they are available.
     """
     if HAS_SKLEARN:
+        dist_kwds = {}
+        if metric == "minkowski":
+            dist_kwds["p"] = p
         if metric in neighbors.VALID_METRICS["kd_tree"]:
             tree = neighbors.KDTree
         else:
             tree = neighbors.BallTree
-        return tree(coordinates, metric=metric).query
+        return tree(coordinates, metric=metric, **dist_kwds).query
     else:
         if metric in ("euclidean", "manhattan", "cityblock", "minkowski"):
             from scipy.spatial import KDTree as tree

--- a/libpysal/graph/_triangulation.py
+++ b/libpysal/graph/_triangulation.py
@@ -95,6 +95,7 @@ def _validate_coincident(triangulator):
                 metric="precomputed",
                 kernel=kernel,
                 bandwidth=bandwidth,
+                taper=False
             )
         # create adjacency
         adjtable = pandas.DataFrame.from_dict(

--- a/libpysal/graph/_utils.py
+++ b/libpysal/graph/_utils.py
@@ -222,3 +222,24 @@ def _evaluate_index(data):
         if isinstance(data, (pd.Series, pd.DataFrame))
         else pd.RangeIndex(0, len(data))
     )
+
+
+def _resolve_islands(heads, tails, ids, weights):
+    """
+    Induce self-loops for a collection of ids and links describing a
+    contiguity graph. Induced self-loops will have zero weight.
+    """
+    islands = np.setdiff1d(ids, heads)
+    if islands.shape != (0,):
+        heads = np.hstack((heads, islands))
+        tails = np.hstack((tails, islands))
+        weights = np.hstack((weights, np.zeros_like(islands, dtype=int)))
+
+    # ensure proper order after adding isolates to the end
+    adjacency = pd.Series(weights, index=pd.MultiIndex.from_arrays([heads, tails]))
+    adjacency = adjacency.reindex(ids, level=0).reindex(ids, level=1)
+    return (
+        adjacency.index.get_level_values(0),
+        adjacency.index.get_level_values(1),
+        adjacency.values,
+    )

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -398,6 +398,7 @@ class Graph(_Set_Mixin):
         bandwidth=None,
         metric="euclidean",
         p=2,
+        coincident="raise",
     ):
         """Generate Graph from geometry data based on a kernel function
 
@@ -436,6 +437,12 @@ class Graph(_Set_Mixin):
             only euclidean, minkowski, and manhattan/cityblock distances are admitted.
         p : int (default: 2)
             parameter for minkowski metric, ignored if metric != "minkowski".
+        coincident: str, optional (default "raise")
+            Method for handling coincident points when ``k`` is not None. Options include
+            ``'raise'`` (raising an exception when coincident points are present),
+            ``'jitter'`` (randomly displace coincident points to produce uniqueness), and
+            ``'clique'`` (induce fully-connected sub cliques for coincident points).
+
 
         Returns
         -------
@@ -452,12 +459,13 @@ class Graph(_Set_Mixin):
             k=k,
             p=p,
             ids=ids,
+            coincident=coincident,
         )
 
         return cls.from_arrays(head, tail, weight)
 
     @classmethod
-    def build_knn(cls, data, k, metric="euclidean", p=2):
+    def build_knn(cls, data, k, metric="euclidean", p=2, coincident="raise"):
         """Generate Graph from geometry data based on k-nearest neighbors search
 
         Parameters
@@ -477,6 +485,12 @@ class Graph(_Set_Mixin):
             only euclidean, minkowski, and manhattan/cityblock distances are admitted.
         p : int (default: 2)
             parameter for minkowski metric, ignored if metric != "minkowski".
+        coincident: str, optional (default "raise")
+            Method for handling coincident points. Options include
+            ``'raise'`` (raising an exception when coincident points are present),
+            ``'jitter'`` (randomly displace coincident points to produce uniqueness), and
+            ``'clique'`` (induce fully-connected sub cliques for coincident points).
+
 
         Returns
         -------
@@ -493,6 +507,7 @@ class Graph(_Set_Mixin):
             k=k,
             p=p,
             ids=ids,
+            coincident=coincident,
         )
 
         return cls.from_arrays(head, tail, weight)

--- a/libpysal/graph/tests/test_kernel.py
+++ b/libpysal/graph/tests/test_kernel.py
@@ -248,6 +248,8 @@ def test_metric(metric):
         data = grocs.to_crs(4326)
     else:
         data = grocs
+    if not HAS_SKLEARN and metric in ["chebyshev", "haversine"]:
+        pytest.skip("metric not supported by scipy")
     head, tail, weight = _kernel(data, metric=metric, kernel="identity", p=1.5)
     assert head.shape[0] == len(data) * (len(data) - 1)
     assert tail.shape == head.shape
@@ -264,13 +266,9 @@ def test_metric(metric):
         assert weight.mean() == pytest.approx(49424.576155)
         assert weight.max() == pytest.approx(173379.431622)
     elif metric == "chebyshev":
-        if not HAS_SKLEARN:
-            pytest.skip("chebyshev not supported by scipy")
         assert weight.mean() == pytest.approx(36590.352895)
         assert weight.max() == pytest.approx(123955.14249)
     else:
-        if not HAS_SKLEARN:
-            pytest.skip("haversine not supported by scipy")
         assert weight.mean() == pytest.approx(0.115835)
         assert weight.max() == pytest.approx(0.371465)
 

--- a/libpysal/graph/tests/test_kernel.py
+++ b/libpysal/graph/tests/test_kernel.py
@@ -216,11 +216,55 @@ def test_kernels(kernel):
         assert weight.max() == pytest.approx(0.9855481738848647)
 
 
-# def test_bandwidth():
-#     raise NotImplementedError()
+@parametrize_data
+@pytest.mark.parametrize("bandwidth", [None, 0.05, 0.4])
+def test_bandwidth(data, bandwidth):
+    head, tail, weight = _kernel(data, bandwidth=bandwidth)
+    assert tail.shape == head.shape
+    assert weight.shape == head.shape
+    if hasattr(data, "index"):
+        np.testing.assert_array_equal(np.unique(head), data.index)
+    else:
+        np.testing.assert_array_equal(np.unique(head), np.arange(len(data)))
 
-# def test_metric():
-#     raise NotImplementedError()
+
+@pytest.mark.parametrize(
+    "metric",
+    [
+        "euclidean",
+        "minkowski",
+        "cityblock",
+        "chebyshev",
+        "haversine",
+    ],
+)
+def test_metric(metric):
+    if metric == "haversine":
+        data = grocs.to_crs(4326)
+    else:
+        data = grocs
+    head, tail, weight = _kernel(data, metric=metric, kernel="identity", p=1.5)
+    assert head.shape[0] == len(data) * (len(data) - 1)
+    assert tail.shape == head.shape
+    assert weight.shape == head.shape
+    np.testing.assert_array_equal(pd.unique(head), data.index)
+
+    if metric == "euclidean":
+        assert weight.mean() == pytest.approx(39758.007362)
+        assert weight.max() == pytest.approx(127937.75272)
+    elif metric == "minkowski":
+        assert weight.mean() == pytest.approx(42288.642129)
+        assert weight.max() == pytest.approx(140674.095752)
+    elif metric == "cityblock":
+        assert weight.mean() == pytest.approx(49424.576155)
+        assert weight.max() == pytest.approx(173379.431622)
+    elif metric == "chebyshev":
+        assert weight.mean() == pytest.approx(36590.352895)
+        assert weight.max() == pytest.approx(123955.14249)
+    else:
+        assert weight.mean() == pytest.approx(0.115835)
+        assert weight.max() == pytest.approx(0.371465)
+
 
 # def test_precomputed(data, ids):
 #     raise NotImplementedError()

--- a/libpysal/graph/tests/test_kernel.py
+++ b/libpysal/graph/tests/test_kernel.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 import pandas as pd
 
-from libpysal.graph._kernel import _kernel, _kernel_functions
+from libpysal.graph._kernel import _kernel, _kernel_functions, _distance_band
 
 grocs = geopandas.read_file(geodatasets.get_path("geoda groceries"))[
     ["OBJECTID", "geometry"]
@@ -222,9 +222,6 @@ def test_kernels(kernel):
 # def test_precomputed(data, ids):
 #     raise NotImplementedError()
 
-# def test_coincident(data):
-#     raise NotImplementedError()
-
 
 def test_coincident():
     grocs_duplicated = pd.concat(
@@ -284,3 +281,38 @@ def test_shape_preservation():
     np.testing.assert_array_equal(head, np.arange(100))
     assert tail.shape == head.shape, "shapes of head and tail do not match"
     np.testing.assert_array_equal(weight, np.zeros((100,), dtype=int))
+
+
+def test_haversine_check():
+    with pytest.raises(ValueError, match="'haversine'"):
+        _kernel(grocs, k=2, metric="haversine")
+
+
+def test_distance_band_colocated():
+    coordinates = np.array([[0, 0], [1, 0], [1, 0], [2, 0], [3, 0]])
+    dist = _distance_band(coordinates, 1)
+    assert dist.shape == (5, 5)
+    np.testing.assert_array_equal(
+        dist.data,
+        np.array(
+            [
+                0.0,
+                1.0,
+                1.0,
+                1.0,
+                0.0,
+                0.0,
+                1.0,
+                1.0,
+                0.0,
+                0.0,
+                1.0,
+                1.0,
+                1.0,
+                0.0,
+                1.0,
+                1.0,
+                0.0,
+            ]
+        ),
+    )

--- a/libpysal/graph/tests/test_kernel.py
+++ b/libpysal/graph/tests/test_kernel.py
@@ -273,6 +273,45 @@ def test_metric(metric):
         assert weight.max() == pytest.approx(0.371465)
 
 
+@pytest.mark.parametrize(
+    "metric",
+    [
+        "euclidean",
+        "minkowski",
+        "cityblock",
+        "chebyshev",
+        "haversine",
+    ],
+)
+def test_metric_k(metric):
+    if metric == "haversine":
+        data = grocs.to_crs(4326)
+    else:
+        data = grocs
+    if not HAS_SKLEARN and metric in ["chebyshev", "haversine"]:
+        pytest.skip("metric not supported by scipy")
+    head, tail, weight = _kernel(data, k=3, metric=metric, kernel="identity", p=1.5)
+    assert head.shape[0] == len(data) * 3
+    assert tail.shape == head.shape
+    assert weight.shape == head.shape
+    np.testing.assert_array_equal(pd.unique(head), data.index)
+
+    if metric == "euclidean":
+        assert weight.mean() == pytest.approx(4577.237441)
+        assert weight.max() == pytest.approx(18791.085051)
+    elif metric == "minkowski":
+        assert weight.mean() == pytest.approx(4884.254721)
+        assert weight.max() == pytest.approx(20681.125211)
+    elif metric == "cityblock":
+        assert weight.mean() == pytest.approx(5665.288523)
+        assert weight.max() == pytest.approx(23980.893147)
+    elif metric == "chebyshev":
+        assert weight.mean() == pytest.approx(4032.283559)
+        assert weight.max() == pytest.approx(16374.141739)
+    else:
+        assert weight.mean() == pytest.approx(0.00021882448)
+        assert weight.max() == pytest.approx(0.000897441)
+
 # def test_precomputed(data, ids):
 #     raise NotImplementedError()
 

--- a/libpysal/graph/tests/test_kernel.py
+++ b/libpysal/graph/tests/test_kernel.py
@@ -197,8 +197,8 @@ def test_kernels(kernel):
         assert weight.mean() == 0.09084085210598618
         assert weight.max() == 0.9372045972129259
     elif kernel == "cosine":
-        assert weight.mean() == 0.1008306468068958
-        assert weight.max() == 0.7852455006403666
+        assert weight.mean() == pytest.approx(0.1008306468068958)
+        assert weight.max() == pytest.approx(0.7852455006403666)
     elif kernel == "boxcar":
         assert weight.mean() == 0.2499540356683214
         assert weight.max() == 1
@@ -212,8 +212,8 @@ def test_kernels(kernel):
         assert weight.mean() == 39758.007361814016
         assert weight.max() == 127937.75271993055
     else:  # function
-        assert weight.mean() == 0.6880384553732511
-        assert weight.max() == 0.9855481738848647
+        assert weight.mean() == pytest.approx(0.6880384553732511)
+        assert weight.max() == pytest.approx(0.9855481738848647)
 
 
 # def test_precomputed(data, ids):

--- a/libpysal/graph/tests/test_kernel.py
+++ b/libpysal/graph/tests/test_kernel.py
@@ -10,96 +10,215 @@ For completeness, we need to test a shuffled dataframe
 - scikit/no scikit
 """
 
+import geodatasets
+import geopandas
 import numpy as np
-from libpysal.graph._kernel import _kernel
+import pytest
+import pandas as pd
 
-# import pandas, geopandas, geodatasets, pytest, shapely, numpy
-# from libpysal.weights.experimental._kernel import (
-#     kernel,
-#     knn,
-#     _optimize_bandwidth,
-#     _kernel_functions
-# )
+from libpysal.graph._kernel import _kernel, _kernel_functions, _knn, _optimize_bandwidth
 
-# grocs = geopandas.read_file(
-#     geodatasets.get_path("geoda groceries")
-# )[['OBJECTID', 'geometry']]
-# grocs['strID'] = grocs.OBJECTID.astype(str)
-# grocs['intID'] = grocs.OBJECTID.values
+grocs = geopandas.read_file(geodatasets.get_path("geoda groceries"))[
+    ["OBJECTID", "geometry"]
+].explode(ignore_index=True)
+grocs["strID"] = grocs.OBJECTID.astype(str)
+grocs["intID"] = grocs.OBJECTID.values
 
-# kernel_functions = list(_kernel_functions.keys())
+kernel_functions = list(_kernel_functions.keys())
 
-# def my_kernel(distances, bandwidth):
-#     output = numpy.cos(distances/distances.max())
-#     output[distances < bandwidth] = 0
-#     return output
 
-# kernel_functions.append(my_kernel)
+def my_kernel(distances, bandwidth):
+    output = np.cos(distances / distances.max())
+    output[distances < bandwidth] = 0
+    return output
 
-# metrics = ("euclidean", "haversine")
 
-# # optimal, small, and larger than largest distance.
-# # the optimal bandwidth should be smaller than the
-# # max distance for all kernels except identity
-# bandwidth = [None, .05, .4]
+kernel_functions.append(my_kernel)
 
-# numpy.random.seed(6301)
-# # create a 2-d laplace distribution as a "degenerate"
-# # over-concentrated distribution
-# # and rescale to match the lenght-scale in groceries
-# lap_coords = numpy.random.laplace(size=(200,2)) / 50
+metrics = ("euclidean", "haversine")
 
-# # create a 2-d cauchy as a "degenerate"
-# # spatial outlier-y distribution
-# # cau_coords = numpy.random.standard_cauchy(size=(200,2))
+np.random.seed(6301)
+# create a 2-d laplace distribution as a "degenerate"
+# over-concentrated distribution
+# and rescale to match the lenght-scale in groceries
+lap_coords = np.random.laplace(size=(200, 2)) / 50
 
-# data = (
-#     grocs,
-#     lap_coords
-#     )
+# create a 2-d cauchy as a "degenerate"
+# spatial outlier-y distribution
+cau_coords = np.random.standard_cauchy(size=(200, 2))
 
-# parametrize_ids = pytest.mark.parametrize("ids", [None, "strID", "intID"])
-# parametrize_data = pytest.mark.parametrize("data", [grocs, lap_coords, cau_coords], ["groceries", "coords: 2d-laplacian"])
-# parametrize_kernelfunctions = pytest.mark.parametrize(
-#     "kernel",
-#     kernel_functions,
-#     kernel_functions[:-2] + ['None', 'custom callable']
-#     )
-# parametrize_metrics = pytest.mark.parametrize(
-#     "metric",
-#     metrics,
-#     metrics
-#     )
-# parametrize_bw = pytest.mark.parametrize(
-#     "bandwidth",
-#     bandwidth,
-#     ['optimal', 'small', 'large']
-#     )
+data = (grocs, lap_coords)
 
-# # how do we parameterize conditional on sklearn in env?
+parametrize_ids = pytest.mark.parametrize("ids", [None, "strID", "intID"])
+parametrize_data = pytest.mark.parametrize("data", [grocs, lap_coords, cau_coords])
+parametrize_kernelfunctions = pytest.mark.parametrize("kernel", kernel_functions)
+parametrize_metrics = pytest.mark.parametrize("metric", metrics, metrics)
 
-# @parametrize_ids
-# @parametrize_data
-# @parametrize_kernelfunctions
-# @parametrize_metrics
-# @paramterize_bw
-# def test_kernel(data, ids, kernel, metric, bandwidth):
-#     raise NotImplementedError()
+# how do we parameterize conditional on sklearn in env?
 
-# @parametrize_ids
-# @parametrize_data
-# @parametrize_kernelfunctions
-# @parametrize_metrics
-# @paramterize_bw
-# def test_knn(data, ids, kernel, metric, bandwidth):
-#     raise NotImplementedError()
 
-# @parametrize_ids
-# @parametrize_data
+@parametrize_ids
+def test_neighbors(ids):
+    if ids:
+        data = grocs.set_index(ids)
+    else:
+        data = grocs
+    head, tail, weight = _kernel(data, bandwidth=5000, kernel="boxcar")
+    assert head.shape[0] == 437
+    assert tail.shape == head.shape
+    assert weight.shape == head.shape
+    np.testing.assert_array_equal(pd.unique(head), data.index)
+    known = np.linspace(9, 436, 10, dtype=int)
+    head_exp = [2, 16, 28, 41, 55, 72, 92, 111, 135, 147]
+    if ids:
+        head_exp = data.index.values[head_exp]
+    np.testing.assert_array_equal(head.values[known], head_exp)
+    tail_exp = [13, 92, 66, 31, 33, 73, 16, 103, 9, 147]
+    if ids:
+        tail_exp = data.index.values[tail_exp]
+    np.testing.assert_array_equal(tail.values[known], tail_exp)
+    np.testing.assert_array_equal(
+        weight[known],
+        np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 0], dtype="int64"),
+    )
+
+
+@parametrize_data
+def test_no_taper(data):
+    head, tail, weight = _kernel(data, taper=False)
+    assert head.shape[0] == len(data) * (len(data) - 1)
+    assert tail.shape == head.shape
+    assert weight.shape == head.shape
+    if hasattr(data, "index"):
+        np.testing.assert_array_equal(np.unique(head), data.index)
+    else:
+        np.testing.assert_array_equal(np.unique(head), np.arange(len(data)))
+
+
+@parametrize_ids
+def test_ids(ids):
+    if ids:
+        data = grocs.set_index(ids)
+    else:
+        data = grocs
+    head, tail, _ = _kernel(data)
+    np.testing.assert_array_equal(pd.unique(head), data.index)
+    assert np.in1d(tail, data.index).all()
+
+
+def test_distance():
+    _, _, weight = _kernel(grocs, kernel="identity")
+    known = np.linspace(9, weight.shape[0], 10, dtype=int, endpoint=False)
+    np.testing.assert_array_almost_equal(
+        weight[known],
+        np.array(
+            [
+                39028.10991144,
+                51086.85388002,
+                21270.55278224,
+                8999.11607504,
+                91203.25966722,
+                36548.75743352,
+                58917.81440314,
+                63359.35143896,
+                24952.48387721,
+                65860.55093353,
+            ]
+        ),
+    )
+
+    _, _, weight = _kernel(lap_coords, kernel="identity")
+    known = np.linspace(9, weight.shape[0], 10, dtype=int, endpoint=False)
+    np.testing.assert_array_almost_equal(
+        weight[known],
+        np.array(
+            [
+                0.0112305,
+                0.03158595,
+                0.06027445,
+                0.01274032,
+                0.07559474,
+                0.02240698,
+                0.07024776,
+                0.05554498,
+                0.06012029,
+                0.03836196,
+            ]
+        ),
+    )
+
+    _, _, weight = _kernel(cau_coords, kernel="identity")
+    known = np.linspace(9, weight.shape[0], 10, dtype=int, endpoint=False)
+    np.testing.assert_array_almost_equal(
+        weight[known],
+        np.array(
+            [
+                5.16946327,
+                2.29669606,
+                1.60345402,
+                1.23831204,
+                19.2459334,
+                2.99545291,
+                2.33316209,
+                2.09711302,
+                2.12594958,
+                6.19347592,
+            ]
+        ),
+    )
+
+
+@parametrize_data
+def test_k(data):
+    head, tail, weight = _kernel(data, k=3, kernel="identity")
+    assert head.shape[0] == data.shape[0] * 3
+    assert tail.shape == head.shape
+    assert weight.shape == head.shape
+
+    # TODO: what shall be the behaviour when k is set but bandwidth
+    # TODO: is too small so weight is zero, eliminating the link with taper?
+    # TODO: now the affected focal has less neighbors than K without warning
+    # TODO: test it with the code above and default kernel
+
+
+@parametrize_kernelfunctions
+def test_kernels(kernel):
+    _, _, weight = _kernel(grocs, kernel=kernel, taper=False)
+    if kernel == "triangular":
+        assert weight.mean() == 0.09416822598434019
+        assert weight.max() == 0.9874476868358023
+    elif kernel == "parabolic":
+        assert weight.mean() == 0.10312196315841769
+        assert weight.max() == 0.749881829575671
+    elif kernel == "gaussian":
+        assert weight.mean() == 0.1124559308071747
+        assert weight.max() == 0.22507021331712948
+    elif kernel == "bisquare":
+        assert weight.mean() == 0.09084085210598618
+        assert weight.max() == 0.9372045972129259
+    elif kernel == "cosine":
+        assert weight.mean() == 0.1008306468068958
+        assert weight.max() == 0.7852455006403666
+    elif kernel == "boxcar":
+        assert weight.mean() == 0.2499540356683214
+        assert weight.max() == 1
+    elif kernel == "discrete":
+        assert weight.mean() == 0.2499540356683214
+        assert weight.max() == 1
+    elif kernel == "identity":
+        assert weight.mean() == 39758.007361814016
+        assert weight.max() == 127937.75271993055
+    elif kernel is None:
+        assert weight.mean() == 39758.007361814016
+        assert weight.max() == 127937.75271993055
+    else:  # function
+        assert weight.mean() == 0.6880384553732511
+        assert weight.max() == 0.9855481738848647
+
+
 # def test_precomputed(data, ids):
 #     raise NotImplementedError()
 
-# @parametrize_data
 # def test_coincident(data):
 #     raise NotImplementedError()
 
@@ -109,8 +228,27 @@ def test_shape_preservation():
         [np.repeat(np.arange(10), 10), np.tile(np.arange(10), 10)]
     ).T
     head, tail, weight = _kernel(
-        coordinates, k=3, metric="euclidean", p=2, kernel="boxcar", bandwidth=0.5
+        coordinates,
+        k=3,
+        metric="euclidean",
+        p=2,
+        kernel="boxcar",
+        bandwidth=0.5,
+        taper=False,
     )
     np.testing.assert_array_equal(head, np.repeat(np.arange(100), 3))
     assert tail.shape == head.shape, "shapes of head and tail do not match"
     np.testing.assert_array_equal(weight, np.zeros((300,), dtype=int))
+
+    head, tail, weight = _kernel(
+        coordinates,
+        k=3,
+        metric="euclidean",
+        p=2,
+        kernel="boxcar",
+        bandwidth=0.5,
+        taper=True,
+    )
+    np.testing.assert_array_equal(head, np.arange(100))
+    assert tail.shape == head.shape, "shapes of head and tail do not match"
+    np.testing.assert_array_equal(weight, np.zeros((100,), dtype=int))

--- a/libpysal/graph/tests/test_kernel.py
+++ b/libpysal/graph/tests/test_kernel.py
@@ -185,38 +185,41 @@ def test_k(data):
 def test_kernels(kernel):
     _, _, weight = _kernel(grocs, kernel=kernel, taper=False)
     if kernel == "triangular":
-        assert weight.mean() == 0.09416822598434019
-        assert weight.max() == 0.9874476868358023
+        assert weight.mean() == pytest.approx(0.09416822598434019)
+        assert weight.max() == pytest.approx(0.9874476868358023)
     elif kernel == "parabolic":
-        assert weight.mean() == 0.10312196315841769
-        assert weight.max() == 0.749881829575671
+        assert weight.mean() == pytest.approx(0.10312196315841769)
+        assert weight.max() == pytest.approx(0.749881829575671)
     elif kernel == "gaussian":
-        assert weight.mean() == 0.1124559308071747
-        assert weight.max() == 0.22507021331712948
+        assert weight.mean() == pytest.approx(0.1124559308071747)
+        assert weight.max() == pytest.approx(0.22507021331712948)
     elif kernel == "bisquare":
-        assert weight.mean() == 0.09084085210598618
-        assert weight.max() == 0.9372045972129259
+        assert weight.mean() == pytest.approx(0.09084085210598618)
+        assert weight.max() == pytest.approx(0.9372045972129259)
     elif kernel == "cosine":
         assert weight.mean() == pytest.approx(0.1008306468068958)
         assert weight.max() == pytest.approx(0.7852455006403666)
     elif kernel == "boxcar":
-        assert weight.mean() == 0.2499540356683214
+        assert weight.mean() == pytest.approx(0.2499540356683214)
         assert weight.max() == 1
     elif kernel == "discrete":
-        assert weight.mean() == 0.2499540356683214
+        assert weight.mean() == pytest.approx(0.2499540356683214)
         assert weight.max() == 1
     elif kernel == "identity":
-        assert weight.mean() == 39758.007361814016
-        assert weight.max() == 127937.75271993055
+        assert weight.mean() == pytest.approx(39758.007361814016)
+        assert weight.max() == pytest.approx(127937.75271993055)
     elif kernel is None:
-        assert weight.mean() == 39758.007361814016
-        assert weight.max() == 127937.75271993055
+        assert weight.mean() == pytest.approx(39758.007361814016)
+        assert weight.max() == pytest.approx(127937.75271993055)
     else:  # function
         assert weight.mean() == pytest.approx(0.6880384553732511)
         assert weight.max() == pytest.approx(0.9855481738848647)
 
 
 # def test_bandwidth():
+#     raise NotImplementedError()
+
+# def test_metric():
 #     raise NotImplementedError()
 
 # def test_precomputed(data, ids):

--- a/libpysal/graph/tests/test_kernel.py
+++ b/libpysal/graph/tests/test_kernel.py
@@ -16,7 +16,12 @@ import numpy as np
 import pytest
 import pandas as pd
 
-from libpysal.graph._kernel import _kernel, _kernel_functions, _distance_band
+from libpysal.graph._kernel import (
+    _kernel,
+    _kernel_functions,
+    _distance_band,
+    HAS_SKLEARN,
+)
 
 grocs = geopandas.read_file(geodatasets.get_path("geoda groceries"))[
     ["OBJECTID", "geometry"]
@@ -259,9 +264,13 @@ def test_metric(metric):
         assert weight.mean() == pytest.approx(49424.576155)
         assert weight.max() == pytest.approx(173379.431622)
     elif metric == "chebyshev":
+        if not HAS_SKLEARN:
+            pytest.skip("chebyshev not supported by scipy")
         assert weight.mean() == pytest.approx(36590.352895)
         assert weight.max() == pytest.approx(123955.14249)
     else:
+        if not HAS_SKLEARN:
+            pytest.skip("haversine not supported by scipy")
         assert weight.mean() == pytest.approx(0.115835)
         assert weight.max() == pytest.approx(0.371465)
 


### PR DESCRIPTION
- `taper` is back and working properly.
- kernel constructors are tested
- fixed issues with conincident points
- exposes sklearn metrics outside knn

One question:

What shall be the behaviour of kernel when `k` is set but the bandwidth s too small so weight is zero, eliminating the link with taper? now the affected focal has less neighbors than K without a warning. I'd say we may warn but that is about it. You can retrieve the rest using `taper=False`.

_edited_