### PR TITLE
triangulation tests + better ci setup

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -27,6 +27,7 @@
             ci/39.yaml,
             ci/310.yaml,
             ci/311.yaml,
+            ci/311-no-optional.yaml,
             ci/311-dev.yaml
          ]
          include:

--- a/ci/311-dev.yaml
+++ b/ci/311-dev.yaml
@@ -30,5 +30,6 @@ dependencies:
       - scipy
       - pandas
       - xarray
+      - scikit-learn
       - git+https://github.com/shapely/shapely.git@main
       - git+https://github.com/geopandas/geopandas.git@main

--- a/ci/311-no-optional.yaml
+++ b/ci/311-no-optional.yaml
@@ -16,5 +16,6 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   # optional used in ci
-  - geopandas-base>=0.12.0
+  - geopandas-base>=0.12.0  # base to avoid pulling sklearn
   - fiona
+  - geodatasets

--- a/ci/311-no-optional.yaml
+++ b/ci/311-no-optional.yaml
@@ -1,0 +1,20 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - platformdirs
+  - beautifulsoup4
+  - jinja2
+  - pandas
+  - scipy
+  - xarray
+  # testing
+  - codecov
+  - matplotlib
+  - pytest
+  - pytest-cov
+  - pytest-xdist
+  # optional used in ci
+  - geopandas-base>=0.12.0
+  - fiona

--- a/libpysal/graph/tests/test_triangulation.py
+++ b/libpysal/graph/tests/test_triangulation.py
@@ -10,7 +10,8 @@ For completeness, we need to test a shuffled dataframe
 """
 import geodatasets
 import geopandas
-import numpy
+import numpy as np
+import pandas as pd
 import pytest
 import shapely
 from scipy import spatial
@@ -33,7 +34,7 @@ kernel_functions = [None] + list(_kernel_functions.keys())
 
 
 def my_kernel(distances, bandwidth):
-    output = numpy.cos(distances / distances.max())
+    output = np.cos(distances / distances.max())
     output[distances < bandwidth] = 0
     return output
 
@@ -43,14 +44,14 @@ kernel_functions.append(my_kernel)
 # optimal, small, and larger than largest distance.
 bandwidths = [None, "auto", 0.5]
 
-numpy.random.seed(6301)
+np.random.seed(6301)
 # create a 2-d laplace distribution as a "degenerate"
 # over-concentrated distribution
-lap_coords = numpy.random.laplace(size=(5, 2))
+lap_coords = np.random.laplace(size=(5, 2))
 
 # create a 2-d cauchy as a "degenerate"
 # spatial outlier-y distribution
-cau_coords = numpy.random.standard_cauchy(size=(5, 2))
+cau_coords = np.random.standard_cauchy(size=(5, 2))
 
 parametrize_ids = pytest.mark.parametrize(
     "ids", [None, "id", "placeid"], ids=["no id", "id", "placeid"]
@@ -86,7 +87,7 @@ parametrize_constructors = pytest.mark.parametrize(
 #     assert heads.dtype == tails.dtype
 #     assert heads.dtype == stores_unique.get(ids, stores_unique.index).dtype, 'ids failed to propagate'
 #     if kernel is None and bandwidth is None:
-#         numpy.testing.assert_array_equal(weights, numpy.ones_like(heads))
+#         np.testing.assert_array_equal(weights, np.ones_like(heads))
 #     assert set(zip(heads, tails)) == set(zip(tails, heads)), "all triangulations should be symmetric, this is not"
 
 
@@ -105,101 +106,193 @@ def test_correctness_voronoi_clipping():
     D = spatial.distance.squareform(spatial.distance.pdist(lap_coords))
 
     extent_known = [
-        numpy.array([0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 3, 3, 4, 4]),
-        numpy.array([1, 2, 3, 4, 0, 3, 4, 0, 3, 0, 1, 2, 0, 1]),
+        np.array([0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 3, 3, 4, 4]),
+        np.array([1, 2, 3, 4, 0, 3, 4, 0, 3, 0, 1, 2, 0, 1]),
     ]
     alpha_known = [
-        numpy.array([0, 0, 0, 1, 2, 2, 3, 3, 4, 4]),
-        numpy.array([2, 3, 4, 4, 0, 3, 0, 2, 0, 1]),
+        np.array([0, 0, 0, 1, 2, 2, 3, 3, 4, 4]),
+        np.array([2, 3, 4, 4, 0, 3, 0, 2, 0, 1]),
     ]
 
-    numpy.testing.assert_array_equal(G_extent.adjacency.index.get_level_values(0), extent_known[0])
-    numpy.testing.assert_array_equal(G_extent.adjacency.index.get_level_values(1), extent_known[1])
+    np.testing.assert_array_equal(
+        G_extent.adjacency.index.get_level_values(0), extent_known[0]
+    )
+    np.testing.assert_array_equal(
+        G_extent.adjacency.index.get_level_values(1), extent_known[1]
+    )
 
-    numpy.testing.assert_array_equal(G_alpha.adjacency.index.get_level_values(0), alpha_known[0])
-    numpy.testing.assert_array_equal(G_alpha.adjacency.index.get_level_values(1), alpha_known[1])
+    np.testing.assert_array_equal(
+        G_alpha.adjacency.index.get_level_values(0), alpha_known[0]
+    )
+    np.testing.assert_array_equal(
+        G_alpha.adjacency.index.get_level_values(1), alpha_known[1]
+    )
 
 
-# TODO: this now fails, probably never worked.
-@pytest.mark.xfail
-def test_correctness_delaunay_family():
-    for i, data in enumerate((cau_coords, lap_coords)):
-        voronoi = _voronoi(data, clip=False)
-        delaunay = _delaunay(data)
-        gabriel = _gabriel(data)
-        relneigh = _relative_neighborhood(data)
-        G_voronoi = Graph.from_arrays(*voronoi)
-        G_delaunay = Graph.from_arrays(*delaunay)
-        G_gabriel = Graph.from_arrays(*gabriel)
-        G_relneigh = Graph.from_arrays(*relneigh)
+def test_correctness_delaunay():
+    head, tail, weight = _delaunay(cau_coords)
 
-        if i:
-            known_delaunay = [
-                (0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4),
-                (1, 2, 4, 0, 2, 3, 0, 1, 3, 4, 1, 2, 4, 0, 2, 3),
-            ]
-            known_gabriel = [
-                (4, 0, 0, 2, 1, 3, 2, 0, 3, 4),
-                (0, 4, 3, 0, 4, 0, 3, 2, 2, 1),
-            ]
-            known_relneigh = [
-                (0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4),
-                (1, 2, 3, 4, 0, 4, 0, 3, 0, 2, 0, 1),
-            ]
-        else:
-            known_delaunay = [
-                (0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4),
-                (1, 2, 3, 4, 0, 3, 4, 0, 3, 4, 0, 1, 2, 0, 1, 2),
-            ]
-            known_gabriel = [
-                (4, 0, 0, 2, 1, 3, 2, 0, 3, 4),
-                (0, 4, 3, 0, 4, 0, 3, 2, 2, 1),
-            ]
-            known_relneigh = [
-                (0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4),
-                (1, 2, 3, 4, 0, 4, 0, 3, 0, 2, 0, 1),
-            ]
+    known_head = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4])
+    known_tail = np.array([1, 2, 4, 0, 2, 3, 0, 1, 3, 4, 1, 2, 4, 0, 2, 3])
 
-        assert G_voronoi == G_delaunay
-        assert G_gabriel <= G_delaunay
-        assert G_relneigh <= G_delaunay
-        for i, name in enumerate(["delaunay", "gabriel", "relneigh"]):
-            G_known = (known_delaunay, known_gabriel, known_relneigh)[i]
-            G_computed = (delaunay, voronoi, gabriel)[i]
-            assert G_known == G_computed, (
-                f"computed {name} not equivalent to stored {name} for "
-                f"{('cauchy', 'laplacian')[i]} coordinates!"
-            )
+    np.testing.assert_array_equal(known_head, head)
+    np.testing.assert_array_equal(known_tail, tail)
+    np.testing.assert_array_equal(np.ones(head.shape), weight)
+
+    head, tail, weight = _delaunay(lap_coords)
+    known_head = np.array([0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4])
+    known_tail = np.array([1, 2, 3, 4, 0, 3, 4, 0, 3, 4, 0, 1, 2, 0, 1, 2])
+
+    np.testing.assert_array_equal(known_head, head)
+    np.testing.assert_array_equal(known_tail, tail)
+    np.testing.assert_array_equal(np.ones(head.shape), weight)
+
+
+def test_correctness_voronoi():
+    head, tail, weight = _voronoi(cau_coords)
+
+    known_head = np.array([0, 0, 0, 1, 1, 2, 2, 2, 2, 3, 4, 4])
+    known_tail = np.array([1, 2, 4, 0, 2, 0, 1, 3, 4, 2, 0, 2])
+
+    np.testing.assert_array_equal(known_head, head)
+    np.testing.assert_array_equal(known_tail, tail)
+    np.testing.assert_array_equal(np.ones(head.shape), weight)
+
+    head, tail, weight = _voronoi(lap_coords)
+    known_head = np.array([0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 3, 3, 4, 4])
+    known_tail = np.array([1, 2, 3, 4, 0, 3, 4, 0, 3, 0, 1, 2, 0, 1])
+
+    np.testing.assert_array_equal(known_head, head)
+    np.testing.assert_array_equal(known_tail, tail)
+    np.testing.assert_array_equal(np.ones(head.shape), weight)
+
+
+def test_correctness_gabriel():
+    head, tail, weight = _gabriel(cau_coords)
+
+    known_head = np.array([0, 0, 1, 1, 2, 2, 2, 3, 4, 4])
+    known_tail = np.array([1, 4, 0, 2, 1, 3, 4, 2, 0, 2])
+
+    np.testing.assert_array_equal(known_head, head)
+    np.testing.assert_array_equal(known_tail, tail)
+    np.testing.assert_array_equal(np.ones(head.shape), weight)
+
+    head, tail, weight = _gabriel(lap_coords)
+    known_head = np.array([0, 0, 0, 1, 2, 2, 3, 3, 4, 4])
+    known_tail = np.array([2, 3, 4, 4, 0, 3, 0, 2, 0, 1])
+
+    np.testing.assert_array_equal(known_head, head)
+    np.testing.assert_array_equal(known_tail, tail)
+    np.testing.assert_array_equal(np.ones(head.shape), weight)
+
+
+def test_correctness_relative_n():
+    head, tail, weight = _relative_neighborhood(cau_coords)
+
+    known_head = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4])
+    known_tail = np.array([1, 2, 4, 0, 2, 3, 0, 1, 3, 4, 1, 2, 4, 0, 2, 3])
+
+    np.testing.assert_array_equal(known_head, head)
+    np.testing.assert_array_equal(known_tail, tail)
+    np.testing.assert_array_equal(np.ones(head.shape), weight)
+
+    head, tail, weight = _relative_neighborhood(lap_coords)
+    known_head = np.array([0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4])
+    known_tail = np.array([1, 2, 3, 4, 0, 4, 0, 3, 0, 2, 0, 1])
+
+    np.testing.assert_array_equal(known_head, head)
+    np.testing.assert_array_equal(known_tail, tail)
+    np.testing.assert_array_equal(np.ones(head.shape), weight)
+
+
+@parametrize_ids
+def test_ids(ids):
+    data = stores_unique.sample(frac=1)
+    if ids is not None:
+        data = data.set_index(ids)
+    head, tail, weight = _delaunay(data)
+
+    assert head.shape[0] == 3368
+    assert tail.shape == head.shape
+    assert weight.shape == head.shape
+    np.testing.assert_array_equal(pd.unique(head), data.index)
+
+    head, tail, weight = _voronoi(data)
+
+    assert head.shape[0] == 3308
+    assert tail.shape == head.shape
+    assert weight.shape == head.shape
+    np.testing.assert_array_equal(pd.unique(head), data.index)
+
+    head, tail, weight = _gabriel(data)
+
+    assert head.shape[0] == 2024
+    assert tail.shape == head.shape
+    assert weight.shape == head.shape
+    np.testing.assert_array_equal(pd.unique(head), data.index)
+
+    head, tail, weight = _relative_neighborhood(data)
+
+    # assert head.shape[0] == 3346  # relativehood returns unstable results atm see #573
+    assert tail.shape == head.shape
+    assert weight.shape == head.shape
+    np.testing.assert_array_equal(pd.unique(head), data.index)
+
+
+def test_kernel():
+    _, _, weight = _delaunay(cau_coords, kernel="gaussian")
+    expected = np.array(
+        [
+            0.1305618,
+            0.17359059,
+            0.22312817,
+            0.1305618,
+            0.1339654,
+            0.03259559,
+            0.17359059,
+            0.1339654,
+            0.06948067,
+            0.180294,
+            0.03259559,
+            0.06948067,
+            0.02004257,
+            0.22312817,
+            0.180294,
+            0.02004257,
+        ]
+    )
+
+    np.testing.assert_array_almost_equal(expected, weight)
 
 
 def test_coincident_raise_voronoi():
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="There are"):
         _voronoi(stores, clip=False)
-    assert "There are" in str(excinfo.value)
 
 
 def test_coincident_jitter_voronoi():
-    G_voronoi_cp_heads, G_voronoi_cp_tails, cp_w = _voronoi(
-        stores, clip=False, coincident="jitter"
-    )
-    G_voronoi_unique_heads, G_voronoi_unique_tails, unique_w = _voronoi(
-        stores_unique, clip=False
-    )
-    assert not numpy.array_equal(G_voronoi_cp_heads, G_voronoi_unique_heads)
-    assert not numpy.array_equal(G_voronoi_cp_tails, G_voronoi_unique_tails)
-    assert not numpy.array_equal(cp_w, unique_w)
+    cp_heads, cp_tails, cp_w = _voronoi(stores, clip=False, coincident="jitter")
+    unique_heads, unique_tails, unique_w = _voronoi(stores_unique, clip=False)
+    assert not np.array_equal(cp_heads, unique_heads)
+    assert not np.array_equal(cp_tails, unique_tails)
+    assert not np.array_equal(cp_w, unique_w)
+
+    assert cp_heads.shape[0] == 3392
+    assert unique_heads.shape[0] == 3368
 
 
 def test_coincident_clique_voronoi():
-    G_voronoi_cp_heads, G_voronoi_cp_tails, cp_w = _voronoi(
-        stores, clip=False, coincident="clique"
-    )
-    G_voronoi_unique_heads, G_voronoi_unique_tails, unique_w = _voronoi(
-        stores_unique, clip=False
-    )
-    assert not numpy.array_equal(G_voronoi_cp_heads, G_voronoi_unique_heads)
-    assert not numpy.array_equal(G_voronoi_cp_tails, G_voronoi_unique_tails)
-    assert not numpy.array_equal(cp_w, unique_w)
+    with pytest.raises(NotImplementedError, match="clique-based"):
+        _voronoi(stores, clip=False, coincident="clique")
+    # G_voronoi_cp_heads, G_voronoi_cp_tails, cp_w = _voronoi(
+    #     stores, clip=False, coincident="clique"
+    # )
+    # G_voronoi_unique_heads, G_voronoi_unique_tails, unique_w = _voronoi(
+    #     stores_unique, clip=False
+    # )
+    # assert not np.array_equal(G_voronoi_cp_heads, G_voronoi_unique_heads)
+    # assert not np.array_equal(G_voronoi_cp_tails, G_voronoi_unique_tails)
+    # assert not np.array_equal(cp_w, unique_w)
 
 
 class Test_Coincident:
@@ -230,52 +323,44 @@ class Test_Coincident:
     def test_delaunay_jitter(self):
         heads, tails, weights = _delaunay(self.df_int, coincident="jitter", seed=0)
 
-        exp_heads = numpy.array(
+        exp_heads = np.array(
             [0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5]
         )
-        exp_tails = numpy.array(
+        exp_tails = np.array(
             [1, 2, 4, 0, 2, 3, 4, 5, 0, 1, 3, 1, 2, 5, 0, 1, 5, 1, 3, 4]
         )
-        exp_w = numpy.ones(exp_heads.shape, dtype="int8")
+        exp_w = np.ones(exp_heads.shape, dtype="int8")
 
-        numpy.testing.assert_array_equal(heads, exp_heads)
-        numpy.testing.assert_array_equal(tails, exp_tails)
+        np.testing.assert_array_equal(heads, exp_heads)
+        np.testing.assert_array_equal(tails, exp_tails)
 
         heads, tails, weights = _delaunay(self.df_string, coincident="jitter", seed=0)
 
-        numpy.testing.assert_array_equal(
-            heads, numpy.vectorize(self.mapping.get)(exp_heads)
-        )
-        numpy.testing.assert_array_equal(
-            tails, numpy.vectorize(self.mapping.get)(exp_tails)
-        )
-        numpy.testing.assert_array_equal(weights, exp_w)
+        np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
+        np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
+        np.testing.assert_array_equal(weights, exp_w)
 
     @pytest.mark.xfail
     def test_delaunay_clique(self):
         # TODO: fix the implemntation to make this pass
         heads, tails, weights = _delaunay(self.df_int, coincident="clique", seed=0)
 
-        exp_heads = numpy.array(
+        exp_heads = np.array(
             [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5]
         )
-        exp_tails = numpy.array(
+        exp_tails = np.array(
             [1, 2, 4, 5, 0, 2, 3, 5, 0, 1, 3, 1, 2, 5, 0, 1, 2, 5, 0, 1, 3]
         )
-        exp_w = numpy.ones(exp_heads.shape, dtype="int8")
+        exp_w = np.ones(exp_heads.shape, dtype="int8")
 
-        numpy.testing.assert_array_equal(heads, exp_heads)
-        numpy.testing.assert_array_equal(tails, exp_tails)
+        np.testing.assert_array_equal(heads, exp_heads)
+        np.testing.assert_array_equal(tails, exp_tails)
 
         heads, tails, weights = _delaunay(self.df_string, coincident="clique", seed=0)
 
-        numpy.testing.assert_array_equal(
-            heads, numpy.vectorize(self.mapping.get)(exp_heads)
-        )
-        numpy.testing.assert_array_equal(
-            tails, numpy.vectorize(self.mapping.get)(exp_tails)
-        )
-        numpy.testing.assert_array_equal(weights, exp_w)
+        np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
+        np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
+        np.testing.assert_array_equal(weights, exp_w)
 
     def test_gabriel_error(self):
         with pytest.raises(
@@ -287,48 +372,40 @@ class Test_Coincident:
     def test_gabriel_jitter(self):
         heads, tails, weights = _gabriel(self.df_int, coincident="jitter", seed=0)
 
-        exp_heads = numpy.array([0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5])
-        exp_tails = numpy.array([2, 4, 2, 3, 4, 5, 0, 1, 3, 1, 2, 5, 0, 1, 1, 3])
-        exp_w = numpy.ones(exp_heads.shape, dtype="int8")
+        exp_heads = np.array([0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5])
+        exp_tails = np.array([2, 4, 2, 3, 4, 5, 0, 1, 3, 1, 2, 5, 0, 1, 1, 3])
+        exp_w = np.ones(exp_heads.shape, dtype="int8")
 
-        numpy.testing.assert_array_equal(heads, exp_heads)
-        numpy.testing.assert_array_equal(tails, exp_tails)
+        np.testing.assert_array_equal(heads, exp_heads)
+        np.testing.assert_array_equal(tails, exp_tails)
 
         heads, tails, weights = _gabriel(self.df_string, coincident="jitter", seed=0)
 
-        numpy.testing.assert_array_equal(
-            heads, numpy.vectorize(self.mapping.get)(exp_heads)
-        )
-        numpy.testing.assert_array_equal(
-            tails, numpy.vectorize(self.mapping.get)(exp_tails)
-        )
-        numpy.testing.assert_array_equal(weights, exp_w)
+        np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
+        np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
+        np.testing.assert_array_equal(weights, exp_w)
 
     @pytest.mark.xfail
     def test_gabriel_clique(self):
         # TODO: fix the implemntation to make this pass
         heads, tails, weights = _gabriel(self.df_int, coincident="clique", seed=0)
 
-        exp_heads = numpy.array(
+        exp_heads = np.array(
             [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5]
         )
-        exp_tails = numpy.array(
+        exp_tails = np.array(
             [1, 2, 4, 5, 0, 2, 3, 5, 0, 1, 3, 1, 2, 5, 0, 1, 2, 5, 0, 1, 3]
         )
-        exp_w = numpy.ones(exp_heads.shape, dtype="int8")
+        exp_w = np.ones(exp_heads.shape, dtype="int8")
 
-        numpy.testing.assert_array_equal(heads, exp_heads)
-        numpy.testing.assert_array_equal(tails, exp_tails)
+        np.testing.assert_array_equal(heads, exp_heads)
+        np.testing.assert_array_equal(tails, exp_tails)
 
         heads, tails, weights = _gabriel(self.df_string, coincident="clique", seed=0)
 
-        numpy.testing.assert_array_equal(
-            heads, numpy.vectorize(self.mapping.get)(exp_heads)
-        )
-        numpy.testing.assert_array_equal(
-            tails, numpy.vectorize(self.mapping.get)(exp_tails)
-        )
-        numpy.testing.assert_array_equal(weights, exp_w)
+        np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
+        np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
+        np.testing.assert_array_equal(weights, exp_w)
 
     def test_relative_neighborhood_error(self):
         with pytest.raises(
@@ -342,24 +419,20 @@ class Test_Coincident:
             self.df_int, coincident="jitter", seed=0
         )
 
-        exp_heads = numpy.array([0, 0, 0, 1, 1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5])
-        exp_tails = numpy.array([1, 2, 4, 0, 3, 4, 5, 0, 3, 1, 2, 5, 0, 1, 5, 1, 3, 4])
-        exp_w = numpy.ones(exp_heads.shape, dtype="int8")
+        exp_heads = np.array([0, 0, 0, 1, 1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5])
+        exp_tails = np.array([1, 2, 4, 0, 3, 4, 5, 0, 3, 1, 2, 5, 0, 1, 5, 1, 3, 4])
+        exp_w = np.ones(exp_heads.shape, dtype="int8")
 
-        numpy.testing.assert_array_equal(heads, exp_heads)
-        numpy.testing.assert_array_equal(tails, exp_tails)
+        np.testing.assert_array_equal(heads, exp_heads)
+        np.testing.assert_array_equal(tails, exp_tails)
 
         heads, tails, weights = _relative_neighborhood(
             self.df_string, coincident="jitter", seed=0
         )
 
-        numpy.testing.assert_array_equal(
-            heads, numpy.vectorize(self.mapping.get)(exp_heads)
-        )
-        numpy.testing.assert_array_equal(
-            tails, numpy.vectorize(self.mapping.get)(exp_tails)
-        )
-        numpy.testing.assert_array_equal(weights, exp_w)
+        np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
+        np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
+        np.testing.assert_array_equal(weights, exp_w)
 
     @pytest.mark.xfail
     def test_relative_neighborhood_clique(self):
@@ -368,28 +441,24 @@ class Test_Coincident:
             self.df_int, coincident="clique", seed=0
         )
 
-        exp_heads = numpy.array(
+        exp_heads = np.array(
             [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5]
         )
-        exp_tails = numpy.array(
+        exp_tails = np.array(
             [1, 2, 4, 5, 0, 2, 3, 5, 0, 1, 3, 1, 2, 5, 0, 1, 2, 5, 0, 1, 3]
         )
-        exp_w = numpy.ones(exp_heads.shape, dtype="int8")
+        exp_w = np.ones(exp_heads.shape, dtype="int8")
 
-        numpy.testing.assert_array_equal(heads, exp_heads)
-        numpy.testing.assert_array_equal(tails, exp_tails)
+        np.testing.assert_array_equal(heads, exp_heads)
+        np.testing.assert_array_equal(tails, exp_tails)
 
         heads, tails, weights = _relative_neighborhood(
             self.df_string, coincident="clique", seed=0
         )
 
-        numpy.testing.assert_array_equal(
-            heads, numpy.vectorize(self.mapping.get)(exp_heads)
-        )
-        numpy.testing.assert_array_equal(
-            tails, numpy.vectorize(self.mapping.get)(exp_tails)
-        )
-        numpy.testing.assert_array_equal(weights, exp_w)
+        np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
+        np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
+        np.testing.assert_array_equal(weights, exp_w)
 
     def test_voronoi_error(self):
         with pytest.raises(
@@ -401,41 +470,40 @@ class Test_Coincident:
     def test_voronoi_jitter(self):
         heads, tails, weights = _voronoi(self.df_int, coincident="jitter", seed=0)
 
-        exp_heads = numpy.array([0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5])
-        exp_tails = numpy.array([1, 2, 4, 0, 2, 3, 4, 5, 0, 1, 3, 1, 2, 5, 0, 1, 1, 3])
-        exp_w = numpy.ones(exp_heads.shape, dtype="int8")
+        exp_heads = np.array([0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5])
+        exp_tails = np.array([1, 2, 4, 0, 2, 3, 4, 5, 0, 1, 3, 1, 2, 5, 0, 1, 1, 3])
+        exp_w = np.ones(exp_heads.shape, dtype="int8")
 
-        numpy.testing.assert_array_equal(heads, exp_heads)
-        numpy.testing.assert_array_equal(tails, exp_tails)
+        np.testing.assert_array_equal(heads, exp_heads)
+        np.testing.assert_array_equal(tails, exp_tails)
 
         heads, tails, weights = _voronoi(self.df_string, coincident="jitter", seed=0)
 
-        numpy.testing.assert_array_equal(
-            heads, numpy.vectorize(self.mapping.get)(exp_heads)
-        )
-        numpy.testing.assert_array_equal(
-            tails, numpy.vectorize(self.mapping.get)(exp_tails)
-        )
-        numpy.testing.assert_array_equal(weights, exp_w)
+        np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
+        np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
+        np.testing.assert_array_equal(weights, exp_w)
 
     @pytest.mark.xfail
     def test_voronoi_clique(self):
         # TODO: fix the implemntation to make this pass
         heads, tails, weights = _voronoi(self.df_int, coincident="clique", seed=0)
 
-        exp_heads = numpy.array([0, 0, 1, 1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 5, 5])
-        exp_tails = numpy.array([1, 4, 0, 2, 3, 5, 1, 3, 1, 2, 5, 0, 1, 1, 3])
-        exp_w = numpy.ones(exp_heads.shape, dtype="int8")
+        exp_heads = np.array([0, 0, 1, 1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 5, 5])
+        exp_tails = np.array([1, 4, 0, 2, 3, 5, 1, 3, 1, 2, 5, 0, 1, 1, 3])
+        exp_w = np.ones(exp_heads.shape, dtype="int8")
 
-        numpy.testing.assert_array_equal(heads, exp_heads)
-        numpy.testing.assert_array_equal(tails, exp_tails)
+        np.testing.assert_array_equal(heads, exp_heads)
+        np.testing.assert_array_equal(tails, exp_tails)
 
         heads, tails, weights = _voronoi(self.df_string, coincident="clique", seed=0)
 
-        numpy.testing.assert_array_equal(
-            heads, numpy.vectorize(self.mapping.get)(exp_heads)
-        )
-        numpy.testing.assert_array_equal(
-            tails, numpy.vectorize(self.mapping.get)(exp_tails)
-        )
-        numpy.testing.assert_array_equal(weights, exp_w)
+        np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
+        np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
+        np.testing.assert_array_equal(weights, exp_w)
+
+    def test_wrong_resolver(self):
+        with pytest.raises(
+            ValueError,
+            match="Recieved option coincident='nonsense'",
+        ):
+            _delaunay(self.df_int, coincident="nonsense")


### PR DESCRIPTION
Adds more tests of triangulation + a minor change to CI setup to ensure we test code both with and without optional deps, like scikit-learn and numba, while also testing against nightly if sklearn (hence new ci env).