### PR TITLE
Delay example data dir creation, add fallback for unwriteable $HOME

### DIFF
--- a/libpysal/examples/base.py
+++ b/libpysal/examples/base.py
@@ -7,6 +7,7 @@ Base class for managing example datasets.
 
 import io
 import os
+import tempfile
 import webbrowser
 from platformdirs import user_data_dir
 import zipfile
@@ -34,8 +35,15 @@ def get_data_home():
     appname = "pysal"
     appauthor = "pysal"
     data_home = user_data_dir(appname, appauthor)
-    if not os.path.exists(data_home):
+
+    try:
+        if not os.path.exists(data_home):
+            os.makedirs(data_home, exist_ok=True)
+    except OSError:
+        # Try to fall back to a tmp directory
+        data_home = os.path.join(tempfile.gettempdir(), "pysal")
         os.makedirs(data_home, exist_ok=True)
+
     return data_home
 
 

--- a/libpysal/examples/base.py
+++ b/libpysal/examples/base.py
@@ -140,8 +140,9 @@ class Example:
         self.root = name.replace(" ", "_")
         self.installed = self.downloaded()
 
-    def get_local_path(self, path=get_data_home()) -> str:
+    def get_local_path(self, path=None) -> str:
         """Get the local path for example."""
+        path = path or get_data_home()
         return os.path.join(path, self.root)
 
     def get_path(self, file_name, verbose=True) -> Union[str, None]:
@@ -179,8 +180,9 @@ class Example:
 
         return IFrame(self.explain_url, width=700, height=350)
 
-    def download(self, path=get_data_home()):
+    def download(self, path=None):
         """Download the files for the example."""
+        path = path or get_data_home()
 
         if not self.downloaded():
             try:


### PR DESCRIPTION
Libpysal will try to create the data directory for storing example data at import time, even if no example objects are used.
We are running a tool in a singularity containers and have libpysal as a subdependency. We do not want to mount the user home directory in the container since this can damage reproducibility (eg python module picked up under `~/.local` etc).

libpysal causes a failure due to "read-only" OSError exceptions when creating the pysal data directory during the import when running in singularity.

This PR simply moves creation of the data dir to the moment when it is actually needed because an example dataset is used.
This avoids the issue we are having mentioned above. Additionaly this also adds a fallback in `get_data_home` to use a temporary directory instead of the users home dir if that directory cannot be created. This is the same behavior as eg. the matplotlib [MPLCONFIGDIR](https://matplotlib.org/stable/users/installing/environment_variables_faq.html#envvar-MPLCONFIGDIR) default.





