### PR TITLE
implement set ops and to_networkx

### DIFF
--- a/libpysal/graph/_set_ops.py
+++ b/libpysal/graph/_set_ops.py
@@ -149,7 +149,7 @@ class _Set_Mixin:
     def issubgraph(self, right):
         """
         Return True if every link in the left Graph also occurs in the right Graph.
-        This requires both Graph are label_equal. Isolates are ignored.
+        This requires both Graphs are labeled equally. Isolates are ignored.
         """
         join = (
             self._adjacency.drop(self.isolates)

--- a/libpysal/graph/_set_ops.py
+++ b/libpysal/graph/_set_ops.py
@@ -1,4 +1,7 @@
+import numpy as np
 import pandas
+
+from ._utils import _resolve_islands
 
 
 class _Set_Mixin:
@@ -6,32 +9,32 @@ class _Set_Mixin:
     This implements common useful set operations on weights as dunder methods.
     """
 
-    def __le__(self, other):
-        return issubgraph(self, other)
+    def __le__(self, other):  # <=
+        return self.issubgraph(self, other)
 
-    def __ge__(self, other):
-        return issubgraph(self, other)
+    def __ge__(self, other):  # >=
+        return self.issubgraph(other, self)
 
-    def __lt__(self, other):
-        return issubgraph(self, other) & (len(self) < len(other))
+    def __lt__(self, other):  # <
+        return self.issubgraph(self, other) & (len(self) < len(other))
 
-    def __gt__(self, other):
-        return issubgraph(self, other) & (len(self) > len(other))
+    def __gt__(self, other):  # >
+        return self.issubgraph(other, self) & (len(self) > len(other))
 
-    def __eq__(self, other):
-        return label_equals(self, other)
+    def __eq__(self, other):  # ==
+        return self.label_equals(self, other)
 
-    def __ne__(self, other):
-        return not label_equals(self, other)
+    def __ne__(self, other):  # not ==
+        return not self.label_equals(self, other)
 
-    def __and__(self, other):
-        return intersection(self, other)
+    def __and__(self, other):  # &
+        return self.intersection(self, other)
 
-    def __or__(self, other):
-        return union(self, other)
+    def __or__(self, other):  # |
+        return self.union(self, other)
 
-    def __xor__(self, other):
-        return symmetric_difference(self, other)
+    def __xor__(self, other):  # ^
+        return self.symmetric_difference(self, other)
 
     def __iand__(self, other):
         raise TypeError("Graphs are immutable")
@@ -42,191 +45,185 @@ class _Set_Mixin:
     def __len__(self):
         return self.n_edges
 
-
-def intersects(left, right):
-    """
-    Returns True if left and right share at least one link, irrespective of weights
-    value.
-    """
-    raise NotImplementedError
-    if left._adjacency.index.isin(right._adjacency.index).any():
-        return True
-    return False
-
-
-def intersection(left, right):
-    """
-    Returns a binary Graph, that includes only those neighbor pairs that exist
-    in both left and right.
-    """
-    raise NotImplementedError
-    from .base import Graph
-
-    intersecting = (
-        left._adjacency[left._adjacency.index.isin(right._adjacency.index)]
-        .astype(bool)
-        .astype(int)
-    )
-
-    # TODO: do we need to insert isolates? What if left and right have different indices?
-    # TODO: do we need to check if left and right are compatible? e.g. using same indices with the same shape of sparse?
-
-    return Graph(intersecting, transformation="b")
-
-
-def symmetric_difference(left, right):
-    """
-    Filter out links that are in both left and right Graph objects.
-    """
-    raise NotImplementedError
-    from .base import Graph
-
-    join = left.adjacency.merge(
-        right.adjacency, on=("focal", "neighbor"), how="outer", indicator=True
-    )
-    return Graph(join[join._merge.str.endswith("only")].drop("_merge", axis=1))
-
-
-def union(left, right):
-    """
-    Provide the union of two Graph objects, collecing all links that are in either graph.
-    """
-    raise NotImplementedError
-    from .base import Graph
-
-    return Graph(
-        left.adjacency.merge(right.adjacency, on=("focal", "neighbor"), how="outer")
-    )
-
-
-def difference(left, right):
-    """
-    Provide the set difference between the graph on the left and the graph on the right.
-    This returns all links in the left graph that are not in the right graph.
-    """
-    raise NotImplementedError
-    from .base import Graph
-
-    join = left.adjacency.merge(
-        right.adjacency, on=("focal", "neighbor"), how="outer", indicator=True
-    )
-    return Graph(join[join._merge == "left_only"].drop("_merge", axis=1))
-
-
-# TODO: profile the "not intersects(left, right)" vs. the empty join test:
-
-
-def isdisjoint(left, right):
-    """
-    Return True if there are no links in the left Graph that also occur in the right Graph. If
-    any link in the left Graph occurs in the right Graph, the two are not disjoint.
-    """
-    raise NotImplementedError
-    return not intersects(left, right)
-    join = left.adjacency.join(right.adjacency, on=("focal", "neighbor"), how="inner")
-    return join.empty()
-
-
-def issubgraph(left, right):
-    """
-    Return True if every link in the left Graph also occurs in the right Graph. This requires
-    both Graph are label_equal.
-    """
-    join = left.adjacency.reset_index(level=1).merge(
-        right.adjacency.reset_index(level=1),
-        on=("focal", "neighbor"),
-        how="outer",
-        indicator=True,
-    )
-    return not (join._merge == "left_only").any()
-
-
-def issupergraph(left, right):
-    """
-    Return True if every link in the left Graph also occurs in the right Graph. This requires
-    both Graph are label_equal.
-    """
-    join = left.adjacency.reset_index(level=1).merge(
-        right.adjacency.reset_index(level=1),
-        on=("focal", "neighbor"),
-        how="outer",
-        indicator=True,
-    )
-    return not (join._merge == "right_only").any()
-
-
-## TODO: Check that each of these statements is true
-# identical is the same as checking whether list of edge tuples...
-# label_equal is the same as checking whether set of edge tuples...s
-
-
-def _identical(left, right):
-    """
-    Check that two graphs are identical. This reqiures them to have
-    1. the same edge labels and node labels
-    2. in the same order
-    3. with the same weights
-
-    This is implemented by comparing the underlying adjacency dataframes.
-
-    This is equivalent to checking whether the list of edge tuples
-    (focal, neighbor, weight) for the two graphs are the same.
-
-    This should generally *NOT BE USED*. Label equality and isomorphism
-    should be the two "levels" of equality that are commonly-encountered
-    by users. Hence, this is a private function, only for developers to
-    check serialisation/deserialisation issues as necessary.
-    """
-    raise NotImplementedError
-    try:
-        pandas.testing.assert_frame_equal(left.adjacency, right.adjacency)
-    except AssertionError:
-        return True
-    return False
-
-
-def label_equals(left, right):
-    """
-    Check that two graphs have the same labels. This reqiures them to have
-    1. the same edge labels and node labels
-    2. with the same weights
-
-    This is implemented by comparing the underlying adjacency dataframes
-    without respect to ordering.
-
-    This is equivalent to checking whether the set of edge tuples
-    (focal, neighbor, weight) for the two graphs are the same.
-
-    See Also
-    --------
-    isomorphic(left, right) to check if ids in left can be re-labelled to be
-    label_equal to right
-    """
-    try:
-        pandas.testing.assert_series_equal(
-            left._adjacency.sort_index(),
-            right._adjacency.sort_index(),
-            check_dtype=False,
+    def intersects(self, left, right):
+        """
+        Returns True if left and right share at least one link, irrespective of weights
+        value.
+        """
+        intersection = left._adjacncy.index.drop(left.isolates).intersection(
+            right._adjacncy.index.drop(right.isolates)
         )
-    except AssertionError:
+        if len(intersection) > 0:
+            return True
         return False
-    return True
 
+    def intersection(self, left, right):
+        """
+        Returns a binary Graph, that includes only those neighbor pairs that exist
+        in both left and right.
+        """
+        from .base import Graph
 
-def isomorphic(left, right):
-    """
-    Check that two graphs are isomorphic. This requires that a re-labelling
-    can be found to convert one graph into the other graph. Requires networkx.
-    """
-    raise NotImplementedError
-    try:
-        from networkx.algorithms import isomorphism as iso
-    except ImportError:
-        raise ImportError("NetworkX is required to check for graph isomorphism")
-    nxleft, nxright = left.to_networkx(), right.to_networkx()
-    if not iso.faster_could_be_isomorphic(nxleft, nxright):
-        return False
-    elif not iso.could_be_isomorphic(nxleft, nxright):
-        return False
-    else:
-        return iso.is_isomorphic(nxleft, nxright)
+        intersection = left._adjacncy.index.drop(left.isolates).intersection(
+            right._adjacncy.index.drop(right.isolates)
+        )
+        return Graph.from_arrays(
+            *_resolve_islands(
+                intersection.get_level_values("focal"),
+                intersection.get_level_values("neighbor"),
+                left.unique_ids,
+                np.ones(intersection.shape[0], dtype=np.int8),
+            )
+        )
+
+    def symmetric_difference(self, left, right):
+        """
+        Filter out links that are in both left and right Graph objects.
+        """
+        from .base import Graph
+
+        if not (left.unique_ids == right.unique_ids).all():
+            raise ValueError(
+                "Cannot do union of Graphs that are based on different sets of unique IDs."
+            )
+
+        sym_diff = left._adjacncy.index.drop(left.isolates).symmetric_difference(
+            right._adjacncy.index.drop(right.isolates)
+        )
+        return Graph.from_arrays(
+            *_resolve_islands(
+                sym_diff.get_level_values("focal"),
+                sym_diff.get_level_values("neighbor"),
+                left.unique_ids,
+                np.ones(sym_diff.shape[0], dtype=np.int8),
+            )
+        )
+
+    def union(self, left, right):
+        """
+        Provide the union of two Graph objects, collecing all links that are in either graph.
+        """
+        from .base import Graph
+
+        if not (left.unique_ids == right.unique_ids).all():
+            raise ValueError(
+                "Cannot do union of Graphs that are based on different sets of unique IDs."
+            )
+
+        union = left._adjacncy.index.drop(left.isolates).union(
+            right._adjacncy.index.drop(right.isolates)
+        )
+        return Graph.from_arrays(
+            *_resolve_islands(
+                union.get_level_values("focal"),
+                union.get_level_values("neighbor"),
+                left.unique_ids,
+                np.ones(union.shape[0], dtype=np.int8),
+            )
+        )
+
+    def difference(self, left, right):
+        """
+        Provide the set difference between the graph on the left and the graph on the right.
+        This returns all links in the left graph that are not in the right graph.
+        """
+        from .base import Graph
+
+        if not (left.unique_ids == right.unique_ids).all():
+            raise ValueError(
+                "Cannot do union of Graphs that are based on different sets of unique IDs."
+            )
+
+        diff = left._adjacncy.index.drop(left.isolates).difference(
+            right._adjacncy.index.drop(right.isolates)
+        )
+        return Graph.from_arrays(
+            *_resolve_islands(
+                diff.get_level_values("focal"),
+                diff.get_level_values("neighbor"),
+                left.unique_ids,
+                np.ones(diff.shape[0], dtype=np.int8),
+            )
+        )
+
+    def issubgraph(self, left, right):
+        """
+        Return True if every link in the left Graph also occurs in the right Graph.
+        This requires both Graph are label_equal. Isolates are ignored.
+        """
+        join = (
+            left._adjacncy.drop(left.isolates)
+            .reset_index(level=1)
+            .merge(
+                right._adjacncy.drop(right.isolates).reset_index(level=1),
+                on=("focal", "neighbor"),
+                how="outer",
+                indicator=True,
+            )
+        )
+        return not (join._merge == "left_only").any()
+
+    def identical(self, left, right):
+        """
+        Check that two graphs are identical. This reqiures them to have
+        1. the same edge labels and node labels
+        2. in the same order
+        3. with the same weights
+
+        This is implemented by comparing the underlying adjacency series.
+
+        This is equivalent to checking whether the sorted list of edge tuples
+        (focal, neighbor, weight) for the two graphs are the same.
+        """
+        try:
+            pandas.testing.assert_series_equal(left._adjacency, right._adjacency)
+        except AssertionError:
+            return False
+        return True
+
+    def label_equals(self, left, right):
+        """
+        Check that two graphs have the same labels. This reqiures them to have
+        1. the same edge labels and node labels
+        2. with the same weights
+
+        This is implemented by comparing the underlying adjacency dataframes
+        without respect to ordering.
+
+        This is equivalent to checking whether the set of edge tuples
+        (focal, neighbor, weight) for the two graphs are the same.
+
+        See Also
+        --------
+        isomorphic(left, right) to check if ids in left can be re-labelled to be
+        label_equal to right
+        """
+        try:
+            pandas.testing.assert_series_equal(
+                left._adjacency.sort_index(),
+                right._adjacency.sort_index(),
+                check_dtype=False,
+            )
+        except AssertionError:
+            return False
+        return True
+
+    def isomorphic(self, left, right):
+        """
+        Check that two graphs are isomorphic. This requires that a re-labelling
+        can be found to convert one graph into the other graph. Requires networkx.
+        """
+        try:
+            from networkx.algorithms import isomorphism as iso
+        except ImportError:
+            raise ImportError("NetworkX is required to check for graph isomorphism")
+
+        nxleft = left.to_networkx()
+        nxright = right.to_networkx()
+
+        if not iso.faster_could_be_isomorphic(nxleft, nxright):
+            return False
+        elif not iso.could_be_isomorphic(nxleft, nxright):
+            return False
+        else:
+            return iso.is_isomorphic(nxleft, nxright)

--- a/libpysal/graph/_set_ops.py
+++ b/libpysal/graph/_set_ops.py
@@ -50,8 +50,8 @@ class _Set_Mixin:
         Returns True if left and right share at least one link, irrespective of weights
         value.
         """
-        intersection = left._adjacncy.index.drop(left.isolates).intersection(
-            right._adjacncy.index.drop(right.isolates)
+        intersection = left._adjacency.index.drop(left.isolates).intersection(
+            right._adjacency.index.drop(right.isolates)
         )
         if len(intersection) > 0:
             return True
@@ -64,8 +64,8 @@ class _Set_Mixin:
         """
         from .base import Graph
 
-        intersection = left._adjacncy.index.drop(left.isolates).intersection(
-            right._adjacncy.index.drop(right.isolates)
+        intersection = left._adjacency.index.drop(left.isolates).intersection(
+            right._adjacency.index.drop(right.isolates)
         )
         return Graph.from_arrays(
             *_resolve_islands(
@@ -87,8 +87,8 @@ class _Set_Mixin:
                 "Cannot do union of Graphs that are based on different sets of unique IDs."
             )
 
-        sym_diff = left._adjacncy.index.drop(left.isolates).symmetric_difference(
-            right._adjacncy.index.drop(right.isolates)
+        sym_diff = left._adjacency.index.drop(left.isolates).symmetric_difference(
+            right._adjacency.index.drop(right.isolates)
         )
         return Graph.from_arrays(
             *_resolve_islands(
@@ -110,8 +110,8 @@ class _Set_Mixin:
                 "Cannot do union of Graphs that are based on different sets of unique IDs."
             )
 
-        union = left._adjacncy.index.drop(left.isolates).union(
-            right._adjacncy.index.drop(right.isolates)
+        union = left._adjacency.index.drop(left.isolates).union(
+            right._adjacency.index.drop(right.isolates)
         )
         return Graph.from_arrays(
             *_resolve_islands(
@@ -129,13 +129,8 @@ class _Set_Mixin:
         """
         from .base import Graph
 
-        if not (left.unique_ids == right.unique_ids).all():
-            raise ValueError(
-                "Cannot do union of Graphs that are based on different sets of unique IDs."
-            )
-
-        diff = left._adjacncy.index.drop(left.isolates).difference(
-            right._adjacncy.index.drop(right.isolates)
+        diff = left._adjacency.index.drop(left.isolates).difference(
+            right._adjacency.index.drop(right.isolates)
         )
         return Graph.from_arrays(
             *_resolve_islands(
@@ -152,10 +147,10 @@ class _Set_Mixin:
         This requires both Graph are label_equal. Isolates are ignored.
         """
         join = (
-            left._adjacncy.drop(left.isolates)
+            left._adjacency.drop(left.isolates)
             .reset_index(level=1)
             .merge(
-                right._adjacncy.drop(right.isolates).reset_index(level=1),
+                right._adjacency.drop(right.isolates).reset_index(level=1),
                 on=("focal", "neighbor"),
                 how="outer",
                 indicator=True,

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -995,7 +995,7 @@ class Graph(_Set_Mixin):
     @cached_property
     def n_edges(self):
         """Number of observations."""
-        return self.adjacency.shape[0] - self.isolates.shape[0]
+        return self._adjacency.shape[0] - self.isolates.shape[0]
 
     @cached_property
     def pct_nonzero(self):
@@ -1006,7 +1006,7 @@ class Graph(_Set_Mixin):
     @cached_property
     def nonzero(self):
         """Number of nonzero weights."""
-        return self.n_edges - len(self.isolates)
+        return (self._adjacency.drop(self.isolates) > 0).sum()
 
     def asymmetry(self, intrinsic=True):
         """Asymmetry check.

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -995,7 +995,7 @@ class Graph(_Set_Mixin):
     @cached_property
     def n_edges(self):
         """Number of observations."""
-        return self.adjacency.shape[0]
+        return self.adjacency.shape[0] - self.isolates.shape[0]
 
     @cached_property
     def pct_nonzero(self):
@@ -1175,6 +1175,34 @@ class Graph(_Set_Mixin):
         read_parquet
         """
         _to_parquet(self, path, **kwargs)
+
+    def to_networkx(self):
+        """Convert Graph to a ``networkx`` graph.
+
+        If Graph is symmetric, returns ``nx.Graph``, otherwise returns a ``nx.DiGraph``.
+
+        Returns
+        -------
+        networkx.Graph | networkx.DiGraph
+            Representation of libpysal Graph as networkx graph
+        """
+        try:
+            import networkx as nx
+        except ImportError:
+            raise ImportError("NetworkX is required.")
+
+        if self.asymmetry().empty:
+            graph_type = nx.Graph
+        else:
+            graph_type = nx.DiGraph
+
+        return nx.from_pandas_edgelist(
+            self._adjacency.reset_index(),
+            source="focal",
+            target="neighbor",
+            edge_attr="weight",
+            create_using=graph_type,
+        )
 
 
 def _arrange_arrays(heads, tails, weights, ids=None):

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -230,9 +230,9 @@ class TestBase:
         np.testing.assert_array_equal(W.id_order, self.letters[:10])
 
     def test_from_sparse(self):
-        row = np.array([0, 3, 1, 0])
-        col = np.array([1, 0, 1, 2])
-        data = np.array([0.1, 0.5, 1, 0.9])
+        row = np.array([0, 0, 1, 2, 3, 3])
+        col = np.array([1, 3, 3, 2, 1, 3])
+        data = np.array([0.1, 0.5, 0.9, 0, 0.3, 0.1])
         sp = sparse.coo_array((data, (row, col)), shape=(4, 4))
         G = graph.Graph.from_sparse(sp)
         expected = graph.Graph.from_arrays(row, col, data)
@@ -252,7 +252,9 @@ class TestBase:
         )
 
         expected = graph.Graph.from_arrays(
-            ["zero", "three", "one", "zero"], ["one", "zero", "one", "two"], data
+            ["zero", "zero", "one", "two", "three", "three"],
+            ["one", "three", "three", "two", "one", "three"],
+            data,
         )
         G_named == expected
 
@@ -266,7 +268,7 @@ class TestBase:
             sp.tocsc(),
             ids=ids,
         )
-        assert G == expected, "sparse csr with ids does not match arrays constructor"
+        assert G == (expected), "sparse csr with ids does not match arrays constructor"
 
         dense = np.array(
             [

--- a/libpysal/graph/tests/test_set_ops.py
+++ b/libpysal/graph/tests/test_set_ops.py
@@ -1,0 +1,139 @@
+import pytest
+import geodatasets
+import geopandas
+import pandas as pd
+from libpysal.graph.base import Graph
+
+
+class Test_Set_Ops:
+    def setup_method(self):
+        self.grocs = geopandas.read_file(geodatasets.get_path("geoda groceries"))[
+            ["OBJECTID", "geometry"]
+        ].explode(ignore_index=True)
+
+        self.distance500 = Graph.build_distance_band(self.grocs, 500)
+        self.distance2500 = Graph.build_distance_band(self.grocs, 2500)
+        self.knn3 = Graph.build_knn(self.grocs, 3)
+
+        self.distance2500_id = Graph.build_distance_band(
+            self.grocs.set_index("OBJECTID"), 2500
+        )
+
+    def test_intersects(self):
+        assert self.distance2500.intersects(self.knn3)
+        assert self.knn3.intersects(self.distance2500)
+        assert not self.knn3.intersects(self.distance2500_id)
+        assert not self.distance2500.intersects(self.distance2500_id)
+
+    def test_intersection(self):
+        result = self.distance2500.intersection(self.knn3)
+        assert len(result) == 115
+        assert result._adjacency.shape[0] == 185
+        pd.testing.assert_index_equal(result.unique_ids, self.distance2500.unique_ids)
+
+    def test_symmetric_difference(self):
+        result = self.distance2500.symmetric_difference(self.knn3)
+        assert len(result) == 334
+        assert result._adjacency.shape[0] == 340
+        pd.testing.assert_index_equal(result.unique_ids, self.distance2500.unique_ids)
+
+        with pytest.raises(ValueError, match="Cannot do symmetric difference"):
+            self.distance2500_id.symmetric_difference(self.knn3)
+
+    def test_union(self):
+        result = self.distance2500.union(self.knn3)
+        assert len(result) == 449
+        assert result._adjacency.shape[0] == 449
+        pd.testing.assert_index_equal(result.unique_ids, self.distance2500.unique_ids)
+
+        with pytest.raises(ValueError, match="Cannot do union"):
+            self.distance2500_id.union(self.knn3)
+
+    def test_difference(self):
+        result = self.distance2500.difference(self.knn3)
+        assert len(result) == 5
+        assert result._adjacency.shape[0] == 148
+        pd.testing.assert_index_equal(result.unique_ids, self.distance2500.unique_ids)
+
+        result = self.knn3.difference(self.distance2500)
+        assert len(result) == 329
+        assert result._adjacency.shape[0] == 340
+        pd.testing.assert_index_equal(result.unique_ids, self.knn3.unique_ids)
+
+    def test_issubgraph(self):
+        assert self.distance500.issubgraph(self.distance2500)
+        assert not self.distance2500.issubgraph(self.distance500)
+        assert not self.knn3.issubgraph(self.distance2500)
+        assert self.knn3.issubgraph(self.knn3)
+
+    def test_equals(self):
+        assert self.distance2500.equals(self.distance2500.copy())
+        assert not self.distance2500.equals(self.distance2500.transform("r"))
+
+    def test_isomorphic(self):
+        assert self.distance2500.isomorphic(self.distance2500_id)
+
+    def test___le__(self):
+        assert self.distance500 <= self.distance2500
+        assert not self.knn3 <= self.distance2500
+        assert self.distance2500 <= self.distance2500
+
+    def test___ge__(self):
+        assert self.distance2500 >= self.distance500
+        assert not self.knn3 >= self.distance2500
+        assert self.distance2500 >= self.distance2500
+
+    def test___lt__(self):
+        assert self.distance500 < self.distance2500
+        assert not self.knn3 < self.distance2500
+        assert not self.distance2500 < self.distance2500
+
+    def test___gt__(self):
+        assert self.distance2500 > self.distance500
+        assert not self.knn3 > self.distance2500
+        assert not self.distance2500 > self.distance2500
+
+    def test___eq__(self):
+        assert self.distance2500 == self.distance2500.copy()
+        assert not self.distance2500 == self.distance2500_id
+
+    def test___ne__(self):
+        assert not self.distance2500 != self.distance2500.copy()
+        assert self.distance2500 != self.distance2500_id
+
+    def test___and__(self):
+        result = self.distance2500 & self.knn3
+        assert len(result) == 115
+        assert result._adjacency.shape[0] == 185
+        pd.testing.assert_index_equal(result.unique_ids, self.distance2500.unique_ids)
+
+    def test___or__(self):
+        result = self.distance2500 | self.knn3
+        assert len(result) == 449
+        assert result._adjacency.shape[0] == 449
+        pd.testing.assert_index_equal(result.unique_ids, self.distance2500.unique_ids)
+
+        with pytest.raises(ValueError, match="Cannot do union"):
+            self.distance2500_id | self.knn3
+
+    def test___xor__(self):
+        result = self.distance2500 ^ self.knn3
+        assert len(result) == 334
+        assert result._adjacency.shape[0] == 340
+        pd.testing.assert_index_equal(result.unique_ids, self.distance2500.unique_ids)
+
+        with pytest.raises(ValueError, match="Cannot do symmetric difference"):
+            self.distance2500_id ^ self.knn3
+
+    def test___iand__(self):
+        with pytest.raises(TypeError, match="Graphs are immutable."):
+            self.distance2500 &= self.knn3
+
+    def test___ior__(self):
+        with pytest.raises(TypeError, match="Graphs are immutable."):
+            self.distance2500 |= self.knn3
+
+    def test___len__(self):
+        assert len(self.distance2500) == 120
+        assert len(self.distance500) == 8
+        assert len(self.knn3) == len(self.grocs) * 3


### PR DESCRIPTION
The refactor of set operations on Graph based on MultiIndex and inclusion of `to_networkx` to allow `isomorphic` check.

Operations resulting in a combination of edges from two graphs (union, symmetric_difference) are allowed only if their `unique_ids` match, otherwise we do not know the canonical order of adjacency.

I am also excluding isolates from `n_edges` as a self-loop is our internal representation of an isolate and not an edge of a graph.

I have also included all set operations as methods on Graph, following the pandas model.

Tests will come hopefully later today.