### PR TITLE
`./cg/*.py` – format, lint, & remove docstring spaces

### DIFF
--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -11,10 +11,10 @@ Author(s):
 
 import numpy as np
 import scipy.spatial as spat
-from scipy import sparse
 from packaging.version import Version
+from scipy import sparse
 
-from ..common import requires, jit, HAS_JIT
+from ..common import HAS_JIT, jit, requires
 
 if not HAS_JIT:
     from warnings import warn
@@ -44,33 +44,28 @@ def nb_dist(x, y):
 
     Parameters
     ----------
-
     x : ndarray
         Coordinates of point `x`
-
     y : ndarray
         Coordinates of point `y`
 
     Returns
     -------
-
     dist : float
         Distance between `x` and `y`
 
     Examples
     --------
-
     >>> x = np.array([0, 0])
     >>> y = np.array([1, 1])
     >>> dist = nb_dist(x, y)
     >>> dist
     1.4142135623730951
-
     """
-    sum = 0
-    for x_i, y_i in zip(x, y):
-        sum += (x_i - y_i) ** 2
-    dist = np.sqrt(sum)
+    sum_ = 0
+    for x_i, y_i in zip(x, y):  # noqa B905
+        sum_ += (x_i - y_i) ** 2
+    dist = np.sqrt(sum_)
     return dist
 
 
@@ -80,7 +75,6 @@ def r_circumcircle_triangle_single(a, b, c):
 
     Parameters
     ----------
-
     a : ndarray
         (2,) Array with coordinates of vertex `a` of the triangle
     b : ndarray
@@ -90,29 +84,23 @@ def r_circumcircle_triangle_single(a, b, c):
 
     Returns
     -------
-
     r : float
         Circumcircle of the triangle
 
     Notes
     -----
-
     Source for equations:
-
     > https://www.mathopenref.com/trianglecircumcircle.html
-
     [Last accessed July 11th. 2018]
 
     Examples
     --------
-
     >>> a = np.array([0, 0])
     >>> b = np.array([0.5, 0])
     >>> c = np.array([0.25, 0.25])
     >>> r = r_circumcircle_triangle_single(a, b, c)
     >>> r
     0.2500000000000001
-
     """
     ab = nb_dist(a, b)
     bc = nb_dist(b, c)
@@ -132,7 +120,6 @@ def r_circumcircle_triangle(a_s, b_s, c_s):
 
     Parameters
     ----------
-
     a_s : ndarray
         (N, 2) array with coordinates of vertices `a` of the triangles
     b_s : ndarray
@@ -142,20 +129,17 @@ def r_circumcircle_triangle(a_s, b_s, c_s):
 
     Returns
     -------
-
     radii : ndarray
         (N,) array with circumcircles for every triangle
 
     Examples
     --------
-
     >>> a_s = np.array([[0, 0], [2, 1], [3, 2]])
     >>> b_s = np.array([[1, 0], [5, 1], [2, 4]])
     >>> c_s = np.array([[0, 7], [1, 3], [4, 2]])
     >>> rs = r_circumcircle_triangle(a_s, b_s, c_s)
     >>> rs
     array([3.53553391, 2.5       , 1.58113883])
-
     """
     len_a = len(a_s)
     r2 = np.zeros((len_a,))
@@ -170,27 +154,23 @@ def get_faces(triangle):
 
     Parameters
     ----------
-
     triangles : ndarray
         (3,) array with the vertex indices for a triangle
 
     Returns
     -------
-
     faces : ndarray
         (3, 2) array with a row for each face containing the indices of the two
         points that make up the face
 
     Examples
     --------
-
     >>> triangle = np.array([3, 1, 4], dtype=np.int32)
     >>> faces = get_faces(triangle)
     >>> faces
     array([[3., 1.],
            [1., 4.],
            [4., 3.]])
-
     """
     faces = np.zeros((3, 2))
     for i, (i0, i1) in enumerate([(0, 1), (1, 2), (2, 0)]):
@@ -204,30 +184,24 @@ def build_faces(faces, triangles_is, num_triangles, num_faces_single):
 
     Parameters
     ----------
-
     faces : ndarray
         (num_triangles * num_faces_single, 2) array of zeroes in int form
-
     triangles_is : ndarray
         (D, 3) array, where D is the number of Delaunay triangles, with the
         vertex indices for each triangle
-
     num_triangles : int
         Number of triangles
-
     num_faces_single : int
         Number of faces a triangle has (i.e. 3)
 
     Returns
     -------
-
     faces : ndarray
         Two dimensional array with a row for every facing segment containing
         the indices of the coordinate points
 
     Examples
     --------
-
     >>> import scipy.spatial as spat
     >>> pts = np.array([[0, 1], [3, 5], [4, 1], [6, 7], [9, 3]])
     >>> triangulation = spat.Delaunay(pts)
@@ -240,7 +214,9 @@ def build_faces(faces, triangles_is, num_triangles, num_faces_single):
     >>> num_faces = num_triangles * num_faces_single
     >>> faces = np.zeros((num_faces, 2), dtype=np.int_)
     >>> mask = np.ones((num_faces,), dtype=np.bool_)
-    >>> faces = build_faces(faces, triangulation.simplices, num_triangles, num_faces_single)
+    >>> faces = build_faces(
+    ...     faces, triangulation.simplices, num_triangles, num_faces_single
+    ... )
     >>> faces
     array([[3, 1],
            [1, 4],
@@ -251,7 +227,6 @@ def build_faces(faces, triangles_is, num_triangles, num_faces_single):
            [2, 1],
            [1, 0],
            [0, 2]])
-
     """
     for i in range(num_triangles):
         from_i = num_faces_single * i
@@ -267,26 +242,26 @@ def nb_mask_faces(mask, faces):
 
     Parameters
     ----------
-
     mask : ndarray
         One-dimensional boolean array set to True with as many observations as
         rows in `faces`
-
     faces : ndarray
         Sorted sequence of faces for all triangles (ie. triangles split by each
         segment)
 
     Returns
     -------
-
     masked : ndarray
          Sequence of outward-facing faces
 
     Examples
     --------
-
     >>> import numpy as np
-    >>> faces = np.array([[0, 1], [0, 2], [1, 2], [1, 2], [1, 3], [1, 4], [1, 4], [2, 4], [3, 4]])
+    >>> faces = np.array(
+    ...     [
+    ...         [0, 1], [0, 2], [1, 2], [1, 2], [1, 3], [1, 4], [1, 4], [2, 4], [3, 4]
+    ...     ]
+    ... )
     >>> mask = np.ones((faces.shape[0], ), dtype=np.bool_)
     >>> masked = nb_mask_faces(mask, faces)
     >>> masked
@@ -295,13 +270,11 @@ def nb_mask_faces(mask, faces):
            [1, 3],
            [2, 4],
            [3, 4]])
-
     """
     for k in range(faces.shape[0] - 1):
-        if mask[k]:
-            if np.all(faces[k] == faces[k + 1]):
-                mask[k] = False
-                mask[k + 1] = False
+        if mask[k] and np.all(faces[k] == faces[k + 1]):
+            mask[k] = False
+            mask[k + 1] = False
     return faces[mask]
 
 
@@ -310,19 +283,16 @@ def get_single_faces(triangles_is):
 
     Parameters
     ----------
-
     triangles_is : ndarray
         (D, 3) array, where D is the number of Delaunay triangles, with the
         vertex indices for each triangle
 
     Returns
     -------
-
     single_faces : ndarray
 
     Examples
     --------
-
     >>> import scipy.spatial as spat
     >>> pts = np.array([[0, 1], [3, 5], [4, 1], [6, 7], [9, 3]])
     >>> alpha = 0.33
@@ -337,7 +307,6 @@ def get_single_faces(triangles_is):
            [1, 3],
            [2, 4],
            [3, 4]])
-
     """
     num_faces_single = 3
     num_triangles = triangles_is.shape[0]
@@ -347,7 +316,7 @@ def get_single_faces(triangles_is):
 
     faces = build_faces(faces, triangles_is, num_triangles, num_faces_single)
 
-    orderlist = ["x{}".format(i) for i in range(faces.shape[1])]
+    orderlist = [f"x{i}" for i in range(faces.shape[1])]
     dtype_list = [(el, faces.dtype.str) for el in orderlist]
     # Arranging each face so smallest vertex is first
     faces.sort(axis=1)
@@ -365,23 +334,18 @@ def _alpha_geoms(alpha, triangles, radii, xys):
 
     Parameters
     ----------
-
     alpha : float
         Alpha value to delineate the alpha-shape
-
     triangles : ndarray
          (D, 3) array, where D is the number of Delaunay triangles, with the
          vertex indices for each triangle
-
     radii : ndarray
         (N,) array with circumcircles for every triangle
-
     xys : ndarray
         (N, 2) array with one point per row and coordinates structured as X and Y
 
     Returns
     -------
-
     geoms : GeoSeries
         Polygon(s) resulting from the alpha shape algorithm, in a GeoSeries.
         The output is a GeoSeries even if only a single polygon is returned. There is
@@ -389,7 +353,6 @@ def _alpha_geoms(alpha, triangles, radii, xys):
 
     Examples
     --------
-
     >>> import scipy.spatial as spat
     >>> pts = np.array([[0, 1], [3, 5], [4, 1], [6, 7], [9, 3]])
     >>> alpha = 0.33
@@ -415,11 +378,10 @@ def _alpha_geoms(alpha, triangles, radii, xys):
     >>> geoms
     0    POLYGON ((0.00000 1.00000, 3.00000 5.00000, 4....
     dtype: geometry
-
     """
+    from geopandas import GeoSeries
     from shapely.geometry import LineString
     from shapely.ops import polygonize
-    from geopandas import GeoSeries
 
     triangles_reduced = triangles[radii < 1 / alpha]
     outer_triangulation = get_single_faces(triangles_reduced)
@@ -430,21 +392,18 @@ def _alpha_geoms(alpha, triangles, radii, xys):
 
 @requires("geopandas", "shapely")
 def alpha_shape(xys, alpha):
-    """Alpha-shape delineation (Edelsbrunner, Kirkpatrick & Seidel, 1983) from a collection of points
+    """Alpha-shape delineation (Edelsbrunner, Kirkpatrick & Seidel, 1983)
+    from a collection of points
 
     Parameters
     ----------
-
     xys : ndarray
-        (N, 2) array with one point per row and coordinates structured as X and
-        Y
-
+        (N, 2) array with one point per row and coordinates structured as X and Y
     alpha : float
         Alpha value to delineate the alpha-shape
 
     Returns
     -------
-
     shapes : GeoSeries
          Polygon(s) resulting from the alpha shape algorithm. The GeoSeries
          object remains so even if only a single polygon is returned. There is
@@ -453,7 +412,6 @@ def alpha_shape(xys, alpha):
 
     Examples
     --------
-
     >>> pts = np.array([[0, 1], [3, 5], [4, 1], [6, 7], [9, 3]])
     >>> alpha = 0.1
     >>> poly = alpha_shape(pts, alpha)
@@ -464,19 +422,17 @@ def alpha_shape(xys, alpha):
     0    POINT (4.69048 3.45238)
     dtype: geometry
 
-
     References
     ----------
-
     Edelsbrunner, H., Kirkpatrick, D., & Seidel, R. (1983). On the shape of
         a set of points in the plane. IEEE Transactions on information theory,
         29(4), 551-559.
-
     """
     if not HAS_JIT:
-        warn(NUMBA_WARN)
+        warn(NUMBA_WARN)  # noqa B028
     if xys.shape[0] < 4:
-        from shapely import ops, geometry as geom
+        from shapely import geometry as geom
+        from shapely import ops
 
         return ops.unary_union([geom.Point(xy) for xy in xys]).convex_hull.buffer(0)
     triangulation = spat.Delaunay(xys)
@@ -497,21 +453,16 @@ def _valid_hull(geoms, points):
 
     Parameters
     ----------
-
     geoms : GeoSeries
         See alpha_geoms()
-
     points : list
         xys parameter cast as shapely.geometry.Point objects
 
     Returns
     -------
-
     flag : bool
         Valid hull for alpha shape [True] or not [False]
-
     """
-    flag = True
     # if there is not exactly one polygon
     if geoms.shape[0] != 1:
         return False
@@ -519,10 +470,7 @@ def _valid_hull(geoms, points):
     if HAS_SHAPELY:
         return shapely.intersects(geoms[0], points).all()
     else:
-        for point in points:
-            if not point.intersects(geoms[0]):
-                return False
-        return True
+        return all(point.intersects(geoms[0]) for point in points)
 
 
 @requires("geopandas", "shapely")
@@ -545,14 +493,13 @@ def alpha_shape_auto(
 
     xys : ndarray
         Nx2 array with one point per row and coordinates structured as X and Y
-
     step : int
         [Optional. Default=1] Number of points in `xys` to jump ahead after
         checking whether the largest possible alpha that includes the point and
         all the other ones with smaller radii
-
     verbose : Boolean
-        [Optional. Default=False] If True, it prints alpha values being tried at every step.
+        [Optional. Default=False] If True, it prints alpha values
+        being tried at every step.
 
     Returns
     -------
@@ -561,7 +508,6 @@ def alpha_shape_auto(
 
     Examples
     --------
-
     >>> pts = np.array([[0, 1], [3, 5], [4, 1], [6, 7], [9, 3]])
     >>> poly = alpha_shape_auto(pts)
     >>> poly.bounds
@@ -571,14 +517,13 @@ def alpha_shape_auto(
 
     References
     ----------
-
     Edelsbrunner, H., Kirkpatrick, D., & Seidel, R. (1983). On the shape of
         a set of points in the plane. IEEE Transactions on information theory,
         29(4), 551-559.
 
     """
     if not HAS_JIT:
-        warn(NUMBA_WARN)
+        warn(NUMBA_WARN)  # noqa B028
     from shapely import geometry as geom
 
     if return_circles:
@@ -624,17 +569,14 @@ def alpha_shape_auto(
     triangles = triangulation.simplices[radii_sorted_i][::-1]
     radii = radii[radii_sorted_i][::-1]
     geoms_prev = _alpha_geoms((1 / radii.max()) - EPS, triangles, radii, xys)
-    if HAS_SHAPELY:
-        points = shapely.points(xys)
-    else:
-        points = [geom.Point(pnt) for pnt in xys]
+    points = shapely.points(xys) if HAS_SHAPELY else [geom.Point(pnt) for pnt in xys]
     if verbose:
         print("Step set to %i" % step)
     for i in range(0, len(radii), step):
         radi = radii[i]
         alpha = (1 / radi) - EPS
         if verbose:
-            print("%.2f%% | Trying a = %f" % ((i + 1) / radii.shape[0], alpha))
+            print(f"{(i + 1) / radii.shape[0]:.2f}% | Trying a = {alpha:f}")
         geoms = _alpha_geoms(alpha, triangles, radii, xys)
         if _valid_hull(geoms, points):
             geoms_prev = geoms
@@ -660,7 +602,6 @@ def construct_bounding_circles(alpha_shape, radius):
     ----------
     alpha_shape : shapely.Polygon
         An alpha-hull with the input radius.
-
     radius : float
         The radius of the input alpha_shape.
 
@@ -668,7 +609,6 @@ def construct_bounding_circles(alpha_shape, radius):
     -------
     center : numpy.ndarray of shape (n,2)
         The centers of the circles defining the alpha_shape.
-
     """
     coordinates = list(alpha_shape.boundary.coords)
     n_coordinates = len(coordinates)
@@ -711,11 +651,12 @@ def _construct_centers(a, b, radius):
         return down_x, down_y
 
 
-def _filter_holes(geoms, points):
+def _filter_holes(geoms, points):  # noqa ARG001
     """
     Filter hole polygons using a computational geometry solution
     """
     import geopandas
+
     if (geoms.interiors.apply(len) > 0).any():
         from shapely.geometry import Polygon
 
@@ -729,11 +670,14 @@ def _filter_holes(geoms, points):
 
         # Now, create the sparse matrix relating the inner geom (rows)
         # to the outer shell (cols) and take the sum.
-        # A z-order of 1 means the polygon is only inside if its own exterior. This means it's not a hole.
-        # A z-order of 2 means the polygon is inside of exactly one other exterior. Because
-        #   the hull generation method is restricted to be planar, this means the polygon is a hole.
-        # In general, an even z-order means that the polygon is always exactly matched to one exterior,
-        #   plus some number of intermediate exterior-hole pairs. Therefore, the polygon is a hole.
+        # A z-order of 1 means the polygon is only inside if its own exterior.
+        #   This means it's not a hole.
+        # A z-order of 2 means the polygon is inside of exactly one other exterior.
+        #   Because the hull generation method is restricted to be planar, this
+        #   means the polygon is a hole.
+        # In general, an even z-order means that the polygon is always exactly
+        #   matched to one exterior, plus some number of intermediate
+        #   exterior-hole pairs. Therefore, the polygon is a hole.
         # In general, an odd z-order means that there is an uneven number of exteriors.
         #   This means the polygon is not a hole.
         zorder = sparse.csc_matrix((np.ones_like(inside), (inside, outside))).sum(
@@ -747,9 +691,10 @@ def _filter_holes(geoms, points):
 
 
 if __name__ == "__main__":
-    import matplotlib.pyplot as plt
     import time
+
     import geopandas as gpd
+    import matplotlib.pyplot as plt
 
     plt.close("all")
     xys = np.random.random((1000, 2))

--- a/libpysal/cg/alpha_shapes.py
+++ b/libpysal/cg/alpha_shapes.py
@@ -429,7 +429,7 @@ def alpha_shape(xys, alpha):
         29(4), 551-559.
     """
     if not HAS_JIT:
-        warn(NUMBA_WARN)  # noqa B028
+        warn(NUMBA_WARN, stacklevel=2)
     if xys.shape[0] < 4:
         from shapely import geometry as geom
         from shapely import ops
@@ -523,7 +523,7 @@ def alpha_shape_auto(
 
     """
     if not HAS_JIT:
-        warn(NUMBA_WARN)  # noqa B028
+        warn(NUMBA_WARN, stacklevel=2)
     from shapely import geometry as geom
 
     if return_circles:

--- a/libpysal/cg/kdtree.py
+++ b/libpysal/cg/kdtree.py
@@ -3,10 +3,15 @@ KDTree for PySAL: Python Spatial Analysis Library.
 
 Adds support for Arc Distance to scipy.spatial.KDTree.
 """
+
+# ruff: noqa: ARG002, N801, N802, N816
+
 import math
-import scipy.spatial
+
 import numpy
+import scipy.spatial
 from numpy import inf
+
 from . import sphere
 from .sphere import RADIUS_EARTH_KM
 
@@ -30,18 +35,15 @@ def KDTree(data, leafsize=10, distance_metric="Euclidean", radius=RADIUS_EARTH_K
     data : array
         The data points to be indexed. This array is not copied, and so
         modifying this data will result in bogus results. Typically nx2.
-
     leafsize : int
-        The number of points at which the algorithm switches over to brute-force. Has to be positive. Optional, default is 10.
-
+        The number of points at which the algorithm switches
+        over to brute-force. Has to be positive. Optional, default is 10.
     distance_metric : string
         Options: "Euclidean" (default) and "Arc".
-
     radius : float
         Radius of the sphere on which to compute distances. Assumes data in
         latitude and longitude. Ignored if distance_metric="Euclidean". Typical
         values: pysal.cg.RADIUS_EARTH_KM (default) pysal.cg.RADIUS_EARTH_MILES
-
     """
 
     if distance_metric.lower() == "euclidean":
@@ -157,7 +159,6 @@ class Arc_KDTree(temp_KDTree):
         True
         >>> (i == i2).all()
         True
-
         """
         eps = sphere.arcdist2linear(eps, self.radius)
         if distance_upper_bound != inf:
@@ -198,12 +199,12 @@ class Arc_KDTree(temp_KDTree):
         >>> kd.query_ball_point(pts, circumference/2.)
         array([list([0, 1, 2, 3]), list([0, 1, 2, 3]), list([0, 1, 2, 3]),
                list([0, 1, 2, 3])], dtype=object)
-
         """
         eps = sphere.arcdist2linear(eps, self.radius)
-        # scipy.sphere.KDTree.query_ball_point appears to ignore the eps argument.
-        # we have some floating point errors moving back and forth between cordinate systems,
-        # so we'll account for that be adding some to our radius, 3*float's eps value.
+        # scipy.sphere.KDTree.query_ball_point appears to ignore
+        # the eps argument. we have some floating point errors moving
+        # back and forth between cordinate systems, so we'll account
+        # for that be adding some to our radius, 3*float's eps value.
         if r > 0.5 * self.circumference:
             raise ValueError(
                 "r, must not exceed 1/2 circumference of the sphere (%f)."
@@ -225,16 +226,23 @@ class Arc_KDTree(temp_KDTree):
         --------
         >>> pts = [(0,90), (0,0), (180,0), (0,-90)]
         >>> kd = Arc_KDTree(pts, radius = sphere.RADIUS_EARTH_KM)
-        >>> kd.query_ball_tree(kd, kd.circumference/4.) == [[0, 1, 2], [0, 1, 3], [0, 2, 3], [1, 2, 3]]
+        >>> (
+        ...     kd.query_ball_tree(kd, kd.circumference/4.)
+        ...     == [[0, 1, 2], [0, 1, 3], [0, 2, 3], [1, 2, 3]]
+        ... )
         True
-        >>> kd.query_ball_tree(kd, kd.circumference/2.) == [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
+        >>> (
+        ...     kd.query_ball_tree(kd, kd.circumference/2.)
+        ...     == [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
+        ... )
         True
 
         """
         eps = sphere.arcdist2linear(eps, self.radius)
         # scipy.sphere.KDTree.query_ball_point appears to ignore the eps argument.
-        # we have some floating point errors moving back and forth between cordinate systems,
-        # so we'll account for that be adding some to our radius, 3*float's eps value.
+        # we have some floating point errors moving back and forth between
+        # coordinate systems, so we'll account for that be adding some
+        # to our radius, 3*float's eps value.
         if self.radius != other.radius:
             raise ValueError("Both trees must have the same radius.")
         if r > 0.5 * self.circumference:
@@ -260,9 +268,11 @@ class Arc_KDTree(temp_KDTree):
         >>> kd = Arc_KDTree(pts, radius = sphere.RADIUS_EARTH_KM)
         >>> kd.query_pairs(kd.circumference/4.) == set([(0, 1), (1, 3), (2, 3), (0, 2)])
         True
-        >>> kd.query_pairs(kd.circumference/2.) == set([(0, 1), (1, 2), (1, 3), (2, 3), (0, 3), (0, 2)])
+        >>> (
+        ...     kd.query_pairs(kd.circumference/2.)
+        ...     == set([(0, 1), (1, 2), (1, 3), (2, 3), (0, 3), (0, 2)])
+        ... )
         True
-
         """
         if r > 0.5 * self.circumference:
             raise ValueError(
@@ -295,7 +305,6 @@ class Arc_KDTree(temp_KDTree):
                 [10007.54339801,     0.        , 20015.08679602, 10007.54339801],
                 [10007.54339801, 20015.08679602,     0.        , 10007.54339801],
                 [20015.08679602, 10007.54339801, 10007.54339801,     0.        ]])
-
         """
         if self.radius != other.radius:
             raise ValueError("Both trees must have the same radius.")

--- a/libpysal/cg/locators.py
+++ b/libpysal/cg/locators.py
@@ -5,12 +5,15 @@ Computational geometry code for PySAL: Python Spatial Analysis Library.
 __author__ = "Sergio J. Rey, Xinyue Ye, Charles Schmidt, Andrew Winslow"
 __credits__ = "Copyright (c) 2005-2011 Sergio J. Rey"
 
-import math
+# ruff: noqa: B028, F403, F405
+
 import copy
+import math
 import warnings
+
 from .rtree import *
-from .standalone import *
 from .shapes import *
+from .standalone import *
 
 __all__ = ["Grid", "BruteForcePointLocator", "PointLocator", "PolygonLocator"]
 
@@ -52,7 +55,7 @@ class Grid:
             self.j_range = int(
                 math.ceil((self.y_range[1] - self.y_range[0]) / self.res)
             )
-        except Exception:
+        except Exception as e:
             raise Exception(
                 "Invalid arguments for Grid(): ("
                 + str(x_range)
@@ -61,7 +64,7 @@ class Grid:
                 + ", "
                 + str(res)
                 + ")"
-            )
+            ) from e
 
     def in_grid(self, loc):
         """
@@ -92,7 +95,6 @@ class Grid:
 
         Examples
         --------
-
         >>> g = Grid(Rectangle(0, 0, 10, 10), 1)
         >>> g.add('A', Point((4.2, 8.7)))
         'A'
@@ -121,7 +123,6 @@ class Grid:
 
         Examples
         --------
-
         >>> g = Grid(Rectangle(0, 0, 10, 10), 1)
         >>> g.add('A', Point((4.2, 8.7)))
         'A'
@@ -151,7 +152,6 @@ class Grid:
 
         Examples
         --------
-
         >>> g = Grid(Rectangle(0, 0, 10, 10), 1)
         >>> g.add('A', Point((1.0, 1.0)))
         'A'
@@ -187,7 +187,8 @@ class Grid:
 
     def proximity(self, pt, r):
         """
-        Returns a list of items found in the grid within a specified distance of a point.
+        Returns a list of items found in the grid
+        within a specified distance of a point.
 
         proximity(Point, number) -> x list
 
@@ -503,7 +504,6 @@ class PolygonLocator:
 
         Examples
         --------
-
         >>> p1 = Polygon([Point((0, 1)), Point((4, 5)), Point((5, 1))])
         >>> p2 = Polygon([Point((3, 9)), Point((6, 7)), Point((1, 1))])
         >>> p3 = Polygon([Point((7, 1)), Point((8, 7)), Point((9, 1))])
@@ -527,7 +527,6 @@ class PolygonLocator:
 
         Notes
         -----
-
         inside means the intersection of the query rectangle and a
         polygon is not empty and is equal to the area of the polygon
         """
@@ -552,7 +551,6 @@ class PolygonLocator:
         ip = []
         GPPI = get_polygon_point_intersect
         for poly in res:
-            flag = True
             lower = poly.bounding_box.lower
             right = poly.bounding_box.right
             upper = poly.bounding_box.upper
@@ -569,7 +567,6 @@ class PolygonLocator:
 
         Examples
         --------
-
         >>> p1 = Polygon([Point((0, 1)), Point((4, 5)), Point((5, 1))])
         >>> p2 = Polygon([Point((3, 9)), Point((6, 7)), Point((1, 1))])
         >>> p3 = Polygon([Point((7, 1)), Point((8, 7)), Point((9, 1))])
@@ -662,16 +659,12 @@ class PolygonLocator:
                 tail = vertices[i + 1]
                 edge = LineSegment(head, tail)
                 li = get_segments_intersect(edge, left_edge)
-                if li:
-                    overlapping.append(polygon)
-                    break
-                elif get_segments_intersect(edge, right_edge):
-                    overlapping.append(polygon)
-                    break
-                elif get_segments_intersect(edge, lower_edge):
-                    overlapping.append(polygon)
-                    break
-                elif get_segments_intersect(edge, upper_edge):
+                if (
+                    li
+                    or get_segments_intersect(edge, right_edge)
+                    or get_segments_intersect(edge, lower_edge)
+                    or get_segments_intersect(edge, upper_edge)
+                ):
                     overlapping.append(polygon)
                     break
         # check remaining for explicit containment of the bounding rectangle
@@ -681,16 +674,12 @@ class PolygonLocator:
         ne = Point(ne)
         nw = Point(nw)
         for polygon in cs:
-            if get_polygon_point_intersect(polygon, sw):
-                overlapping.append(polygon)
-                break
-            elif get_polygon_point_intersect(polygon, se):
-                overlapping.append(polygon)
-                break
-            elif get_polygon_point_intersect(polygon, ne):
-                overlapping.append(polygon)
-                break
-            elif get_polygon_point_intersect(polygon, nw):
+            if (
+                get_polygon_point_intersect(polygon, sw)
+                or get_polygon_point_intersect(polygon, se)
+                or get_polygon_point_intersect(polygon, ne)
+                or get_polygon_point_intersect(polygon, nw)
+            ):
                 overlapping.append(polygon)
                 break
         return list(set(overlapping))
@@ -720,7 +709,7 @@ class PolygonLocator:
         >>> try: n = pl.nearest(Point((-1, 1)))
         ... except NotImplementedError: print("future test: str(min(n.vertices())) == (0.0, 1.0)")
         future test: str(min(n.vertices())) == (0.0, 1.0)
-        """
+        """  # noqa E501
         raise NotImplementedError
 
     def region(self, region_rect):
@@ -755,7 +744,6 @@ class PolygonLocator:
         """
         Returns polygons that contain point
 
-
         Parameters
         ----------
         point: point (x,y)
@@ -785,7 +773,6 @@ class PolygonLocator:
         (3.3333333333333335, 1.3333333333333333)
         >>> pl.contains_point((1,1))[0].centroid
         (3.3333333333333335, 1.3333333333333333)
-
         """
         # bbounding box containment
         res = [r.leaf_obj() for r in self._rtree.query_point(point) if r.is_leaf()]

--- a/libpysal/cg/polygonQuadTreeStructure.py
+++ b/libpysal/cg/polygonQuadTreeStructure.py
@@ -4,8 +4,9 @@ This structure could speed up the determining of point in polygon process
 """
 __author__ = "Hu Shao"
 
-from .shapes import Ring
 import math
+
+from .shapes import Ring
 
 
 def cwt(a, b, tolerance=1e-9):
@@ -20,10 +21,8 @@ def cwt(a, b, tolerance=1e-9):
     ----------
     a : float
         The first value
-
     b : float
         The second value
-
     tolerance : float
         Tolerance for the comparing
 
@@ -31,7 +30,6 @@ def cwt(a, b, tolerance=1e-9):
     -------
     if_bigger_than  : int
         if a is bigger than b 1: a > b 0: a == b -1: a < b
-
     """
     tolerance = math.fabs(tolerance)
     if a - b > tolerance:
@@ -42,47 +40,38 @@ def cwt(a, b, tolerance=1e-9):
         return 0
 
 
-class Cell(object):
-    """Basic rectangle geometry used for dividing research area (polygon) into quadtree structure
+class Cell:
+    """Basic rectangle geometry used for dividing research
+    area (polygon) into quadtree structure.
 
     Attributes
     ----------
     level : int
         Quadtree level this cell belongs to. Begins with 0
-
     min_x : float
         min x coordinate of this cell
-
     min_y : float
         min y coordinate of this cell
-
     length_x : float
         width of this cell
-
     length_y : float
         height of this cell
-
     arcs : list
         detected arc list which are within this cell
-
     status : str
-        enum status of this cell, indicating this cell's spatial relationship with the research area
+        enum status of this cell, indicating this cell's spatial
+        relationship with the research area
                   "in"      : this cell lies totally inside of the research area
                   "out"     : this cell lies totally outside of the research area
                   "maybe"   : this cell intersects with the research area's boundary
-
     children_l_b : Cell
         children of current cell, left-bottom
-
     children_l_t : Cell
         children of current cell, left-top
-
     children_r_b : Cell
         children of current cell, right-bottom
-
     children_t_t : Cell
         children of current cell, right-top
-
     """
 
     def __init__(self, level, min_x, min_y, length_x, length_y, arcs, status):
@@ -92,24 +81,19 @@ class Cell(object):
         ----------
         level : int
             on which quadtree level this cell belongs to. Begins with 0
-
         min_x : float
             min x coordinate of this cell
-
         min_y : float
             min y coordinate of this cell
-
         length_x : float
             width of this cell
-
         length_y : float
             height of this cell
-
         arcs : list
             detected arc list which are within this cell
-
         status : str
-            enum status of this cell, indicating this cell's spatial relationship with the research area
+            enum status of this cell, indicating this cell's spatial
+            relationship with the research area
                       "in"      : this cell lies totally inside of the research area
                       "out"     : this cell lies totally outside of the research area
                       "maybe"   : this cell intersects with the research area's boundary
@@ -130,13 +114,12 @@ class Cell(object):
 
     @property
     def rings(self):
-        """ the list of rings which are formed by the intersection of this cell and the arcs pass them
+        """the list of rings which are formed by the intersection
+        of this cell and the arcs pass them
 
         Returns
         -------
-
         rings : list
-
         """
         if self._rings is None:
             if self.status == "in" or self.status == "out":
@@ -156,9 +139,9 @@ class Cell(object):
         return self._rings
 
     def split(self):
-        """equally split current cell into 4 sub cells
-
-        if this cell in needed to be splitted into four parts, add the result cells as children to current cell
+        """Equally split current cell into 4 sub cells. If this cell in needed
+        to be splitted into four parts, add the result cells as children
+        to current cell.
         """
 
         if self.status == "in" or self.status == "out":
@@ -176,17 +159,21 @@ class Cell(object):
         - Point order of the arcs MUST be clockwise
         - The two end-points of each arc MUST lie on the borders of the cell
         - When a arc goes in a cell, it MUST goes out from the same one
-        - The intersection points MUST be lying on the inner-boundaries which are used to divide the cell into 4 sub-cells
+        - The intersection points MUST be lying on the
+            inner-boundaries which are used to divide the cell into 4 sub-cells
         - Use the intersection points to split the arcs into small ones
-        - No need to store cell boundaries as arcs, store the intersection points, points' relative location from
+        - No need to store cell boundaries as arcs, store the
+            intersection points, points' relative location from
         """
         if self.level == 0:
             if len(self.arcs) != 1:
                 raise LookupError(
-                    "Unexpected arc number! Only single ring can be assigned to the root cell"
+                    "Unexpected arc number! Only single ring "
+                    "can be assigned to the root cell"
                 )
                 return
-            # Do some initialize work, find one point lies on the border of the rectangle(cell) and begin with this point
+            # Do some initialize work, find one point lies on
+            # the border of the rectangle(cell) and begin with this point
             arc = self.arcs[0]
             if (
                 arc[0] == arc[len(arc) - 1]
@@ -216,11 +203,13 @@ class Cell(object):
                 y1 = arc[index + 1][1]
                 if temp_arc_belonging is None:
                     """
-                    In this section, determine which sub-cell does the current temp_arc belong to
-                    Although every single arc must begin and end on the cell's outer boundaries, when the split
-                    process begin, there might be some sub-arcs begin at the split-line. So here we should
-                    consider all possible situations
-                    See the image cell_boundary_category_rule to better understand the process
+                    In this section, determine which sub-cell does
+                    the current temp_arc belong to. Although every
+                    single arc must begin and end on the cell's outer
+                    boundaries, when the split process begin, there might
+                    be some sub-arcs begin at the split-line. So here we should
+                    consider all possible situations See the image
+                    cell_boundary_category_rule to better understand the process
                     """
                     if cwt(x0, self.min_x, self.zero_tolerance) == 0:  # left border
                         if cwt(y0, middle_y, self.zero_tolerance) == -1:  # position 1
@@ -232,7 +221,9 @@ class Cell(object):
                                 temp_arc_belonging = "l_b"
                             elif cwt(y1, y0, self.zero_tolerance) == 1:  # going up
                                 temp_arc_belonging = "l_t"
-                            else:  # just by chance this segment lies on split_line_h, throw it
+                            else:
+                                # just by chance this segment lies on
+                                # split_line_h, throw it
                                 continue
                     elif (
                         cwt(x0, self.min_x + self.length_x, self.zero_tolerance) == 0
@@ -246,7 +237,9 @@ class Cell(object):
                                 temp_arc_belonging = "r_b"
                             elif cwt(y1, y0, self.zero_tolerance) == 1:  # going up
                                 temp_arc_belonging = "r_t"
-                            else:  # just by chance this segment lies on split_line_h, throw it
+                            else:
+                                # just by chance this segment lies on
+                                # split_line_h, throw it
                                 continue
                     elif cwt(y0, self.min_y, self.zero_tolerance) == 0:  # bottom border
                         if cwt(x0, middle_x, self.zero_tolerance) == -1:  # position 8
@@ -258,7 +251,9 @@ class Cell(object):
                                 temp_arc_belonging = "l_b"
                             elif cwt(x1, x0, self.zero_tolerance) == 1:  # going right
                                 temp_arc_belonging = "r_b"
-                            else:  # just by chance this segment lies on split_line_v, throw it
+                            else:
+                                # just by chance this segment lies on
+                                # split_line_v, throw it
                                 continue
                     elif (
                         cwt(y0, self.min_y + self.length_y, self.zero_tolerance) == 0
@@ -272,7 +267,9 @@ class Cell(object):
                                 temp_arc_belonging = "l_t"
                             elif cwt(x1, x0, self.zero_tolerance) == 1:  # going right
                                 temp_arc_belonging = "r_t"
-                            else:  # just by chance this segment lies on split_line_v, throw it
+                            else:
+                                # just by chance this segment lies
+                                # on split_line_v, throw it
                                 continue
                     elif cwt(x0, middle_x, self.zero_tolerance) == 0:  # split_line_v
                         if cwt(y0, middle_y, self.zero_tolerance) == 1:  # position c
@@ -289,7 +286,9 @@ class Cell(object):
                                 temp_arc_belonging = "l_b"
                             else:  # x1==x0, just by chance on the split_line_v
                                 continue
-                        else:  # in condition that p0 lies at the cross point of two split lines
+                        else:
+                            # in condition that p0 lies at the
+                            # cross point of two split lines
                             if (
                                 cwt(x1, x0, self.zero_tolerance) == 0
                                 or cwt(y1, y0, self.zero_tolerance) == 0
@@ -323,16 +322,18 @@ class Cell(object):
                 if temp_arc_belonging is None:
                     raise Exception("Error on cell split!!!")
 
-                # At this point, the belonging sub-cell of current segment is already known.
+                # At this point, the belonging sub-cell
+                # of current segment is already known.
                 # Let's begin the splitting!
                 """
                 Firstly determine if the segment totally lies on the split_lines.
-                p1 (x1, y1) could lie on the split_lines
-                This situation is not the same with previous ones which "both points lie on the same split_line"
-                In previous situation, the p1 is the begin point of a sub arc, we can just throw that segment if
-                it totally lie on split_line. However, in current situation, the segment is in the middle of the
-                sub-arc. So if the segment is detected totally lie on the split_line, we should split the sub_arc
-                here.
+                p1 (x1, y1) could lie on the split_lines. This situation is not
+                the same with previous ones which "both points lie on the same
+                split_line". In previous situation, the p1 is the begin point of a
+                sub arc, we can just throw that segment if it totally lie on
+                split_line. However, in current situation, the segment is in the
+                middle of the sub-arc. So if the segment is detected totally lie
+                on the split_line, we should split the sub_arc here.
                 """
                 if (
                     cwt(x0, x1, self.zero_tolerance)
@@ -395,7 +396,8 @@ class Cell(object):
                 intersect_point = None
                 intersect_point_mark = None
                 if (intersect_point_h is not None) and (intersect_point_v is not None):
-                    # In this situation, the current segment cannot be vertical nor horizontal.
+                    # In this situation, the current segment
+                    # cannot be vertical nor horizontal.
                     # Find the closer intersection point to p0
                     if math.fabs(intersect_point_h[0] - x0) < math.fabs(
                         intersect_point_v[0] - x0
@@ -430,7 +432,8 @@ class Cell(object):
                             if (intersect_point_h is not None) and (
                                 intersect_point_v is not None
                             ):
-                                # under the situation that a single segment intersects with both split lines,
+                                # under the situation that a single segment
+                                # intersects with both split lines,
                                 # here need carefully process
                                 small_arc = [intersect_point_h, intersect_point_v]
                                 if (
@@ -440,7 +443,9 @@ class Cell(object):
                                         self.zero_tolerance,
                                     )
                                     != 0
-                                ):  # deal with the situation that the segment just goes through center point
+                                ):
+                                    # deal with the situation that the segment
+                                    # just goes through center point
                                     cell_arcs_l_t.append(small_arc)
                                 temp_arc = [intersect_point_v, [x1, y1]]
                                 temp_arc_belonging = "r_t"
@@ -451,7 +456,8 @@ class Cell(object):
                             if (intersect_point_h is not None) and (
                                 intersect_point_v is not None
                             ):
-                                # under the situation that a single segment intersects with both split lines,
+                                # under the situation that a single segment
+                                # intersects with both split lines,
                                 # here need carefully process
                                 small_arc = [intersect_point_v, intersect_point_h]
                                 if (
@@ -461,7 +467,9 @@ class Cell(object):
                                         self.zero_tolerance,
                                     )
                                     != 0
-                                ):  # deal with the situation that the segment just goes through center point
+                                ):
+                                    # deal with the situation that
+                                    # the segment just goes through center point
                                     cell_arcs_r_b.append(small_arc)
                                 temp_arc = [intersect_point_h, [x1, y1]]
                                 temp_arc_belonging = "r_t"
@@ -474,7 +482,8 @@ class Cell(object):
                             if (intersect_point_h is not None) and (
                                 intersect_point_v is not None
                             ):
-                                # under the situation that a single segment intersects with both split lines,
+                                # under the situation that a single segment
+                                # intersects with both split lines,
                                 # here need carefully process
                                 small_arc = [intersect_point_h, intersect_point_v]
                                 if (
@@ -484,7 +493,9 @@ class Cell(object):
                                         self.zero_tolerance,
                                     )
                                     != 0
-                                ):  # deal with the situation that the segment just goes through center point
+                                ):
+                                    # deal with the situation that the segment
+                                    # just goes through center point
                                     cell_arcs_l_b.append(small_arc)
                                 temp_arc = [intersect_point_v, [x1, y1]]
                                 temp_arc_belonging = "r_b"
@@ -495,7 +506,8 @@ class Cell(object):
                             if (intersect_point_h is not None) and (
                                 intersect_point_v is not None
                             ):
-                                # under the situation that a single segment intersects with both split lines,
+                                # under the situation that a single segment
+                                # intersects with both split lines,
                                 # here need carefully process
                                 small_arc = [intersect_point_v, intersect_point_h]
                                 if (
@@ -505,7 +517,9 @@ class Cell(object):
                                         self.zero_tolerance,
                                     )
                                     != 0
-                                ):  # deal with the situation that the segment just goes through center point
+                                ):
+                                    # deal with the situation that
+                                    # the segment just goes through center point
                                     cell_arcs_r_t.append(small_arc)
                                 temp_arc = [intersect_point_h, [x1, y1]]
                                 temp_arc_belonging = "r_b"
@@ -518,7 +532,8 @@ class Cell(object):
                             if (intersect_point_h is not None) and (
                                 intersect_point_v is not None
                             ):
-                                # under the situation that a single segment intersects with both split lines,
+                                # under the situation that a single segment
+                                # intersects with both split lines,
                                 # here need carefully process
                                 small_arc = [intersect_point_h, intersect_point_v]
                                 if (
@@ -528,7 +543,9 @@ class Cell(object):
                                         self.zero_tolerance,
                                     )
                                     != 0
-                                ):  # deal with the situation that the segment just goes through center point
+                                ):
+                                    # deal with the situation that
+                                    # the segment just goes through center point
                                     cell_arcs_r_t.append(small_arc)
                                 temp_arc = [intersect_point_v, [x1, y1]]
                                 temp_arc_belonging = "l_t"
@@ -539,7 +556,8 @@ class Cell(object):
                             if (intersect_point_h is not None) and (
                                 intersect_point_v is not None
                             ):
-                                # under the situation that a single segment intersects with both split lines,
+                                # under the situation that a single segment
+                                # intersects with both split lines,
                                 # here need carefully process
                                 small_arc = [intersect_point_v, intersect_point_h]
                                 if (
@@ -549,7 +567,9 @@ class Cell(object):
                                         self.zero_tolerance,
                                     )
                                     != 0
-                                ):  # deal with the situation that the segment just goes through center point
+                                ):
+                                    # deal with the situation that
+                                    # the segment just goes through center point
                                     cell_arcs_l_b.append(small_arc)
                                 temp_arc = [intersect_point_h, [x1, y1]]
                                 temp_arc_belonging = "l_t"
@@ -562,7 +582,8 @@ class Cell(object):
                             if (intersect_point_h is not None) and (
                                 intersect_point_v is not None
                             ):
-                                # under the situation that a single segment intersects with both split lines,
+                                # under the situation that a single segment
+                                # intersects with both split lines,
                                 # here need carefully process
                                 small_arc = [intersect_point_h, intersect_point_v]
                                 if (
@@ -572,7 +593,9 @@ class Cell(object):
                                         self.zero_tolerance,
                                     )
                                     != 0
-                                ):  # deal with the situation that the segment just goes through center point
+                                ):
+                                    # deal with the situation that
+                                    # the segment just goes through center point
                                     cell_arcs_r_b.append(small_arc)
                                 temp_arc = [intersect_point_v, [x1, y1]]
                                 temp_arc_belonging = "l_b"
@@ -583,7 +606,8 @@ class Cell(object):
                             if (intersect_point_h is not None) and (
                                 intersect_point_v is not None
                             ):
-                                # under the situation that a single segment intersects with both split lines,
+                                # under the situation that a single segment
+                                # intersects with both split lines,
                                 # here need carefully process
                                 small_arc = [intersect_point_v, intersect_point_h]
                                 if (
@@ -593,7 +617,9 @@ class Cell(object):
                                         self.zero_tolerance,
                                     )
                                     != 0
-                                ):  # deal with the situation that the segment just goes through center point
+                                ):
+                                    # deal with the situation that
+                                    # the segment just goes through center point
                                     cell_arcs_l_t.append(small_arc)
                                 temp_arc = [intersect_point_h, [x1, y1]]
                                 temp_arc_belonging = "l_b"
@@ -605,7 +631,8 @@ class Cell(object):
                         and cwt(temp_arc[0][1], temp_arc[1][1], self.zero_tolerance)
                         == 0
                     ):
-                        # to deal with the situation that p1 just lied on one of the split-lines
+                        # to deal with the situation that p1
+                        # just lied on one of the split-lines
                         temp_arc = []
                         temp_arc_belonging = None
                 else:  # simply append the point to current arc
@@ -627,12 +654,14 @@ class Cell(object):
         status_r_b = "maybe"
         status_r_t = "maybe"
         """
-        At this point, all the arcs in this cell have been split into sub-arcs and allocated to 4 sub-cells.
-        So, we can try to create the cells on left-bottom, right-bottom, left-top and right-top.
-        Before doing that, we need to determine the status of each sub-cell, especially those who are totally
-        within or out of the study area.
-        These two kind of sub-cell have the same property: they don't have arc allocated. So, If here exists
-        cell(s) who don't have arcs allocated, we need to begin the check
+        At this point, all the arcs in this cell have been split into
+        sub-arcs and allocated to 4 sub-cells. So, we can try to create
+        the cells on left-bottom, right-bottom, left-top and right-top.
+        Before doing that, we need to determine the status of each sub-cell,
+        especially those who are totally within or out of the study area.
+        These two kind of sub-cell have the same property: they don't have
+        arc allocated. So, If here exists cell(s) who don't have arcs
+        allocated, we need to begin the check
         """
         if (
             len(cell_arcs_l_b)
@@ -658,40 +687,28 @@ class Cell(object):
                 for ring in construct_rings:
                     if ring.contains_point(center):
                         is_in = True
-                if is_in:
-                    status_l_b = "in"
-                else:
-                    status_l_b = "out"
+                status_l_b = "in" if is_in else "out"
             if len(cell_arcs_l_t) == 0:
                 center = [self.min_x + length_x / 2, middle_y + length_y / 2]
                 is_in = False
                 for ring in construct_rings:
                     if ring.contains_point(center):
                         is_in = True
-                if is_in:
-                    status_l_t = "in"
-                else:
-                    status_l_t = "out"
+                status_l_t = "in" if is_in else "out"
             if len(cell_arcs_r_b) == 0:
                 center = [middle_x + length_x / 2, self.min_y + length_y / 2]
                 is_in = False
                 for ring in construct_rings:
                     if ring.contains_point(center):
                         is_in = True
-                if is_in:
-                    status_r_b = "in"
-                else:
-                    status_r_b = "out"
+                status_r_b = "in" if is_in else "out"
             if len(cell_arcs_r_t) == 0:
                 center = [middle_x + length_x / 2, middle_y + length_y / 2]
                 is_in = False
                 for ring in construct_rings:
                     if ring.contains_point(center):
                         is_in = True
-                if is_in:
-                    status_r_t = "in"
-                else:
-                    status_r_t = "out"
+                status_r_t = "in" if is_in else "out"
 
         cells_l_b = Cell(
             level, self.min_x, self.min_y, length_x, length_y, cell_arcs_l_b, status_l_b
@@ -723,7 +740,6 @@ class Cell(object):
         Returns
         -------
         if_contains : bool
-
         """
         if self.status == "out":
             return False
@@ -747,7 +763,6 @@ class Cell(object):
 def extract_connecting_borders_between_points(
     cell_min_point, cell_length_x, cell_length_y, point_begin, point_end, zero_tolerance
 ):
-
     """There is an rectangle and two points on the border, this function is
     used to extract the borders connecting these two points. The segments must
     be clockwise
@@ -756,25 +771,19 @@ def extract_connecting_borders_between_points(
     ----------
     cell_min_point : list
         the bottom-left point of the cell, like [x0, y0]
-
     cell_length_x : float
         width of the cell
-
     cell_length_y : float
         height of the cell
-
     point_begin  : list
         the first point on the cell's border. like [xa, ya]
-
     point_end : list
         the second point on the cell's border. like [xb, yb]
-
     result_type : str
         MUST be one of ["segments", "border_ids"]. Indicts which kind of result
         will return. "segments": return the segments list which connecting
         these two points "border_ids" return a list of ids of the orders of the
         cell connecting these two points
-
     zero_tolerance : float
         value of zero_tolerance for determining if two float values are equal
 
@@ -784,7 +793,6 @@ def extract_connecting_borders_between_points(
         like (segments, involved_border_ids) 1. list of points, including the
         start and end points 2. list of border ids being involved in the
         segments, not necessary to be in the original order
-
     """
     if point_begin == point_end:
         return ([], [])
@@ -889,23 +897,18 @@ def get_relative_location_on_cell_border(
     cell_min_point, cell_length_x, cell_length_y, point, zero_tolerance
 ):
     """When a point is on the border of a cell, this function can be used to
-    calculate the relative location of the point
+    calculate the relative location of the point to cell's left-bottom corner.
 
-    to cell's left-bottom corner.
     Parameters
     ----------
     cell_min_point : list
         the bottom-left point of the cell, like [x0, y0]
-
     cell_length_x : float
         width of the cell
-
     cell_length_y : float
         height of the cell
-
     point : list
          the point on the cell's border. like [x, y]
-
     zero_tolerance : float
         value of zero_tolerance for determining if two float values are equal
 
@@ -913,7 +916,6 @@ def get_relative_location_on_cell_border(
     -------
     distance : float
         range from 0 to 4
-
     """
     border_id_p = -1
     if cwt(point[0], cell_min_point[0], zero_tolerance) == 0:
@@ -943,16 +945,12 @@ def extract_segments_from_cell_with_arcs(
     ----------
     cell_min_point : array
         the bottom-left point of the cell, like [x0, y0]
-
     cell_length_x : float
         width of the cell
-
     cell_length_y : float
         height of the cell
-
     arcs : array
         array of point lists
-
     zero_tolerance : float
         value of zero_tolerance for determining if two float values are equal
 
@@ -964,7 +962,6 @@ def extract_segments_from_cell_with_arcs(
         same. Note that there might be multiple rings extracted in a cell. 2.
         the ids of borders of the cell who are involved in the ring. Duplicated
         ids are removed and they may not be in the original order
-
     """
     arc_begin_points = []  # beginning points of each arc
     arc_begin_points_location = []  # location of beginning points of each arc
@@ -995,7 +992,8 @@ def extract_segments_from_cell_with_arcs(
     rings = []
     involved_border_ids = []
     used_arc_ids = []
-    # every time find an unused arc with minimum begin-point-location, and begin the track form here
+    # every time find an unused arc with minimum begin-point-location,
+    # and begin the track form here
     new_ring = []  # the point list
     new_ring_end_point = None
     new_ring_end_point_location = -1
@@ -1026,7 +1024,8 @@ def extract_segments_from_cell_with_arcs(
             for point in arcs[arc_id_with_min_begin_location]:
                 new_ring.append(point)
         else:
-            # there is already a selected arc, find the next available arc(maybe itself) and add the borders between
+            # there is already a selected arc, find the next
+            # available arc(maybe itself) and add the borders between
             # these two arcs
             arc_id_with_relatively_min_begin_location = -1
             for i in range(0, len(arcs)):
@@ -1081,7 +1080,8 @@ def extract_segments_from_cell_with_arcs(
                 arc_id_with_relatively_min_begin_location
             ]
             if arc_id_with_relatively_min_begin_location not in selected_arc_ids:
-                #  find a new arc, add the point sequence in this arc to the ring, and continue the searching further
+                #  find a new arc, add the point sequence
+                # in this arc to the ring, and continue the searching further
                 selected_arc_ids.append(arc_id_with_relatively_min_begin_location)
                 single_arc = arcs[arc_id_with_relatively_min_begin_location]
                 for i in range(0, len(single_arc)):
@@ -1089,7 +1089,8 @@ def extract_segments_from_cell_with_arcs(
                         continue
                     new_ring.append(single_arc[i])
             else:
-                # the newly found arc is exactly the beginning one, a whole closed ring is formed. stop here
+                # the newly found arc is exactly the beginning one,
+                # a whole closed ring is formed. stop here
                 rings.append(new_ring)
                 new_ring = []
                 new_ring_end_point = None
@@ -1102,7 +1103,7 @@ def extract_segments_from_cell_with_arcs(
     return (rings, involved_border_ids)
 
 
-class QuadTreeStructureSingleRing(object):
+class QuadTreeStructureSingleRing:
     """This class is the main manager of cells.
 
     By giving a study area. This class can construct a cell list depicting the
@@ -1122,7 +1123,6 @@ class QuadTreeStructureSingleRing(object):
         ring : Ring
             the point list of study area. But in the class of Ring in PySAL
             Example: Ring([[0.0, 0.0], [3.0, 2.0], [5.0, 1.0]])
-
         """
         self.ring = ring
         self.root_cell = Cell(
@@ -1138,11 +1138,13 @@ class QuadTreeStructureSingleRing(object):
         # here build the quad tree structure
         # The criterion of stopping splitting the tree:
         #    1. The status is "in" or "out"
-        #    2. The level >= 5 and the the number of current cell only contains one ring and all segments of the ring is no more than 4
+        #    2. The level >= 5 and the the number of current
+        #       cell only contains one ring and all segments
+        #       of the ring is no more than 4
         #    3. The level >= 8
         cells_for_processing = [self.root_cell]
         total_cell_count = 1
-        for i in range(0, 8):  # 10
+        for _i in range(0, 8):  # 10
             result_cell_list = []
             while len(cells_for_processing) > 0:
                 cell = cells_for_processing.pop()
@@ -1157,9 +1159,10 @@ class QuadTreeStructureSingleRing(object):
                 for child in children_cells:
                     if child.status == "out" or child.status == "in":
                         continue
-                    if child.level >= 5:  # 6
-                        if len(child.rings) == 1 and child.rings[0].len <= 5:
-                            continue
+                    if child.level >= 5 and (  # 6
+                        len(child.rings) == 1 and child.rings[0].len <= 5
+                    ):
+                        continue
                     result_cell_list.append(child)
             cells_for_processing = result_cell_list
 
@@ -1174,7 +1177,6 @@ class QuadTreeStructureSingleRing(object):
         Returns
         -------
         if_contains : bool
-
         """
 
         # bbox check

--- a/libpysal/cg/rtree.py
+++ b/libpysal/cg/rtree.py
@@ -15,16 +15,16 @@ __all__ = ["RTree", "Rect", "Rtree"]
 
 
 import array
-import numpy
-import random
 import time
+
+import numpy
 
 MAXCHILDREN = 10
 MAX_KMEANS = 5
 BUFFER = numpy.finfo(float).eps
 
 
-class Rect(object):
+class Rect:
     """A rectangle class that stores an axis aligned rectangle and two flags
     (swapped_x and swapped_y). The flags are stored implicitly via swaps in
     the order of minx/y and maxx/y.
@@ -39,7 +39,6 @@ class Rect(object):
         self.x, self.y, self.xx, self.yy, self.swapped_x, self.swapped_y = state
 
     def __init__(self, minx: float, miny: float, maxx: float, maxy: float):
-
         self.swapped_x = maxx < minx
         self.swapped_y = maxy < miny
         self.x = minx
@@ -59,17 +58,16 @@ class Rect(object):
 
     def overlap(self, orect):
         """Return the overlapping area of two rectangles.
-        
+
         Parameters
         ----------
         orect : libpysal.cg.Rect
             Another rectangle.
-        
+
         Returns
         -------
         overlapping_area : float
             The area of the overlap between ``orect`` and ``self``.
-        
         """
 
         overlapping_area = self.intersect(orect).area()
@@ -99,7 +97,9 @@ class Rect(object):
         return w * h
 
     def extent(self) -> tuple:
-        """Return the extent of the rectangle in the form: (minx, minx, width, height)."""
+        """Return the extent of the rectangle in the form:
+        (minx, minx, width, height).
+        """
 
         x = self.x
         y = self.y
@@ -108,7 +108,7 @@ class Rect(object):
 
     def grow(self, amt=None, sf=0.5):
         """Grow the bounds of a rectangle.
-        
+
         Parameters
         ----------
         amt : float
@@ -116,12 +116,11 @@ class Rect(object):
             triggers the value of ``BUFFER``.
         sf : float
             The scale factor for ``amt``. Default is ``0.5``.
-            
+
         Returns
         -------
         rect : libpysal.cg.Rect
             A new rectangle grown by ``amt`` and scaled by ``sf``.
-        
         """
 
         if not amt:
@@ -133,52 +132,45 @@ class Rect(object):
 
     def intersect(self, o):
         """Find the intersection of two rectangles.
-        
+
         Parameters
         ----------
         o : libpysal.cg.Rect
             Another rectangle.
-            
+
         Returns
         -------
         intersection : {libpysal.cg.NullRect, libpysal.cg.Rect}
             The intersecting part of ``o`` and ``self``.
-
         """
 
         intersection = None
 
-        if self is NullRect:
-            intersection = NullRect
-        elif o is NullRect:
+        if self is NullRect or o is NullRect:
             intersection = NullRect
 
         if not intersection:
-
             nx, ny = max(self.x, o.x), max(self.y, o.y)
             nx2, ny2 = min(self.xx, o.xx), min(self.yy, o.yy)
             w, h = nx2 - nx, ny2 - ny
 
-            if w <= 0 or h <= 0:
-                intersection = NullRect
-            else:
-                intersection = Rect(nx, ny, nx2, ny2)
+            intersection = NullRect if w <= 0 or h <= 0 else Rect(nx, ny, nx2, ny2)
 
         return intersection
 
     def does_contain(self, o):
         """Check whether the rectangle contains the other rectangle.
-        
+
         Parameters
         ----------
         o : libpysal.cg.Rect
             Another rectangle.
-        
+
         Returns
         -------
         dc : bool
             ``True`` if ``self`` contains ``o`` otherwise ``False``.
-        
+
         """
 
         dc = self.does_containpoint((o.x, o.y)) and self.does_containpoint((o.xx, o.yy))
@@ -187,17 +179,16 @@ class Rect(object):
 
     def does_intersect(self, o):
         """Check whether the rectangles interect.
-        
+
         Parameters
         ----------
         o : libpysal.cg.Rect
             Another rectangle.
-        
+
         Returns
         -------
         dcp : bool
             ``True`` if ``self`` intersects ``o`` otherwise ``False``.
-        
         """
 
         di = self.intersect(o).area() > 0
@@ -206,17 +197,16 @@ class Rect(object):
 
     def does_containpoint(self, p):
         """Check whether the rectangle contains a point or not.
-        
+
         Parameters
         ----------
         p : libpysal.cg.Point
             A point.
-        
+
         Returns
         -------
         dcp : bool
             ``True`` if ``self`` contains ``p`` otherwise ``False``.
-        
         """
 
         x, y = p
@@ -227,17 +217,16 @@ class Rect(object):
 
     def union(self, o):
         """Union two rectangles.
-        
+
         Parameters
         ----------
         o : libpysal.cg.Rect
             Another rectangle.
-        
+
         Returns
         -------
         res : libpysal.cg.Rect
             The union of ``o`` and ``self``.
-
         """
 
         if o is NullRect:
@@ -265,17 +254,16 @@ class Rect(object):
 
     def union_point(self, o):
         """Union the rectangle and a point
-        
+
         Parameters
         ----------
         o : libpysal.cg.Point
             A point.
-        
+
         Returns
         -------
         res : libpysal.cg.Rect
             The union of ``o`` and ``self``.
-
         """
 
         x, y = o
@@ -309,35 +297,34 @@ NullRect.swapped_y = False
 
 def union_all(kids):
     """Create union of all child rectangles.
-    
+
     Parameters
     ----------
     kids : list
         A list of ``libpysal.cg._NodeCursor`` objects.
-    
+
     Returns
     -------
     cur : {libpysal.cg.Rect, libpysal.cg.NullRect}
         The unioned result of all child rectangles.
-    
     """
 
     cur = NullRect
     for k in kids:
         cur = cur.union(k.rect)
 
-    assert False == cur.swapped_x
+    assert False is cur.swapped_x
 
     return cur
 
 
-def Rtree():
+def Rtree():  # noqa N802
     return RTree()
 
 
-class RTree(object):
+class RTree:
     """An RTree for efficiently querying space based on intersecting rectangles.
-    
+
     Attributes
     ----------
     count : int
@@ -357,12 +344,11 @@ class RTree(object):
         The pool of leaf objects in the tree.
     cursor : libpysal.cg._NodeCursor
         The non-root node and all its children.
-    
+
     Examples
     --------
-    
     Instantiate an ``RTree``.
-    
+
     >>> from libpysal.cg import RTree, Chain
     >>> segments = [
     ...     [(0.0, 1.5), (1.5, 1.5)],
@@ -374,10 +360,10 @@ class RTree(object):
     >>> rt = RTree()
     >>> for segment in segments:
     ...     rt.insert(segment, Rect(*segment.bounding_box).grow(sf=10.))
-    
+
     Examine the tree generation statistics. The statistics here
     are all 0 due to the simple structure of the tree in this example.
-    
+
     >>> rt.stats
     {'overflow_f': 0,
      'avg_overflow_t_f': 0.0,
@@ -386,55 +372,53 @@ class RTree(object):
      'sum_kmeans_iter_f': 0,
      'count_kmeans_iter_f': 0,
      'avg_kmeans_iter_f': 0.0}
-    
+
     Examine the number of nodes and leaves.
     There five nodes and four leaves (the root plus its four children).
-    
+
     >>> rt.count, rt.leaf_count
     (5, 4)
-    
+
     The pool of nodes are the node IDs in the tree.
-    
+
     >>> rt.node_pool
     array('L', [0, 4, 0, 0, 1, 1, 2, 2, 3, 3])
-    
+
     The pool of leaves are the geometric objects that were inserted into the tree.
-    
+
     >>> rt.leaf_pool[0].vertices
     [(0.0, 1.5), (1.5, 1.5)]
-    
+
     The pool of rectangles are the bounds of partitioned space in the tree.
     Examine the first one.
-    
+
     >>> rt.rect_pool[:4]
     array('d', [-2.220446049250313e-15, -2.220446049250313e-15, 3.000000000000002, 3.000000000000002])
-    
+
     Add the bounding box of a leaf to the tree manually.
-    
+
     >>> rt.add(Chain(((2,2), (4,4))), (2,2,4,4))
     >>> rt.count, rt.leaf_count
     (6, 5)
-    
+
     Query the tree for an intersection. One object is contained in this query.
-    
+
     >>> rt.intersection([.4, 2.1, .9, 2.6])[0].vertices
     [(0.5, 2), (1, 2.5)]
-    
+
     Query the tree with a much larger box. All objects are contained in this query.
-    
+
     >>> len(rt.intersection([-1, -1, 4, 4])) == rt.leaf_count
     True
-    
+
     Query the tree with box outside the tree objects.
     No objects are contained in this query.
-    
+
     >>> rt.intersection([5, 5, 6, 6])
     []
-    
-    """
+    """  # noqa E501
 
     def __init__(self):
-
         self.count = 0
         self.stats = {
             "overflow_f": 0,
@@ -471,14 +455,13 @@ class RTree(object):
 
     def insert(self, o, orect):
         """Insert an object and its bounding box into the tree.
-        
+
         Parameters
         ----------
         o : libpysal.cg.{Point, Chain, Rectangle, Polygon}
             The object to insert into the tree.
         orect : ibpysal.cg.Rect
             The object's bounding box.
-        
         """
 
         self.cursor.insert(o, orect)
@@ -486,38 +469,36 @@ class RTree(object):
 
     def query_rect(self, r):
         """Query a rectangle.
-        
+
         Parameters
         ----------
         r : {tuple, libpysal.cg.Point}
             The bounding box of the rectangle in question;
             a :math:`(minx,miny,maxx,maxy)` set of coordinates.
-        
+
         Yields
         ------
         x : generator
             ``libpysal.cg._NodeCursor`` objects.
         """
 
-        for x in self.cursor.query_rect(r):
-            yield x
+        yield from self.cursor.query_rect(r)
 
     def query_point(self, p):
         """Query a point.
-        
+
         Parameters
         ----------
         p : {tuple, libpysal.cg.Point}
             The point in question; an :math:`(x,y)` coordinate.
-        
+
         Yields
         ------
         x : generator
             ``libpysal.cg._NodeCursor`` objects.
         """
 
-        for x in self.cursor.query_point(p):
-            yield x
+        yield from self.cursor.query_point(p)
 
     def walk(self, pred):
         """Walk the tree structure with ``pred`` (a function)."""
@@ -527,18 +508,17 @@ class RTree(object):
     def intersection(self, boundingbox):
         """Query for an intersection between leaves in the ``RTree``
         and the bounding box of an object.
-        
+
         Parameters
         ----------
         boundingbox : list
             The bounding box: ``[minx, miny, maxx, maxy]``.
-        
+
         Returns
         -------
         objs : list
             A list of objects whose bounding
             boxes intersect with the query bounding box.
-
         """
 
         # grow the bounding box slightly to handle coincident edges
@@ -548,25 +528,24 @@ class RTree(object):
 
         return objs
 
-    def add(self, id, boundingbox):
+    def add(self, id_, boundingbox):
         """Add the bounding box of a leaf to the ``RTree`` manually with a specified ID.
 
         Parameters
         ----------
-        id : int
+        id_ : int
             An object id.
         boundingbox : list
             The bounding box: ``[minx, miny, maxx, maxy]``.
-        
         """
 
-        self.cursor.insert(id, Rect(*boundingbox))
+        self.cursor.insert(id_, Rect(*boundingbox))
 
 
-class _NodeCursor(object):
+class _NodeCursor:
     """An internal class for keeping track of, and reorganizing,
     the structure and composition of the ``RTree``.
-    
+
     Parameters
     ----------
     rooto : libpysal.cg.{Point, Chain, Rectangle, Polygon}
@@ -579,7 +558,7 @@ class _NodeCursor(object):
         The ID of the first child of the node.
     next_sibling : int
         The ID of the sibling of the node.
-    
+
     Attributes
     ----------
     root : libpysal.cg.RTree
@@ -588,13 +567,12 @@ class _NodeCursor(object):
         See ``RTree.node_pool``.
     rpool : array.array
         See ``RTree.rect_pool``.
-    
     """
 
     @classmethod
     def create(cls, rooto, rect):
         """Create a node in the tree structure.
-        
+
         Parameters
         ----------
         rooto : libpysal.cg.{Point, Chain, Rectangle, Polygon}
@@ -603,12 +581,11 @@ class _NodeCursor(object):
             The ID of the node.
         rect : libpysal.cg.Rect
             The bounding rectangle of the leaf object.
-        
+
         Returns
         -------
         retv : libpysal.cg._NodeCursor
             The generated node.
-        
         """
 
         idx = rooto.count
@@ -625,22 +602,21 @@ class _NodeCursor(object):
     @classmethod
     def create_with_children(cls, children, rooto):
         """Create a non-leaf node in the tree structure.
-        
+
         Parameters
         ----------
         children : list
             The child nodes of the node to be generated
         rooto : libpysal.cg.{Point, Chain, Rectangle, Polygon}
             The object from which the node will be generated.
-        
+
         Returns
         -------
         nc : libpysal.cg._NodeCursor
             The generated node with children.
-        
         """
-        rect = union_all([c for c in children])
-        nr = Rect(rect.x, rect.y, rect.xx, rect.yy)
+        rect = union_all(list(children))
+        Rect(rect.x, rect.y, rect.xx, rect.yy)
 
         assert not rect.swapped_x
         nc = _NodeCursor.create(rooto, rect)
@@ -652,7 +628,7 @@ class _NodeCursor(object):
     @classmethod
     def create_leaf(cls, rooto, leaf_obj, leaf_rect):
         """Create a leaf node in the tree structure.
-        
+
         Parameters
         ----------
         rooto : libpysal.cg.{Point, Chain, Rectangle, Polygon}
@@ -661,12 +637,11 @@ class _NodeCursor(object):
             The leaf object.
         leaf_rect : libpysal.cg.Rect
             The bounding rectangle of the leaf object.
-        
+
         Returns
         -------
         res : libpysal.cg._NodeCursor
             The generated leaf node.
-        
         """
 
         rect = Rect(leaf_rect.x, leaf_rect.y, leaf_rect.xx, leaf_rect.yy)
@@ -718,7 +693,6 @@ class _NodeCursor(object):
         ) = state
 
     def __init__(self, rooto, index, rect, first_child, next_sibling):
-
         self.root = rooto
         self.rpool = rooto.rect_pool
         self.npool = rooto.node_pool
@@ -734,38 +708,34 @@ class _NodeCursor(object):
             yield self
             if not self.is_leaf():
                 for c in self.children():
-                    for cr in c.walk(predicate):
-                        yield cr
+                    yield from c.walk(predicate)
 
     def query_rect(self, r):
         """Yield objects that intersect with the rectangle (``r``)."""
 
-        def p(o, x):
+        def p(o, x):  # noqa ARG001
             return r.does_intersect(o.rect)
 
-        for rr in self.walk(p):
-            yield rr
+        yield from self.walk(p)
 
     def query_point(self, point):
         """Yield objects that intersect with the point (``point``)."""
 
-        def p(o, x):
+        def p(o, x):  # noqa ARG001
             return o.rect.does_containpoint(point)
 
-        for rr in self.walk(p):
-            yield rr
+        yield from self.walk(p)
 
     def lift(self):
         """Promote a node to (potentially) rearrange the
         tree structure for optimal clustering.
-        
+
         Called from ``_NodeCursor._balance()``.
-        
+
         Returns
         -------
         lifted : libpysal.cg._NodeCursor
             The lifted node.
-        
         """
 
         lifted = _NodeCursor(
@@ -802,27 +772,25 @@ class _NodeCursor(object):
     def has_children(self) -> bool:
         """Return ``True`` if the node has children, otherwise ``False``."""
 
-        return not self.is_leaf() and 0 != self.first_child
+        return not self.is_leaf() and self.first_child != 0
 
     def holds_leaves(self) -> bool:
         """Return ``True`` if the node holds leaves, otherwise ``False``."""
 
-        if 0 == self.first_child:
+        if self.first_child == 0:
             return True
         else:
             return self.has_children() and self.get_first_child().is_leaf()
 
     def get_first_child(self):
         """Get the first child of a node.
-        
+
         Returns
         -------
         c : libpysal.cg._NodeCursor
             The first child of the specified node.
-        
         """
 
-        fc = self.first_child
         c = _NodeCursor(self.root, 0, NullRect, 0, 0)
         c._become(self.first_child)
 
@@ -857,9 +825,8 @@ class _NodeCursor(object):
     def nchildren(self) -> int:
         """The number of children nodes."""
 
-        i = self.index
         c = 0
-        for x in self.children():
+        for _x in self.children():
             c += 1
 
         return c
@@ -867,7 +834,6 @@ class _NodeCursor(object):
     def insert(self, leafo, leafrect):
         """Insert a leaf object into the tree. See
         ``RTree.insert(o, orect)`` for parameter description.
-        
         """
 
         index = self.index
@@ -889,12 +855,12 @@ class _NodeCursor(object):
                 # ----------------------
                 # Micro-optimization:
                 #   inlining union() calls -- logic is:
-                #       ignored, child = min(
-                #           [
-                #               ((c.rect.union(leafrect)).area() - c.rect.area(),c.index)
-                #               for c in self.children()
-                #           ]
-                #       )
+                #   ignored, child = min(
+                #       [
+                #           ((c.rect.union(leafrect)).area() - c.rect.area(),c.index)
+                #           for c in self.children()
+                #       ]
+                #   )
                 child = None
                 minarea = -1.0
                 for c in self.children():
@@ -921,7 +887,7 @@ class _NodeCursor(object):
         and ``silhouette_coeff()`` for (heuristically) optimal clusterings of
         nodes in the tree structure after the child count of a node has grown
         past the maximum allowed number (see ``MAXCHILDREN``).
-        
+
         Called from ``_NodeCursor.insert()``.
         """
 
@@ -929,8 +895,6 @@ class _NodeCursor(object):
             return
 
         t = time.process_time()
-
-        cur_score = -10
 
         s_children = [c.lift() for c in self.children()]
 
@@ -959,15 +923,14 @@ class _NodeCursor(object):
 
     def _set_children(self, cs: list):
         """Set up the (new/altered) leaf tree structure.
-        
+
         Called from ``_NodeCursor.create_with_children()``
         and ``_NodeCursor._balance()``.
-        
         """
 
         self.first_child = 0
 
-        if 0 == len(cs):
+        if len(cs) == 0:
             return
 
         pred = None
@@ -975,7 +938,7 @@ class _NodeCursor(object):
             if pred is not None:
                 pred.next_sibling = c.index
                 pred._save_back()
-            if 0 == self.first_child:
+            if self.first_child == 0:
                 self.first_child = c.index
             pred = c
         pred.next_sibling = 0
@@ -983,14 +946,13 @@ class _NodeCursor(object):
         self._save_back()
 
     def _insert_child(self, c):
-        """Internal function for child node insertion. 
+        """Internal function for child node insertion.
         Called from ``_NodeCursor.insert()``.
-        
+
         Parameters
         ----------
         c : libpysal.cg._NodeCursor
             A child ``libpysal.cg._NodeCursor`` object.
-        
         """
 
         c.next_sibling = self.first_child
@@ -1001,7 +963,7 @@ class _NodeCursor(object):
     def children(self):
         """Yield the children of a node."""
 
-        if 0 == self.first_child:
+        if self.first_child == 0:
             return
 
         idx = self.index
@@ -1012,7 +974,7 @@ class _NodeCursor(object):
         self._become(self.first_child)
         while True:
             yield self
-            if 0 == self.next_sibling:
+            if self.next_sibling == 0:
                 break
             else:
                 self._become(self.next_sibling)
@@ -1027,19 +989,18 @@ class _NodeCursor(object):
 
 def avg_diagonals(node, onodes):
     """Calculate the mean diagonals.
-    
+
     Parameters
     ----------
     node : libpysal.cg._NodeCursor
         The target node in question.
     onodes : ist
         A list of ``libpysal.cg._NodeCursor`` objects.
-    
+
     Returns
     -------
     diag_avg : float
         The mean diagonal distance of ``node`` and ``onodes``.
-    
     """
 
     nidx = node.index
@@ -1068,7 +1029,7 @@ def avg_diagonals(node, onodes):
 
 def silhouette_w(node, cluster, next_closest_cluster):
     """Calculate a silhouette score between a certain node and 2 clusters:
-    
+
     Parameters
     ----------
     node : libpysal.cg._NodeCursor
@@ -1077,13 +1038,12 @@ def silhouette_w(node, cluster, next_closest_cluster):
         A list of ``libpysal.cg._NodeCursor`` objects.
     next_closest_cluster : list
         Another list of ``libpysal.cg._NodeCursor`` objects.
-    
+
     Returns
     -------
     silw : float
         The silhouette score between ``{node, cluster}``
         and ``{node, next_closest_cluster}``.
-    
     """
 
     ndist = avg_diagonals(node, cluster)
@@ -1099,17 +1059,16 @@ def silhouette_coeff(clustering):
     the clusters are well defined, a score of ``0`` indicates the clusters are
     undefined, and a score of ``-1`` indicates the clusters are defined
     incorrectly.
-    
+
     Parameters
     ----------
     clustering : list
         A list of ``libpysal.cg._NodeCursor`` objects.
-    
+
     Returns
     -------
     silcoeff : float
         Score for how well defined the clusters are.
-        
     """
 
     # special case for a clustering of 1.0
@@ -1135,17 +1094,16 @@ def silhouette_coeff(clustering):
 
 def center_of_gravity(nodes):
     """Find the center of gravity of multiple nodes.
-    
+
     Parameters
     ----------
     nodes : list
         A list of ``libpysal.cg.RTree`` and ``libpysal.cg._NodeCursor`` objects.
-    
+
     Returns
     -------
     cog : float
         The center of gravity of multiple nodes.
-    
     """
 
     totarea = 0.0
@@ -1165,28 +1123,27 @@ def center_of_gravity(nodes):
 
 def closest(centroids, node):
     """Find the closest controid to the node's center of gravity.
-    
+
     Parameters
     ----------
     centroids : list
         A list of (x, y) coordinates for the center of other clusters.
     node : libpysal.cg_NodeCursor
         A ``libpysal.cg._NodeCursor`` instance.
-    
+
     Returns
     -------
     ridx : int
         The index of the nearest centroid of other cluster.
-
     """
 
     x, y = center_of_gravity([node])
     dist = -1
     ridx = -1
 
-    for (i, (xx, yy)) in enumerate(centroids):
+    for i, (xx, yy) in enumerate(centroids):
         dsq = ((xx - x) ** 2) + ((yy - y) ** 2)
-        if -1 == dist or dsq < dist:
+        if dist == -1 or dsq < dist:
             dist = dsq
             ridx = i
 
@@ -1195,7 +1152,7 @@ def closest(centroids, node):
 
 def k_means_cluster(root, k, nodes):
     """Find ``k`` clusters.
-    
+
     Parameters
     ----------
     root : libpysal.cg.RTree
@@ -1204,12 +1161,11 @@ def k_means_cluster(root, k, nodes):
         The number clusters to find.
     nodes : list
         A list of ``libpysal.cg.RTree`` and ``libpysal.cg._NodeCursor`` objects.
-    
+
     Returns
     -------
     clusters : list
         Updated versions of ``nodes`` defining new clusters.
-    
     """
 
     t = time.process_time()
@@ -1223,7 +1179,7 @@ def k_means_cluster(root, k, nodes):
     # Initialize: take n random nodes.
     # random.shuffle(ns)
 
-    cluster_starts = ns[:k]
+    ns[:k]
     cluster_centers = [center_of_gravity([n]) for n in ns[:k]]
 
     # Loop until stable:
@@ -1241,12 +1197,9 @@ def k_means_cluster(root, k, nodes):
         for c in clusters:
             if len(c) == 0:
                 print("Error....")
-                print(("Nodes: %d, centers: %s." % (len(ns), repr(cluster_centers))))
+                print("Nodes: %d, centers: %s." % (len(ns), repr(cluster_centers)))
 
             assert len(c) > 0
-
-        rest = ns
-        first = False
 
         new_cluster_centers = [center_of_gravity(c) for c in clusters]
         if new_cluster_centers == cluster_centers:

--- a/libpysal/cg/rtree.py
+++ b/libpysal/cg/rtree.py
@@ -1179,8 +1179,8 @@ def k_means_cluster(root, k, nodes):
     # Initialize: take n random nodes.
     # random.shuffle(ns)
 
-    ns[:k]
-    cluster_centers = [center_of_gravity([n]) for n in ns[:k]]
+    cluster_starts = ns[:k]
+    cluster_centers = [center_of_gravity([n]) for n in cluster_starts]
 
     # Loop until stable:
     while True:

--- a/libpysal/cg/shapely_ext.py
+++ b/libpysal/cg/shapely_ext.py
@@ -1,7 +1,11 @@
-from shapely import geometry as geom, ops as shops, __version__ as shapely_version
+from shapely import __version__ as shapely_version
+from shapely import geometry as geom
+from shapely import ops as shops
+
+from .shapes import asShape
 
 _basegeom = geom.base.BaseGeometry
-from .shapes import asShape
+
 
 __all__ = [
     "to_wkb",
@@ -213,7 +217,8 @@ def unary_union(shapes):
     # seems to be the same as cascade_union except that it handles multipart polygons
     if shapely_version < "1.2.16":
         raise Exception(
-            "shapely 1.2.16 or higher needed for unary_union; upgrade shapely or try cascade_union instead"
+            "shapely 1.2.16 or higher needed for unary_union; "
+            "upgrade shapely or try cascade_union instead"
         )
     o = []
     for shape in shapes:

--- a/libpysal/cg/shapes.py
+++ b/libpysal/cg/shapes.py
@@ -5,11 +5,13 @@ Computational geometry code for PySAL: Python Spatial Analysis Library.
 
 __author__ = "Sergio J. Rey, Xinyue Ye, Charles Schmidt, Andrew Winslow, Hu Shao"
 
-import math
-from .sphere import arcdist
-from typing import Union
-import warnings
+# ruff: noqa: A003, B028, N802, E402
 
+import math
+import warnings
+from typing import Union
+
+from .sphere import arcdist
 
 __all__ = [
     "Point",
@@ -23,7 +25,10 @@ __all__ = [
 ]
 
 
-dep_msg = "Objects based on the `Geometry` class will deprecated and removed in a future version of libpysal."
+dep_msg = (
+    "Objects based on the `Geometry` class will deprecated "
+    "and removed in a future version of libpysal."
+)
 
 
 def asShape(obj):
@@ -46,16 +51,12 @@ def asShape(obj):
     -------
     obj : {libpysal.cg.{Point, LineSegment, Line, Ray, Chain, Polygon}
         A new geometric representation of the object.
-
     """
 
-    if isinstance(obj, (Point, LineSegment, Line, Ray, Chain, Polygon)):
+    if isinstance(obj, Point | LineSegment | Line | Ray | Chain | Polygon):
         pass
     else:
-        if hasattr(obj, "__geo_interface__"):
-            geo = obj.__geo_interface__
-        else:
-            geo = obj
+        geo = obj.__geo_interface__ if hasattr(obj, "__geo_interface__") else obj
 
         if hasattr(geo, "type"):
             raise TypeError("%r does not appear to be a shape object." % (obj))
@@ -66,7 +67,6 @@ def asShape(obj):
         #    raise NotImplementedError, "%s are not supported at this time."%geo_type
 
         if geo_type in _geoJSON_type_to_Pysal_type:
-
             obj = _geoJSON_type_to_Pysal_type[geo_type].__from_geo_interface__(geo)
         else:
             raise NotImplementedError("%s is not supported at this time." % geo_type)
@@ -74,10 +74,9 @@ def asShape(obj):
     return obj
 
 
-class Geometry(object):
+class Geometry:
     """A base class to help implement ``is_geometry``
     and make geometric types extendable.
-
     """
 
     def __init__(self):
@@ -94,9 +93,7 @@ class Point(Geometry):
 
     Examples
     --------
-
     >>> p = Point((1, 3))
-
     """
 
     def __init__(self, loc):
@@ -121,13 +118,11 @@ class Point(Geometry):
 
         Examples
         --------
-
         >>> Point((0, 1)) < Point((0, 1))
         False
 
         >>> Point((0, 1)) < Point((1, 1))
         True
-
         """
 
         return (self.__loc) < (other.__loc)
@@ -142,13 +137,11 @@ class Point(Geometry):
 
         Examples
         --------
-
         >>> Point((0, 1)) <= Point((0, 1))
         True
 
         >>> Point((0, 1)) <= Point((1, 1))
         True
-
         """
 
         return (self.__loc) <= (other.__loc)
@@ -163,13 +156,11 @@ class Point(Geometry):
 
         Examples
         --------
-
         >>> Point((0, 1)) == Point((0, 1))
         True
 
         >>> Point((0, 1)) == Point((1, 1))
         False
-
         """
 
         try:
@@ -187,13 +178,11 @@ class Point(Geometry):
 
         Examples
         --------
-
         >>> Point((0, 1)) != Point((0, 1))
         False
 
         >>> Point((0, 1)) != Point((1, 1))
         True
-
         """
 
         try:
@@ -211,13 +200,11 @@ class Point(Geometry):
 
         Examples
         --------
-
         >>> Point((0, 1)) > Point((0, 1))
         False
 
         >>> Point((0, 1)) > Point((1, 1))
         False
-
         """
 
         return (self.__loc) > (other.__loc)
@@ -232,13 +219,11 @@ class Point(Geometry):
 
         Examples
         --------
-
         >>> Point((0, 1)) >= Point((0, 1))
         True
 
         >>> Point((0, 1)) >= Point((1, 1))
         False
-
         """
 
         return (self.__loc) >= (other.__loc)
@@ -248,13 +233,11 @@ class Point(Geometry):
 
         Examples
         --------
-
         >>> hash(Point((0, 1))) == hash(Point((0, 1)))
         True
 
         >>> hash(Point((0, 1))) == hash(Point((1, 1)))
         False
-
         """
 
         return hash(self.__loc)
@@ -270,13 +253,11 @@ class Point(Geometry):
 
         Examples
         --------
-
         >>> p = Point((5.5, 4.3))
         >>> p[0] == 5.5
         True
         >>> p[1] == 4.3
         True
-
         """
 
         return self.__loc.__getitem__(*args)
@@ -292,14 +273,12 @@ class Point(Geometry):
 
         Examples
         --------
-
         >>> p = Point((3, 6, 2))
         >>> p[:2] == (3, 6)
         True
 
         >>> p[1:2] == (6,)
         True
-
         """
 
         return self.__loc.__getslice__(*args)
@@ -309,10 +288,8 @@ class Point(Geometry):
 
         Examples
         --------
-
         >>> len(Point((1, 2)))
         2
-
         """
 
         return len(self.__loc)
@@ -322,10 +299,8 @@ class Point(Geometry):
 
         Examples
         --------
-
         >>> Point((0, 1))
         (0.0, 1.0)
-
         """
 
         return str(self)
@@ -335,11 +310,9 @@ class Point(Geometry):
 
         Examples
         --------
-
         >>> p = Point((1, 3))
         >>> str(p)
         '(1.0, 3.0)'
-
         """
 
         return str(self.__loc)
@@ -371,9 +344,7 @@ class LineSegment(Geometry):
 
     Examples
     --------
-
     >>> ls = LineSegment(Point((1, 2)), Point((5, 6)))
-
     """
 
     def __init__(self, start_pt, end_pt):
@@ -393,7 +364,6 @@ class LineSegment(Geometry):
 
         Examples
         --------
-
         >>> l1 = LineSegment(Point((1, 2)), Point((5, 6)))
         >>> l2 = LineSegment(Point((5, 6)), Point((1, 2)))
         >>> l1 == l2
@@ -401,7 +371,6 @@ class LineSegment(Geometry):
 
         >>> l2 == l1
         True
-
         """
 
         eq = False
@@ -409,9 +378,9 @@ class LineSegment(Geometry):
         if not isinstance(other, self.__class__):
             pass
         else:
-            if other.p1 == self._p1 and other.p2 == self._p2:
-                eq = True
-            elif other.p2 == self._p1 and other.p1 == self._p2:
+            if (other.p1 == self._p1 and other.p2 == self._p2) or (
+                other.p2 == self._p1 and other.p1 == self._p2
+            ):
                 eq = True
 
         return eq
@@ -427,7 +396,6 @@ class LineSegment(Geometry):
 
         Examples
         --------
-
         >>> ls = LineSegment(Point((5, 0)), Point((10, 0)))
         >>> ls1 = LineSegment(Point((5, 0)), Point((10, 1)))
         >>> ls.intersect(ls1)
@@ -440,7 +408,6 @@ class LineSegment(Geometry):
         >>> ls2 = LineSegment(Point((7, -1)), Point((7, 2)))
         >>> ls.intersect(ls2)
         True
-
         """
 
         ccw1 = self.sw_ccw(other.p2)
@@ -461,10 +428,8 @@ class LineSegment(Geometry):
 
         Examples
         --------
-
         >>> ls = LineSegment(Point((1, 2)), Point((5, 6)))
         >>> ls._reset_props()
-
         """
 
         self._bounding_box = None
@@ -482,12 +447,10 @@ class LineSegment(Geometry):
 
         Examples
         --------
-
         >>> ls = LineSegment(Point((1, 2)), Point((5, 6)))
         >>> r = ls._get_p1()
         >>> r == Point((1, 2))
         True
-
         """
 
         return self._p1
@@ -508,12 +471,10 @@ class LineSegment(Geometry):
 
         Examples
         --------
-
         >>> ls = LineSegment(Point((1, 2)), Point((5, 6)))
         >>> r = ls._set_p1(Point((3, -1)))
         >>> r == Point((3.0, -1.0))
         True
-
         """
 
         self._p1 = p1
@@ -534,12 +495,10 @@ class LineSegment(Geometry):
 
         Examples
         --------
-
         >>> ls = LineSegment(Point((1, 2)), Point((5, 6)))
         >>> r = ls._get_p2()
         >>> r == Point((5, 6))
         True
-
         """
 
         return self._p2
@@ -560,12 +519,10 @@ class LineSegment(Geometry):
 
         Examples
         --------
-
         >>> ls = LineSegment(Point((1, 2)), Point((5, 6)))
         >>> r = ls._set_p2(Point((3, -1)))
         >>> r == Point((3.0, -1.0))
         True
-
         """
 
         self._p2 = p2
@@ -586,14 +543,12 @@ class LineSegment(Geometry):
 
         Examples
         --------
-
         >>> ls = LineSegment(Point((0, 0)), Point((5, 0)))
         >>> ls.is_ccw(Point((2, 2)))
         True
 
         >>> ls.is_ccw(Point((2, -2)))
         False
-
         """
 
         v1 = (self._p2[0] - self._p1[0], self._p2[1] - self._p1[1])
@@ -612,14 +567,12 @@ class LineSegment(Geometry):
 
         Examples
         --------
-
         >>> ls = LineSegment(Point((0, 0)), Point((5, 0)))
         >>> ls.is_cw(Point((2, 2)))
         False
 
         >>> ls.is_cw(Point((2, -2)))
         True
-
         """
 
         v1 = (self._p2[0] - self._p1[0], self._p2[1] - self._p1[1])
@@ -638,7 +591,6 @@ class LineSegment(Geometry):
             ``-1`` if the points are collinear and ``self.p1`` is in the middle.
             ``1`` if the points are collinear and ``self.p2`` is in the middle.
             ``0`` if the points are collinear and ``pt`` is in the middle.
-
         """
 
         p0 = self.p1
@@ -652,9 +604,7 @@ class LineSegment(Geometry):
 
         if dy1 * dx2 < dy2 * dx1:
             is_ccw = 1
-        elif dy1 * dx2 > dy2 * dx1:
-            is_ccw = -1
-        elif dx1 * dx2 < 0 or dy1 * dy2 < 0:
+        elif (dy1 * dx2 > dy2 * dx1) or (dx1 * dx2 < 0 or dy1 * dy2 < 0):
             is_ccw = -1
         elif dx1 * dx1 + dy1 * dy1 >= dx2 * dx2 + dy2 * dy2:
             is_ccw = 0
@@ -673,7 +623,6 @@ class LineSegment(Geometry):
 
         Examples
         --------
-
         >>> ls = LineSegment(Point((1, 2)), Point((5, 6)))
         >>> swap = ls.get_swap()
         >>> swap.p1[0]
@@ -687,7 +636,6 @@ class LineSegment(Geometry):
 
         >>> swap.p2[1]
         2.0
-
         """
 
         line_seg = LineSegment(self._p2, self._p1)
@@ -705,7 +653,6 @@ class LineSegment(Geometry):
 
         Examples
         --------
-
         >>> ls = LineSegment(Point((1, 2)), Point((5, 6)))
         >>> ls.bounding_box.left
         1.0
@@ -718,7 +665,6 @@ class LineSegment(Geometry):
 
         >>> ls.bounding_box.upper
         6.0
-
         """
 
         # If LineSegment attributes p1, p2 changed, recompute
@@ -742,11 +688,9 @@ class LineSegment(Geometry):
 
         Examples
         --------
-
         >>> ls = LineSegment(Point((2, 2)), Point((5, 2)))
         >>> ls.len
         3.0
-
         """
 
         # If LineSegment attributes p1, p2 changed, recompute
@@ -766,7 +710,6 @@ class LineSegment(Geometry):
 
         Examples
         --------
-
         >>> ls = LineSegment(Point((2, 2)), Point((3, 3)))
         >>> l = ls.line
         >>> l.m
@@ -774,10 +717,9 @@ class LineSegment(Geometry):
 
         >>> l.b
         0.0
-
         """
 
-        if self._line == False:
+        if self._line is False:
             dx = self._p1[0] - self._p2[0]
             dy = self._p1[1] - self._p2[1]
 
@@ -804,14 +746,12 @@ class VerticalLine(Geometry):
 
     Examples
     --------
-
     >>> ls = VerticalLine(0)
     >>> ls.m
     inf
 
     >>> ls.b
     nan
-
     """
 
     def __init__(self, x):
@@ -820,7 +760,7 @@ class VerticalLine(Geometry):
         self.m = float("inf")
         self.b = float("nan")
 
-    def x(self, y) -> float:
+    def x(self, y) -> float:  # noqa ARG002
         """Returns the :math:`x`-value of the line at a particular :math:`y`-value.
 
         Parameters
@@ -830,16 +770,14 @@ class VerticalLine(Geometry):
 
         Examples
         --------
-
         >>> l = VerticalLine(0)
         >>> l.x(0.25)
         0.0
-
         """
 
         return self._x
 
-    def y(self, x) -> float:
+    def y(self, x) -> float:  # noqa ARG002
         """Returns the :math:`y`-value of the line at a particular :math:`x`-value.
 
         Parameters
@@ -849,11 +787,9 @@ class VerticalLine(Geometry):
 
         Examples
         --------
-
         >>> l = VerticalLine(1)
         >>> l.y(1)
         nan
-
         """
 
         return float("nan")
@@ -876,14 +812,12 @@ class Line(Geometry):
 
     Examples
     --------
-
     >>> ls = Line(1, 0)
     >>> ls.m
     1.0
 
     >>> ls.b
     0.0
-
     """
 
     def __init__(self, m, b):
@@ -909,11 +843,9 @@ class Line(Geometry):
 
         Examples
         --------
-
         >>> l = Line(0.5, 0)
         >>> l.x(0.25)
         0.5
-
         """
 
         if self.m == 0:
@@ -931,11 +863,9 @@ class Line(Geometry):
 
         Examples
         --------
-
         >>> l = Line(1, 0)
         >>> l.y(1)
         1.0
-
         """
 
         if self.m == 0:
@@ -964,14 +894,12 @@ class Ray:
 
     Examples
     --------
-
     >>> l = Ray(Point((0, 0)), Point((1, 0)))
     >>> str(l.o)
     '(0.0, 0.0)'
 
     >>> str(l.p)
     '(1.0, 0.0)'
-
     """
 
     def __init__(self, origin, second_p):
@@ -997,15 +925,13 @@ class Chain(Geometry):
 
     Examples
     --------
-
     >>> c = Chain([Point((0, 0)), Point((1, 0)), Point((1, 1)), Point((2, 1))])
-
     """
 
     def __init__(self, vertices: list):
         warnings.warn(dep_msg, FutureWarning)
         if isinstance(vertices[0], list):
-            self._vertices = [part for part in vertices]
+            self._vertices = list(vertices)
         else:
             self._vertices = [vertices]
         self._reset_props()
@@ -1032,7 +958,6 @@ class Chain(Geometry):
         functions of other attributes. The ``getter``s for these attributes
         (implemented as ``properties``) then recompute their values if they
         have been reset since the last call to the ``getter``.
-
         """
 
         self._len = None
@@ -1045,15 +970,13 @@ class Chain(Geometry):
 
         Examples
         --------
-
         >>> c = Chain([Point((0, 0)), Point((1, 0)), Point((1, 1)), Point((2, 1))])
         >>> verts = c.vertices
         >>> len(verts)
         4
-
         """
 
-        return sum([part for part in self._vertices], [])
+        return sum(list(self._vertices), [])
 
     @property
     def parts(self) -> list:
@@ -1061,7 +984,6 @@ class Chain(Geometry):
 
         Examples
         --------
-
         >>> c = Chain(
         ...     [
         ...         [Point((0, 0)), Point((1, 0)), Point((1, 1)), Point((0, 1))],
@@ -1070,10 +992,9 @@ class Chain(Geometry):
         ... )
         >>> len(c.parts)
         2
-
         """
 
-        return [[v for v in part] for part in self._vertices]
+        return [list(part) for part in self._vertices]
 
     @property
     def bounding_box(self):
@@ -1086,7 +1007,6 @@ class Chain(Geometry):
 
         Examples
         --------
-
         >>> c = Chain([Point((0, 0)), Point((2, 0)), Point((2, 1)), Point((0, 1))])
         >>> c.bounding_box.left
         0.0
@@ -1099,7 +1019,6 @@ class Chain(Geometry):
 
         >>> c.bounding_box.upper
         1.0
-
         """
 
         if self._bounding_box is None:
@@ -1119,7 +1038,6 @@ class Chain(Geometry):
 
         Examples
         --------
-
         >>> c = Chain([Point((0, 0)), Point((1, 0)), Point((1, 1)), Point((2, 1))])
         >>> c.len
         3.0
@@ -1132,7 +1050,6 @@ class Chain(Geometry):
         ... )
         >>> c.len
         4.0
-
         """
 
         def dist(v1: tuple, v2: tuple) -> Union[int, float]:
@@ -1150,7 +1067,6 @@ class Chain(Geometry):
     def arclen(self) -> Union[int, float]:
         """Returns the geometric length of the chain
         computed using 'arcdistance' (meters).
-
         """
 
         def part_perimeter(p: list) -> Union[int, float]:
@@ -1166,7 +1082,7 @@ class Chain(Geometry):
         """Returns the segments that compose the chain."""
 
         return [
-            [LineSegment(a, b) for (a, b) in zip(part[:-1], part[1:])]
+            [LineSegment(a, b) for (a, b) in zip(part[:-1], part[1:], strict=True)]
             for part in self._vertices
         ]
 
@@ -1201,7 +1117,6 @@ class Ring(Geometry):
     _quad_tree_structure : libpysal.cg.QuadTreeStructureSingleRing
         The quad tree structure for the ring. This structure helps
         test if a point is inside the ring.
-
     """
 
     def __init__(self, vertices):
@@ -1228,12 +1143,10 @@ class Ring(Geometry):
 
     @staticmethod
     def dist(v1, v2) -> Union[int, float]:
-
         return math.hypot(v1[0] - v2[0], v1[1] - v2[1])
 
     @property
     def perimeter(self) -> Union[int, float]:
-
         if self._perimeter is None:
             dist = self.dist
             v = self.vertices
@@ -1253,7 +1166,6 @@ class Ring(Geometry):
 
         Examples
         --------
-
         >>> r = Ring(
         ...     [
         ...         Point((0, 0)),
@@ -1275,7 +1187,6 @@ class Ring(Geometry):
 
         >>> r.bounding_box.upper
         1.0
-
         """
 
         if self._bounding_box is None:
@@ -1292,7 +1203,6 @@ class Ring(Geometry):
 
         Examples
         --------
-
         >>> r = Ring(
         ...     [
         ...         Point((0, 0)),
@@ -1304,7 +1214,6 @@ class Ring(Geometry):
         ... )
         >>> r.area
         2.0
-
         """
 
         return abs(self.signed_area)
@@ -1336,13 +1245,11 @@ class Ring(Geometry):
 
         Notes
         -----
-
         The centroid returned by this method is the geometric centroid.
         Also known as the 'center of gravity' or 'center of mass'.
 
         Examples
         --------
-
         >>> r = Ring(
         ...     [
         ...         Point((0, 0)),
@@ -1354,7 +1261,6 @@ class Ring(Geometry):
         ... )
         >>> str(r.centroid)
         '(1.0, 0.5)'
-
         """
 
         if self._centroid is None:
@@ -1379,7 +1285,6 @@ class Ring(Geometry):
         """Build the quad tree structure for this polygon. Once
         the structure is built, speed for testing if a point is
         inside the ring will be increased significantly.
-
         """
 
         self._quad_tree_structure = QuadTreeStructureSingleRing(self)
@@ -1397,7 +1302,6 @@ class Ring(Geometry):
         -------
         point_contained : bool
             ``True`` if ``point`` is contained within the polygon, otherwise ``False``.
-
         """
 
         point_contained = False
@@ -1483,9 +1387,7 @@ class Polygon(Geometry):
 
     Examples
     --------
-
     >>> p1 = Polygon([Point((0, 0)), Point((1, 0)), Point((1, 1)), Point((0, 1))])
-
     """
 
     def __init__(self, vertices, holes=None):
@@ -1523,7 +1425,6 @@ class Polygon(Geometry):
         GEOS, Shapely, and geoJSON do. In GEOS, etc, polygons may only
         have a single exterior ring, all other parts are holes.
         MultiPolygons are simply a list of polygons.
-
         """
 
         geo_type = geo["type"].lower()
@@ -1576,14 +1477,12 @@ class Polygon(Geometry):
 
         Examples
         --------
-
         >>> p1 = Polygon([Point((0, 0)), Point((0, 1)), Point((1, 1)), Point((1, 0))])
         >>> p1.len
         4
 
         >>> len(p1)
         4
-
         """
 
         if self._len is None:
@@ -1596,16 +1495,12 @@ class Polygon(Geometry):
 
         Examples
         --------
-
         >>> p1 = Polygon([Point((0, 0)), Point((0, 1)), Point((1, 1)), Point((1, 0))])
         >>> len(p1.vertices)
         4
-
         """
 
-        return sum([part for part in self._vertices], []) + sum(
-            [part for part in self._holes], []
-        )
+        return sum(list(self._vertices), []) + sum(list(self._holes), [])
 
     @property
     def holes(self) -> list:
@@ -1613,17 +1508,15 @@ class Polygon(Geometry):
 
         Examples
         --------
-
         >>> p = Polygon(
         ...     [Point((0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))],
         ...     [Point((1, 2)), Point((2, 2)), Point((2, 1)), Point((1, 1))]
         ... )
         >>> len(p.holes)
         1
-
         """
 
-        return [[v for v in part] for part in self._holes]
+        return [list(part) for part in self._holes]
 
     @property
     def parts(self) -> list:
@@ -1631,7 +1524,6 @@ class Polygon(Geometry):
 
         Examples
         --------
-
         >>> p = Polygon(
         ...     [
         ...         [Point((0, 0)), Point((1, 0)), Point((1, 1)), Point((0, 1))],
@@ -1640,10 +1532,9 @@ class Polygon(Geometry):
         ... )
         >>> len(p.parts)
         2
-
         """
 
-        return [[v for v in part] for part in self._vertices]
+        return [list(part) for part in self._vertices]
 
     @property
     def perimeter(self) -> Union[int, float]:
@@ -1651,11 +1542,9 @@ class Polygon(Geometry):
 
         Examples
         --------
-
         >>> p = Polygon([Point((0, 0)), Point((1, 0)), Point((1, 1)), Point((0, 1))])
         >>> p.perimeter
         4.0
-
         """
 
         def dist(v1: Union[int, float], v2: Union[int, float]) -> float:
@@ -1682,9 +1571,7 @@ class Polygon(Geometry):
 
         See Also
         --------
-
         libpysal.cg.bounding_box
-
         """
 
         if self._bbox is None:
@@ -1707,7 +1594,6 @@ class Polygon(Geometry):
 
         Examples
         --------
-
         >>> p = Polygon([Point((0, 0)), Point((2, 0)), Point((2, 1)), Point((0, 1))])
         >>> p.bounding_box.left
         0.0
@@ -1720,7 +1606,6 @@ class Polygon(Geometry):
 
         >>> p.bounding_box.upper
         1.0
-
         """
 
         if self._bounding_box is None:
@@ -1739,7 +1624,6 @@ class Polygon(Geometry):
 
         Examples
         --------
-
         >>> p = Polygon([Point((0, 0)), Point((1, 0)), Point((1, 1)), Point((0, 1))])
         >>> p.area
         1.0
@@ -1750,7 +1634,6 @@ class Polygon(Geometry):
         ... )
         >>> p.area
         99.0
-
         """
 
         def part_area(pv: list) -> float:
@@ -1759,7 +1642,7 @@ class Polygon(Geometry):
                 __area += (pv[i][0] + pv[i + 1][0]) * (pv[i][1] - pv[i + 1][1])
             __area = __area * 0.5
             if __area < 0:
-                __area = -area
+                __area = -area  # noqa F821
             return __area
 
         sum_area = lambda part_type: sum([part_area(part) for part in part_type])
@@ -1773,21 +1656,18 @@ class Polygon(Geometry):
 
         Notes
         -----
-
         The centroid returned by this method is the geometric
         centroid and respects multipart polygons with holes.
         Also known as the 'center of gravity' or 'center of mass'.
 
         Examples
         --------
-
         >>> p = Polygon(
         ...     [Point((0, 0)), Point((10, 0)), Point((10, 10)), Point((0, 10))],
         ...     [Point((1, 1)), Point((1, 2)), Point((2, 2)), Point((2, 1))]
         ... )
         >>> p.centroid
         (5.0353535353535355, 5.0353535353535355)
-
         """
 
         CP = [ring.centroid for ring in self._part_rings]
@@ -1796,8 +1676,8 @@ class Polygon(Geometry):
         AH = [-ring.area for ring in self._hole_rings]
 
         A = AP + AH
-        cx = sum([pt[0] * area for pt, area in zip(CP + CH, A)]) / sum(A)
-        cy = sum([pt[1] * area for pt, area in zip(CP + CH, A)]) / sum(A)
+        cx = sum([pt[0] * area for pt, area in zip(CP + CH, A, strict=True)]) / sum(A)
+        cy = sum([pt[1] * area for pt, area in zip(CP + CH, A, strict=True)]) / sum(A)
 
         return cx, cy
 
@@ -1805,7 +1685,6 @@ class Polygon(Geometry):
         """Build the quad tree structure for this polygon. Once
         the structure is built, speed for testing if a point is
         inside the ring will be increased significantly.
-
         """
 
         for ring in self._part_rings:
@@ -1829,7 +1708,6 @@ class Polygon(Geometry):
 
         Examples
         --------
-
         >>> p = Polygon(
         ...     [Point((0,0)), Point((4,0)), Point((4,5)), Point((2,3)), Point((0,5))]
         ... )
@@ -1862,9 +1740,7 @@ class Polygon(Geometry):
 
         Notes
         -----
-
         Points falling exactly on polygon edges may yield unpredictable results.
-
         """
 
         searching = True
@@ -1903,7 +1779,6 @@ class Rectangle(Geometry):
 
     Examples
     --------
-
     >>> r = Rectangle(-4, 3, 10, 17)
     >>> r.left #minx
     -4.0
@@ -1916,7 +1791,6 @@ class Rectangle(Geometry):
 
     >>> r.upper #maxy
     17.0
-
     """
 
     def __init__(self, left, lower, right, upper):
@@ -1936,7 +1810,6 @@ class Rectangle(Geometry):
 
         Examples
         --------
-
         >>> r = Rectangle(0, 0, 0, 0)
         >>> bool(r)
         False
@@ -1944,7 +1817,6 @@ class Rectangle(Geometry):
         >>> r = Rectangle(0, 0, 1, 1)
         >>> bool(r)
         True
-
         """
 
         return bool(self.area)
@@ -1970,16 +1842,14 @@ class Rectangle(Geometry):
 
         Examples
         --------
-
         >>> r = Rectangle(-4, 3, 10, 17)
         >>> r[:]
         [-4.0, 3.0, 10.0, 17.0]
-
         """
 
-        l = [self.left, self.lower, self.right, self.upper]
+        l_ = [self.left, self.lower, self.right, self.upper]
 
-        return l.__getitem__(key)
+        return l_.__getitem__(key)
 
     def set_centroid(self, new_center):
         """Moves the rectangle center to a new specified point.
@@ -1991,7 +1861,6 @@ class Rectangle(Geometry):
 
         Examples
         --------
-
         >>> r = Rectangle(0, 0, 4, 4)
         >>> r.set_centroid(Point((4, 4)))
         >>> r.left
@@ -2005,7 +1874,6 @@ class Rectangle(Geometry):
 
         >>> r.upper
         6.0
-
         """
 
         shift = (
@@ -2029,7 +1897,6 @@ class Rectangle(Geometry):
 
         Examples
         --------
-
         >>> r = Rectangle(0, 0, 4, 4)
         >>> r.set_scale(2)
         >>> r.left
@@ -2040,7 +1907,6 @@ class Rectangle(Geometry):
         -2.0
         >>> r.upper
         6.0
-
         """
 
         center = ((self.left + self.right) / 2, (self.lower + self.upper) / 2)
@@ -2056,11 +1922,9 @@ class Rectangle(Geometry):
 
         Examples
         --------
-
         >>> r = Rectangle(0, 0, 4, 4)
         >>> r.area
         16.0
-
         """
 
         return (self.right - self.left) * (self.upper - self.lower)
@@ -2071,11 +1935,9 @@ class Rectangle(Geometry):
 
         Examples
         --------
-
         >>> r = Rectangle(0, 0, 4, 4)
         >>> r.width
         4.0
-
         """
 
         return self.right - self.left
@@ -2086,17 +1948,15 @@ class Rectangle(Geometry):
 
         Examples
         --------
-
         >>> r = Rectangle(0, 0, 4, 4)
         >>> r.height
         4.0
-
         """
 
         return self.upper - self.lower
 
 
-_geoJSON_type_to_Pysal_type = {
+_geoJSON_type_to_Pysal_type = {  # noqa N816
     "point": Point,
     "linestring": Chain,
     "multilinestring": Chain,

--- a/libpysal/cg/sphere.py
+++ b/libpysal/cg/sphere.py
@@ -15,12 +15,12 @@ __author__ = (
 )
 
 import math
-import numpy
-import scipy.spatial
-import scipy.constants
-from scipy.spatial.distance import euclidean
-from math import pi, cos, sin
+from math import cos, pi, sin
 
+import numpy
+import scipy.constants
+import scipy.spatial
+from scipy.spatial.distance import euclidean
 
 __all__ = [
     "RADIUS_EARTH_KM",
@@ -67,13 +67,11 @@ def arcdist(pt0, pt1, radius=RADIUS_EARTH_KM):
 
     Examples
     --------
-    
     >>> pt0 = (0, 0)
     >>> pt1 = (180, 0)
     >>> d = arcdist(pt0, pt1, RADIUS_EARTH_MILES)
     >>> d == math.pi * RADIUS_EARTH_MILES
     True
-    
     """
 
     dist = linear2arcdist(euclidean(toXYZ(pt0), toXYZ(pt1)), radius)
@@ -84,7 +82,7 @@ def arcdist(pt0, pt1, radius=RADIUS_EARTH_KM):
 def arcdist2linear(arc_dist, radius=RADIUS_EARTH_KM):
     """Convert an arc distance (spherical earth)
     to a linear distance (R3) in the unit sphere.
-    
+
     Parameters
     ----------
     arc_dist : float
@@ -95,24 +93,22 @@ def arcdist2linear(arc_dist, radius=RADIUS_EARTH_KM):
         radius in miles, ``RADIUS_EARTH_MILES`` (``3958.76``)
         is also an option.
         Source: http://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html
-    
+
     Returns
     -------
     linear_dist : float
         The linear distance conversion of ``arc_dist``.
-    
+
     Examples
     --------
-    
     >>> pt0 = (0, 0)
     >>> pt1 = (180, 0)
     >>> d = arcdist(pt0, pt1, RADIUS_EARTH_MILES)
     >>> d == math.pi * RADIUS_EARTH_MILES
     True
-    
+
     >>> arcdist2linear(d, RADIUS_EARTH_MILES)
     2.0
-    
     """
 
     circumference = 2 * math.pi * radius
@@ -126,7 +122,7 @@ def arcdist2linear(arc_dist, radius=RADIUS_EARTH_KM):
 def linear2arcdist(linear_dist, radius=RADIUS_EARTH_KM):
     """Convert a linear distance in the unit sphere
     (R3) to an arc distance based on supplied radius.
-    
+
     Parameters
     ----------
     linear_dist : float
@@ -137,26 +133,24 @@ def linear2arcdist(linear_dist, radius=RADIUS_EARTH_KM):
         radius in miles, ``RADIUS_EARTH_MILES`` (``3958.76``)
         is also an option.
         Source: http://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html
-    
+
     Returns
     -------
     arc_dist : float
         The arc distance conversion of ``linear_dist``.
-    
+
     Raises
     ------
     ValueError
         Raised when ``linear_dist`` exceeds the diameter of the unit sphere.
-    
+
     Examples
     --------
-    
     >>> pt0 = (0, 0)
     >>> pt1 = (180, 0)
     >>> d = arcdist(pt0, pt1, RADIUS_EARTH_MILES)
     >>> d == linear2arcdist(2.0, radius=RADIUS_EARTH_MILES)
     True
-    
     """
 
     if linear_dist == float("inf"):
@@ -166,16 +160,16 @@ def linear2arcdist(linear_dist, radius=RADIUS_EARTH_KM):
         raise ValueError(msg)
     else:
         circumference = 2 * math.pi * radius
-        a2 = linear_dist ** 2
+        a2 = linear_dist**2
         theta = math.degrees(math.acos((2 - a2) / (2.0)))
         arc_dist = (theta * circumference) / 360.0
 
     return arc_dist
 
 
-def toXYZ(pt):
+def toXYZ(pt):  # noqa N802
     """Convert a point's latitude and longitude to x,y,z.
-    
+
     Parameters
     ----------
     pt : tuple
@@ -185,7 +179,6 @@ def toXYZ(pt):
     -------
     x, y, z : tuple
         A point in form (x, y, z).
-    
     """
 
     phi, theta = list(map(math.radians, pt))
@@ -197,19 +190,18 @@ def toXYZ(pt):
     return x, y, z
 
 
-def toLngLat(xyz):
+def toLngLat(xyz):  # noqa N802
     """Convert a point's x,y,z to latitude and longitude.
-    
+
     Parameters
     ----------
     xyz : tuple
         A point assumed to be in form (x,y,z).
-    
+
     Returns
     -------
     phi, theta : tuple
         A point in form (phi, theta) [y,x].
-    
     """
 
     x, y, z = xyz
@@ -228,7 +220,7 @@ def toLngLat(xyz):
 
 def brute_knn(pts, k, mode="arc", radius=RADIUS_EARTH_KM):
     """Computes a brute-force :math:`k` nearest neighbors.
-    
+
     Parameters
     ----------
     pts : list
@@ -244,12 +236,11 @@ def brute_knn(pts, k, mode="arc", radius=RADIUS_EARTH_KM):
         radius in miles, ``RADIUS_EARTH_MILES`` (``3958.76``)
         is also an option.
         Source: http://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html
-    
+
     Returns
     -------
     w : dict
         A neighbor ID lookup.
-    
     """
 
     n = len(pts)
@@ -298,7 +289,6 @@ def fast_knn(pts, k, return_dist=False, radius=RADIUS_EARTH_KM):
         A neighbor ID lookup.
     wd : dict
         A neighbor distance lookup (optional).
-
     """
 
     pts = numpy.array(pts)
@@ -341,7 +331,6 @@ def fast_threshold(pts, dist, radius=RADIUS_EARTH_KM):
         A neighbor distance lookup where the key is the ID
         of a point and the value is a list of IDs for other
         points within ``dist`` of the key point,
-
     """
 
     d = arcdist2linear(dist, radius)
@@ -350,9 +339,9 @@ def fast_threshold(pts, dist, radius=RADIUS_EARTH_KM):
     wd = {}
 
     for i in range(len(pts)):
-        l = r[i]
-        l.remove(i)
-        wd[i] = l
+        l_ = r[i]
+        l_.remove(i)
+        wd[i] = l_
 
     return wd
 
@@ -372,14 +361,12 @@ def lonlat(pointslist):
 
     Examples
     --------
-    
     >>> points = [
     ...     (41.981417, -87.893517), (41.980396, -87.776787), (41.980906, -87.696450)
     ... ]
     >>> newpoints = lonlat(points)
     >>> newpoints
     [(-87.893517, 41.981417), (-87.776787, 41.980396), (-87.69645, 41.980906)]
-
     """
 
     newpts = [(i[1], i[0]) for i in pointslist]
@@ -402,10 +389,8 @@ def haversine(x):
 
     Examples
     --------
-    
     >>> haversine(math.pi) # is 180 in radians, hence sin of 90 = 1
     1.0
-
     """
 
     x = math.sin(x / 2)
@@ -441,7 +426,6 @@ def radangle(p0, p1):
 
     Examples
     --------
-    
     >>> p0 = (-87.893517, 41.981417)
     >>> p1 = (-87.519295, 41.657498)
     >>> radangle(p0, p1)
@@ -449,10 +433,8 @@ def radangle(p0, p1):
 
     Notes
     -----
-    
     Uses haversine formula, function haversine and degree to radian
     conversion lambda function ``d2r``.
-
     """
 
     x0, y0 = d2r(p0[0]), d2r(p0[1])
@@ -491,20 +473,17 @@ def harcdist(p0, p1, lonx=True, radius=RADIUS_EARTH_KM):
 
     Examples
     --------
-    
     >>> p0 = (-87.893517, 41.981417)
     >>> p1 = (-87.519295, 41.657498)
     >>> harcdist(p0, p1)
     47.52873002976876
-    
+
     >>> harcdist(p0, p1, radius=None)
     0.007460167953189258
 
     Notes
     -----
-    
     Uses the ``radangle`` function to compute radian angle.
-
     """
 
     if not (lonx):
@@ -521,7 +500,7 @@ def harcdist(p0, p1, lonx=True, radius=RADIUS_EARTH_KM):
 
 
 def geointerpolate(p0, p1, t, lonx=True):
-    """Finds a point on a sphere along the great circle distance between
+    r"""Finds a point on a sphere along the great circle distance between
     two points on a sphere also known as a way point in great circle navigation.
 
     Parameters
@@ -546,17 +525,15 @@ def geointerpolate(p0, p1, t, lonx=True):
 
     Examples
     --------
-    
     >>> p0 = (-87.893517, 41.981417)
     >>> p1 = (-87.519295, 41.657498)
     >>> geointerpolate(p0, p1, 0.1)             # using lon-lat
     (-87.85592403438788, 41.949079912574796)
-    
+
     >>> p3 = (41.981417, -87.893517)
     >>> p4 = (41.657498, -87.519295)
     >>> geointerpolate(p3, p4, 0.1, lonx=False) # using lat-lon
     (41.949079912574796, -87.85592403438788)
-
     """
 
     if not (lonx):
@@ -612,7 +589,6 @@ def geogrid(pup, pdown, k, lonx=True):
 
     Examples
     --------
-    
     >>> pup = (42.023768, -87.946389)       # Arlington Heights, IL
     >>> pdown = (41.644415, -87.524102)     # Hammond, IN
     >>> geogrid(pup,pdown, 3, lonx=False)
@@ -632,13 +608,9 @@ def geogrid(pup, pdown, k, lonx=True):
      (41.64458672568646, -87.80562679171955),
      (41.64458672568646, -87.66486420828045),
      (41.644415, -87.524102)]
-
     """
 
-    if lonx:
-        corners = [pup, pdown]
-    else:
-        corners = lonlat([pup, pdown])
+    corners = [pup, pdown] if lonx else lonlat([pup, pdown])
 
     tpoints = [float(i) / k for i in range(k)[1:]]
     leftcorners = [corners[0], (corners[0][0], corners[1][1])]

--- a/libpysal/cg/standalone.py
+++ b/libpysal/cg/standalone.py
@@ -6,14 +6,18 @@ Helper functions for computational geometry in PySAL.
 __author__ = "Sergio J. Rey, Xinyue Ye, Charles Schmidt, Andrew Winslow"
 __credits__ = "Copyright (c) 2005-2009 Sergio J. Rey"
 
-import doctest
-import math
+# ruff: noqa: F403, F405
+
+
 import copy
+import math
 import random
-from .shapes import *
 from itertools import islice
-import scipy.spatial
+
 import numpy as np
+import scipy.spatial
+
+from .shapes import *
 
 EPSILON_SCALER = 3
 
@@ -51,7 +55,7 @@ def bbcommon(bb, bbother):
         A bounding box.
     bbother : list
         The bounding box to test against.
-    
+
     Returns
     -------
     chflag : int
@@ -59,19 +63,18 @@ def bbcommon(bb, bbother):
 
     Examples
     --------
-
     >>> b0 = [0, 0, 10, 10]
     >>> b1 = [10, 0, 20, 10]
     >>> bbcommon(b0, b1)
     1
-    
     """
 
     chflag = 0
 
-    if not ((bbother[2] < bb[0]) or (bbother[0] > bb[2])):
-        if not ((bbother[3] < bb[1]) or (bbother[1] > bb[3])):
-            chflag = 1
+    if (not ((bbother[2] < bb[0]) or (bbother[0] > bb[2]))) and (
+        not ((bbother[3] < bb[1]) or (bbother[1] > bb[3]))
+    ):
+        chflag = 1
 
     return chflag
 
@@ -91,20 +94,18 @@ def get_bounding_box(items):
 
     Examples
     --------
-    
     >>> bb = get_bounding_box([Point((-1, 5)), Rectangle(0, 6, 11, 12)])
     >>> bb.left
     -1.0
-    
+
     >>> bb.lower
     5.0
-    
+
     >>> bb.right
     11.0
-    
+
     >>> bb.upper
     12.0
-    
     """
 
     def left(o):
@@ -170,26 +171,24 @@ def get_angle_between(ray1, ray2):
         A ray forming the beginning of the angle measured.
     ray2 : libpysal.cg.Ray
         A ray forming the end of the angle measured.
-    
+
     Returns
     -------
     angle : float
         The angle between ``ray1`` and ``ray2``.
-    
+
     Raises
     ------
     ValueError
         Raised when rays do not have the same origin.
-    
+
     Examples
     --------
-    
     >>> get_angle_between(
     ...     Ray(Point((0, 0)), Point((1, 0))),
     ...     Ray(Point((0, 0)), Point((1, 0)))
     ... )
     0.0
-    
     """
 
     if ray1.o != ray2.o:
@@ -233,13 +232,11 @@ def is_collinear(p1, p2, p3):
 
     Examples
     --------
-    
     >>> is_collinear(Point((0, 0)), Point((1, 1)), Point((5, 5)))
     True
-    
+
     >>> is_collinear(Point((0, 0)), Point((1, 1)), Point((5, 0)))
     False
-    
     """
 
     eps = np.finfo(type(p1[0])).eps
@@ -274,19 +271,17 @@ def get_segments_intersect(seg1, seg2):
 
     Examples
     --------
-    
     >>> seg1 = LineSegment(Point((0, 0)), Point((0, 10)))
     >>> seg2 = LineSegment(Point((-5, 5)), Point((5, 5)))
     >>> i = get_segments_intersect(seg1, seg2)
     >>> isinstance(i, Point)
     True
-    
+
     >>> str(i)
     '(0.0, 5.0)'
-    
+
     >>> seg3 = LineSegment(Point((100, 100)), Point((100, 101)))
     >>> i = get_segments_intersect(seg2, seg3)
-    
     """
 
     p1 = seg1.p1
@@ -353,16 +348,14 @@ def get_segment_point_intersect(seg, pt):
 
     Examples
     --------
-    
     >>> seg = LineSegment(Point((0, 0)), Point((0, 10)))
     >>> pt = Point((0, 5))
     >>> i = get_segment_point_intersect(seg, pt)
     >>> str(i)
     '(0.0, 5.0)'
-    
+
     >>> pt2 = Point((5, 5))
     >>> get_segment_point_intersect(seg, pt2)
-    
     """
 
     eps = np.finfo(type(pt[0])).eps
@@ -401,16 +394,14 @@ def get_polygon_point_intersect(poly, pt):
 
     Examples
     --------
-    
     >>> poly = Polygon([Point((0, 0)), Point((1, 0)), Point((1, 1)), Point((0, 1))])
     >>> pt = Point((0.5, 0.5))
     >>> i = get_polygon_point_intersect(poly, pt)
     >>> str(i)
     '(0.5, 0.5)'
-    
+
     >>> pt2 = Point((2, 2))
     >>> get_polygon_point_intersect(poly, pt2)
-    
     """
 
     def pt_lies_on_part_boundary(p, vx):
@@ -424,9 +415,9 @@ def get_polygon_point_intersect(poly, pt):
     if get_rectangle_point_intersect(poly.bounding_box, pt) is None:
         pass
     else:
-        if [vxs for vxs in poly._vertices if pt_lies_on_part_boundary(pt, vxs)] != []:
-            ret = pt
-        elif [vxs for vxs in poly._vertices if _point_in_vertices(pt, vxs)] != []:
+        if [
+            vxs for vxs in poly._vertices if pt_lies_on_part_boundary(pt, vxs)
+        ] != [] or [vxs for vxs in poly._vertices if _point_in_vertices(pt, vxs)] != []:
             ret = pt
         if poly._holes != [[]]:
             if [vxs for vxs in poly.holes if pt_lies_on_part_boundary(pt, vxs)] != []:
@@ -458,16 +449,15 @@ def get_rectangle_point_intersect(rect, pt):
 
     Examples
     --------
-    
+
     >>> rect = Rectangle(0, 0, 5, 5)
     >>> pt = Point((1, 1))
     >>> i = get_rectangle_point_intersect(rect, pt)
     >>> str(i)
     '(1.0, 1.0)'
-    
+
     >>> pt2 = Point((10, 10))
     >>> get_rectangle_point_intersect(rect, pt2)
-    
     """
 
     if rect.left <= pt[0] <= rect.right and rect.lower <= pt[1] <= rect.upper:
@@ -494,28 +484,24 @@ def get_ray_segment_intersect(ray, seg):
         The intersecting point or line between ``ray`` and
         ``seg`` if an intersection exists or ``None`` if
         ``ray`` and ``seg`` do not intersect.
-    
+
     See Also
     --------
-    
     libpysal.cg.get_segments_intersect
-    
-    
+
     Examples
     --------
-    
     >>> ray = Ray(Point((0, 0)), Point((0, 1)))
     >>> seg = LineSegment(Point((-1, 10)), Point((1, 10)))
     >>> i = get_ray_segment_intersect(ray, seg)
     >>> isinstance(i, Point)
     True
-    
+
     >>> str(i)
     '(0.0, 10.0)'
-    
+
     >>> seg2 = LineSegment(Point((10, 10)), Point((10, 11)))
     >>> get_ray_segment_intersect(ray, seg2)
-    
     """
 
     # Upper bound on origin to segment dist (+1)
@@ -554,51 +540,47 @@ def get_rectangle_rectangle_intersection(r0, r1, checkOverlap=True):
     checkOverlap : bool
         Call ``bbcommon(r0, r1)`` prior to complex geometry
         checking. Default is ``True``. Prior to setting as
-        ``False`` see the Notes section. 
-    
+        ``False`` see the Notes section.
+
     Returns
     -------
     intersection : {libpysal.cg.Point, libpysal.cg.LineSegment, libpysal.cg.Rectangle, None}
-        The intersecting point, line, or rectangle between 
-        `r0`` and ``r1`` if an intersection exists or ``None``
+        The intersecting point, line, or rectangle between
+        ``r0`` and ``r1`` if an intersection exists or ``None``
         if ``r0`` and ``r1`` do not intersect.
 
     Notes
     -----
-    
     The algorithm assumes the rectangles overlap. The keyword
     ``checkOverlap=False`` should be used with extreme caution.
 
     Examples
     --------
-    
     >>> r0 = Rectangle(0,4,6,9)
     >>> r1 = Rectangle(4,0,9,7)
     >>> ri = get_rectangle_rectangle_intersection(r0,r1)
     >>> ri[:]
     [4.0, 4.0, 6.0, 7.0]
-    
+
     >>> r0 = Rectangle(0,0,4,4)
     >>> r1 = Rectangle(2,1,6,3)
     >>> ri = get_rectangle_rectangle_intersection(r0,r1)
     >>> ri[:]
     [2.0, 1.0, 4.0, 3.0]
-    
+
     >>> r0 = Rectangle(0,0,4,4)
     >>> r1 = Rectangle(2,1,3,2)
     >>> ri = get_rectangle_rectangle_intersection(r0,r1)
     >>> ri[:] == r1[:]
     True
-    
-    """
+    """  # noqa E501
 
     intersection = None
     common_bb = True
 
-    if checkOverlap:
-        if not bbcommon(r0, r1):
-            # raise ValueError, "Rectangles do not intersect"
-            common_bb = False
+    if checkOverlap and not bbcommon(r0, r1):
+        # raise ValueError, "Rectangles do not intersect"
+        common_bb = False
 
     if common_bb:
         left = max(r0.left, r1.left)
@@ -625,7 +607,7 @@ def get_polygon_point_dist(poly, pt):
     ----------
     poly : libpysal.cg.Polygon
         A polygon to compute distance from.
-    
+
     pt : libpysal.cg.Point
         a point to compute distance from
 
@@ -633,19 +615,17 @@ def get_polygon_point_dist(poly, pt):
     -------
     dist : float
         The distance between ``poly`` and ``point``.
-    
+
     Examples
     --------
-    
     >>> poly = Polygon([Point((0, 0)), Point((1, 0)), Point((1, 1)), Point((0, 1))])
     >>> pt = Point((2, 0.5))
     >>> get_polygon_point_dist(poly, pt)
     1.0
-    
+
     >>> pt2 = Point((0.5, 0.5))
     >>> get_polygon_point_dist(poly, pt2)
     0.0
-    
     """
 
     if get_polygon_point_intersect(poly, pt) is not None:
@@ -654,7 +634,7 @@ def get_polygon_point_dist(poly, pt):
         part_prox = []
         for vertices in poly._vertices:
             vx_range = range(-1, len(vertices) - 1)
-            seg = lambda i: LineSegment(vertices[i], vertices[i + 1])
+            seg = lambda i: LineSegment(vertices[i], vertices[i + 1])  # noqa B023
             _min_dist = min([get_segment_point_dist(seg(i), pt)[0] for i in vx_range])
             part_prox.append(_min_dist)
         dist = min(part_prox)
@@ -669,24 +649,22 @@ def get_points_dist(pt1, pt2):
     ----------
     pt1 : libpysal.cg.Point
         A point.
-    
+
     pt2 : libpysal.cg.Point
         The other point.
-    
+
     Returns
     -------
     dist : float
         The distance between ``pt1`` and ``pt2``.
-    
+
     Examples
     --------
-    
     >>> get_points_dist(Point((4, 4)), Point((4, 8)))
     4.0
-    
+
     >>> get_points_dist(Point((0, 0)), Point((0, 0)))
     0.0
-    
     """
 
     dist = math.hypot(pt1[0] - pt2[0], pt1[1] - pt2[1])
@@ -705,7 +683,7 @@ def get_segment_point_dist(seg, pt):
         A line segment to compute distance from.
     pt : libpysal.cg.Point
         A point to compute distance from.
-    
+
     Returns
     -------
     dist : float
@@ -716,16 +694,14 @@ def get_segment_point_dist(seg, pt):
 
     Examples
     --------
-    
     >>> seg = LineSegment(Point((0, 0)), Point((10, 0)))
     >>> pt = Point((5, 5))
     >>> get_segment_point_dist(seg, pt)
     (5.0, 0.5)
-    
+
     >>> pt2 = Point((0, 0))
     >>> get_segment_point_dist(seg, pt2)
     (0.0, 0.0)
-    
     """
 
     src_p = seg.p1
@@ -782,7 +758,7 @@ def get_point_at_angle_and_dist(ray, angle, dist):
         The angle relative to ``ray`` at which ``point`` is located.
     dist : float
         The distance from the origin of ``ray`` at which ``point`` is located.
-    
+
     Returns
     -------
     point : libpysal.cg.Point
@@ -790,18 +766,16 @@ def get_point_at_angle_and_dist(ray, angle, dist):
 
     Examples
     --------
-    
     >>> ray = Ray(Point((0, 0)), Point((1, 0)))
     >>> pt = get_point_at_angle_and_dist(ray, math.pi, 1.0)
     >>> isinstance(pt, Point)
     True
-    
+
     >>> round(pt[0], 8)
     -1.0
-    
+
     >>> round(pt[1], 8)
     0.0
-    
     """
 
     v = (ray.p[0] - ray.o[0], ray.p[1] - ray.o[1])
@@ -817,7 +791,7 @@ def get_point_at_angle_and_dist(ray, angle, dist):
 
 def convex_hull(points):
     """Returns the convex hull of a set of points.
-    
+
     Parameters
     ----------
     points : list
@@ -827,14 +801,12 @@ def convex_hull(points):
     -------
     stack : list
         A list of points representing the convex hull.
-    
+
     Examples
     --------
-    
     >>> points = [Point((0, 0)), Point((4, 4)), Point((4, 0)), Point((3, 1))]
     >>> convex_hull(points)
     [(0.0, 0.0), (4.0, 0.0), (4.0, 4.0)]
-    
     """
 
     def right_turn(p1, p2, p3) -> bool:
@@ -863,7 +835,7 @@ def convex_hull(points):
 def is_clockwise(vertices):
     """Returns whether a list of points describing
     a polygon are clockwise or counterclockwise.
-    
+
     Parameters
     ----------
     vertices : list
@@ -873,21 +845,19 @@ def is_clockwise(vertices):
     -------
     clockwise : bool
         ``True`` if ``vertices`` are clockwise, otherwise ``False``.
-    
+
     See Also
     --------
-    
     libpysal.cg.ccw
-    
+
     Examples
     --------
-    
     >>> is_clockwise([Point((0, 0)), Point((10, 0)), Point((0, 10))])
     False
-    
+
     >>> is_clockwise([Point((0, 0)), Point((0, 10)), Point((10, 0))])
     True
-    
+
     >>> v = [
     ...     (-106.57798, 35.174143999999998),
     ...     (-106.583412, 35.174141999999996),
@@ -950,7 +920,6 @@ def is_clockwise(vertices):
     ... ]
     >>> is_clockwise(v)
     True
-    
     """
 
     clockwise = True
@@ -971,7 +940,7 @@ def is_clockwise(vertices):
 
 def ccw(vertices):
     """Returns whether a list of points is counterclockwise.
-    
+
     Parameters
     ----------
     vertices : list
@@ -981,21 +950,18 @@ def ccw(vertices):
     -------
     counter_clockwise : bool
         ``True`` if ``vertices`` are counter clockwise, otherwise ``False``.
-    
+
     See Also
     --------
-    
     libpysal.cg.is_clockwise
-    
+
     Examples
     --------
-    
     >>> ccw([Point((0, 0)), Point((10, 0)), Point((0, 10))])
     True
-    
+
     >>> ccw([Point((0, 0)), Point((0, 10)), Point((10, 0))])
     False
-    
     """
 
     counter_clockwise = True
@@ -1008,7 +974,7 @@ def ccw(vertices):
 
 def seg_intersect(a, b, c, d):
     """Tests if two segments (a,b) and (c,d) intersect.
-    
+
     Parameters
     ----------
     a : libpysal.cg.Point
@@ -1019,15 +985,14 @@ def seg_intersect(a, b, c, d):
         The first vertex for the second segment.
     d : libpysal.cg.Point
         The second vertex for the second segment.
-    
+
     Returns
     -------
     segments_intersect : bool
         ``True`` if segments ``(a,b)`` and ``(c,d)``, otherwise ``False``.
-    
+
     Examples
     --------
-    
     >>> a = Point((0,1))
     >>> b = Point((0,10))
     >>> c = Point((-2,5))
@@ -1035,10 +1000,9 @@ def seg_intersect(a, b, c, d):
     >>> e = Point((-3,5))
     >>> seg_intersect(a, b, c, d)
     True
-    
+
     >>> seg_intersect(a, b, c, e)
     False
-    
     """
 
     segments_intersect = True
@@ -1063,7 +1027,7 @@ def _point_in_vertices(pt, vertices):
         A point.
     vertices : list
         A list of vertices representing as polygon.
-    
+
     Returns
     -------
     pt_in_poly : bool
@@ -1071,13 +1035,11 @@ def _point_in_vertices(pt, vertices):
 
     Examples
     --------
-    
     >>> _point_in_vertices(
     ...     Point((1, 1)),
     ...     [Point((0, 0)), Point((10, 0)), Point((0, 10))]
     ... )
     True
-    
     """
 
     def neg_ray_intersect(p1, p2, p3) -> bool:
@@ -1099,7 +1061,7 @@ def _point_in_vertices(pt, vertices):
 
         return nr_inters
 
-    vert_y_set = set([v[1] for v in vertices])
+    vert_y_set = {v[1] for v in vertices}
     while pt[1] in vert_y_set:
         # Perturb the location very slightly
         pt = pt[0], pt[1] + -1e-14 + random.random() * 2e-14
@@ -1126,35 +1088,34 @@ def point_touches_rectangle(point, rect):
         A point or point coordinates.
     rect : libpysal.cg.Rectangle
         A rectangle.
-    
+
     Returns
     -------
     chflag : int
         ``1`` if ``point`` is in (or touches
         boundary of) ``rect``, otherwise ``0``.
-    
+
     Examples
     --------
-    
     >>> rect = Rectangle(0, 0, 10, 10)
     >>> a = Point((5, 5))
     >>> b = Point((10, 5))
     >>> c = Point((11, 11))
     >>> point_touches_rectangle(a, rect)
     1
-    
+
     >>> point_touches_rectangle(b, rect)
     1
-    
+
     >>> point_touches_rectangle(c, rect)
     0
-    
     """
 
     chflag = 0
-    if point[0] >= rect.left and point[0] <= rect.right:
-        if point[1] >= rect.lower and point[1] <= rect.upper:
-            chflag = 1
+    if (point[0] >= rect.left and point[0] <= rect.right) and (
+        point[1] >= rect.lower and point[1] <= rect.upper
+    ):
+        chflag = 1
 
     return chflag
 
@@ -1170,7 +1131,7 @@ def get_shared_segments(poly1, poly2, bool_ret=False):
         A Polygon.
     bool_ret : bool
         Return only a ``bool``. Default is ``False``.
-    
+
     Returns
     -------
     common : list
@@ -1181,7 +1142,6 @@ def get_shared_segments(poly1, poly2, bool_ret=False):
 
     Examples
     --------
-    
     >>> from libpysal.cg.shapes import Polygon
     >>> x = [0, 0, 1, 1]
     >>> y = [0, 1, 1, 0]
@@ -1190,7 +1150,6 @@ def get_shared_segments(poly1, poly2, bool_ret=False):
     >>> poly2 = Polygon(list(map(Point, zip(x, y))) )
     >>> get_shared_segments(poly1, poly2, bool_ret=True)
     True
-
     """
 
     # get_rectangle_rectangle_intersection inlined for speed.
@@ -1203,7 +1162,6 @@ def get_shared_segments(poly1, poly2, bool_ret=False):
 
     segmentsA = set()
     common = list()
-    partsA = poly1.parts
 
     for part in poly1.parts + [p for p in poly1.holes if p]:
         if part[0] != part[-1]:  # not closed
@@ -1237,10 +1195,7 @@ def get_shared_segments(poly1, poly2, bool_ret=False):
             if x >= wLeft and x <= wRight and y >= wLower and y <= wUpper:
                 x, y = b
                 if x >= wLeft and x <= wRight and y >= wLower and y <= wUpper:
-                    if a > b:
-                        seg = (b, a)
-                    else:
-                        seg = (a, b)
+                    seg = (b, a) if a > b else (a, b)
                     if seg in segmentsA:
                         common.append(LineSegment(*seg))
                         if bool_ret:
@@ -1257,7 +1212,7 @@ def get_shared_segments(poly1, poly2, bool_ret=False):
 
 
 def distance_matrix(X, p=2.0, threshold=5e7):
-    """Calculate a distance matrix.
+    r"""Calculate a distance matrix.
 
     Parameters
     ----------
@@ -1279,20 +1234,18 @@ def distance_matrix(X, p=2.0, threshold=5e7):
     -------
     D : numpy.ndarray
         An n by :math:`m` :math:`p`-norm distance matrix.
-    
+
     Raises
     ------
     TypeError
         Raised when an invalid dimensional array is passed in.
-    
+
     Notes
     -----
-    
     Needs optimization/integration with other weights in PySAL.
-    
+
     Examples
     --------
-    
     >>> x, y = [r.flatten() for r in np.indices((3, 3))]
     >>> data = np.array([x, y]).T
     >>> d = distance_matrix(data)
@@ -1315,7 +1268,6 @@ def distance_matrix(X, p=2.0, threshold=5e7):
             1.41421356, 1.        , 0.        , 1.        ],
            [2.82842712, 2.23606798, 2.        , 2.23606798, 1.41421356,
             1.        , 2.        , 1.        , 0.        ]])
-    
     """
 
     if X.ndim == 1:
@@ -1327,7 +1279,7 @@ def distance_matrix(X, p=2.0, threshold=5e7):
 
     n, k = X.shape
 
-    if (n ** 2) * 32 > threshold:
+    if (n**2) * 32 > threshold:
         D = scipy.spatial.distance_matrix(X, X, p)
     else:
         M = np.ones((n, n))
@@ -1338,7 +1290,7 @@ def distance_matrix(X, p=2.0, threshold=5e7):
             dx = xM - xM.T
             if p % 2 != 0:
                 dx = np.abs(dx)
-            dx2 = dx ** p
+            dx2 = dx**p
             D += dx2
         D = D ** (1.0 / p)
 

--- a/libpysal/cg/voronoi.py
+++ b/libpysal/cg/voronoi.py
@@ -31,15 +31,14 @@ def voronoi(points, radius=None):
         the list contains the sequence of the indices of Voronoi vertices
         composing a Voronoi polygon (region), whereas the array contains
         the Voronoi vertex coordinates.
-    
+
     Examples
     --------
-    
     >>> points = [(10.2, 5.1), (4.7, 2.2), (5.3, 5.7), (2.7, 5.3)]
     >>> regions, coordinates = voronoi(points)
     >>> regions
     [[1, 3, 2], [4, 5, 1, 0], [0, 1, 7, 6], [9, 0, 8]]
-    
+
     >>> coordinates
     array([[  4.21783296,   4.08408578],
            [  7.51956025,   3.51807539],
@@ -51,7 +50,6 @@ def voronoi(points, radius=None):
            [  9.4642193 ,  19.3994576 ],
            [  1.78491801,  19.89803294],
            [ -9.22691341,  -4.58994414]])
-    
     """
 
     vor = voronoi_regions(Voronoi(points), radius=radius)
@@ -68,13 +66,12 @@ def voronoi_regions(vor, radius=None):
         A planar Voronoi diagram.
     radius : float (optional)
         Distance to 'points at infinity'. Default is ``None.``
-    
+
     Returns
     -------
     regions_vertices : tuple
         A two-element tuple consisting of a list of finite voronoi regions
         and an array Voronoi vertex coordinates.
-    
     """
 
     new_regions = []
@@ -85,7 +82,7 @@ def voronoi_regions(vor, radius=None):
         radius = vor.points.ptp().max() * 2
 
     all_ridges = {}
-    for (p1, p2), (v1, v2) in zip(vor.ridge_points, vor.ridge_vertices):
+    for (p1, p2), (v1, v2) in zip(vor.ridge_points, vor.ridge_vertices, strict=True):
         all_ridges.setdefault(p1, []).append((p2, v1, v2))
         all_ridges.setdefault(p2, []).append((p1, v1, v2))
 
@@ -148,14 +145,13 @@ def as_dataframes(regions, vertices, points):
         Finite Voronoi polygons as geometries.
     points_df : geopandas.GeoDataFrame
         Originator points as geometries.
-    
+
     Raises
     ------
     ImportError
         Raised when ``geopandas`` is not available.
     ImportError
         Raised when ``shapely`` is not available.
-    
     """
 
     try:
@@ -164,21 +160,17 @@ def as_dataframes(regions, vertices, points):
         gpd = None
 
     try:
-        from shapely.geometry import Polygon, Point
+        from shapely.geometry import Point, Polygon
     except ImportError:
-        from .shapes import Polygon, Point
+        from .shapes import Point, Polygon
 
     if gpd is not None:
         region_df = gpd.GeoDataFrame(
-            geometry = gpd.GeoSeries(
-                Polygon(vertices[region]) for region in regions
-                )
-            )
+            geometry=gpd.GeoSeries(Polygon(vertices[region]) for region in regions)
+        )
         point_df = gpd.GeoDataFrame(
-            geometry = gpd.GeoSeries(
-                Point(pnt) for pnt in points
-                )
-            )
+            geometry=gpd.GeoSeries(Point(pnt) for pnt in points)
+        )
     else:
         import pandas as pd
 
@@ -206,7 +198,7 @@ def voronoi_frames(points, radius=None, clip="extent"):
     clip : {str, shapely.geometry.Polygon}
         An overloaded option about how to clip the voronoi cells.
         Default is ``'extent'``. Options are as follows.
-        
+
         * ``'none'``/``None`` -- No clip is applied. Voronoi cells may be arbitrarily larger that the source map. Note that this may lead to cells that are many orders of magnitude larger in extent than the original map. Not recommended.
         * ``'bbox'``/``'extent'``/``'bounding box'`` -- Clip the voronoi cells to the bounding box of the input points.
         * ``'chull``/``'convex hull'`` -- Clip the voronoi cells to the convex hull of the input points.
@@ -217,12 +209,11 @@ def voronoi_frames(points, radius=None, clip="extent"):
     -------
     reg_vtx : tuple
         Two ``geopandas.GeoDataFrame`` (or ``pandas.DataFrame`` if ``geopandas``
-        is unavailable) objects--``(region_df, points_df)``--of finite 
+        is unavailable) objects--``(region_df, points_df)``--of finite
         Voronoi polygons and the originator points as geometries.
 
     Notes
     -----
-
     If ``geopandas`` is not available the return types will be
     ``pandas.DataFrame`` objects, each with a geometry column populated
     with PySAL shapes. If ``geopandas`` is available, return types are
@@ -231,16 +222,14 @@ def voronoi_frames(points, radius=None, clip="extent"):
 
     Examples
     --------
-    
     >>> points = [(10.2, 5.1), (4.7, 2.2), (5.3, 5.7), (2.7, 5.3)]
     >>> regions_df, points_df = voronoi_frames(points)
     >>> regions_df.shape
     (4, 1)
-    
+
     >>> regions_df.shape == points_df.shape
     True
-
-    """
+    """  # noqa E501
 
     regions, vertices = voronoi(points, radius=radius)
     regions, vertices = as_dataframes(regions, vertices, points)
@@ -254,7 +243,7 @@ def voronoi_frames(points, radius=None, clip="extent"):
 def clip_voronoi_frames_to_extent(regions, vertices, clip="extent"):
     """Generate a geopandas.GeoDataFrame of Voronoi cells clipped to
     a specified extent.
-    
+
     Parameters
     ----------
     regions : geopandas.GeoDataFrame
@@ -276,12 +265,12 @@ def clip_voronoi_frames_to_extent(regions, vertices, clip="extent"):
             contains all points (e.g. the smallest alphashape,
             using ``libpysal.cg.alpha_shape_auto``).
           - Polygon: Clip to an arbitrary Polygon.
-    
+
     Returns
     -------
     clipped_regions : geopandas.GeoDataFrame
         A ``geopandas.GeoDataFrame`` of clipped voronoi regions.
-    
+
     Raises
     ------
     ImportError
@@ -290,22 +279,19 @@ def clip_voronoi_frames_to_extent(regions, vertices, clip="extent"):
         Raised when ``geopandas`` is not available.
     ValueError
         Raised when in invalid value for ``clip`` is passed in.
-    
     """
     try:
         from shapely.geometry import Polygon
     except ImportError:
-        raise ImportError("Shapely is required to clip voronoi regions.")
+        raise ImportError("Shapely is required to clip voronoi regions.") from None
     try:
         import geopandas
     except ImportError:
-        raise ImportError("Geopandas is required to clip voronoi regions.")
+        raise ImportError("Geopandas is required to clip voronoi regions.") from None
 
     if isinstance(clip, Polygon):
         clipper = geopandas.GeoDataFrame(geometry=[clip])
-    elif clip is None:
-        return regions
-    elif clip.lower() == "none":
+    elif clip is None or clip.lower() == "none":
         return regions
     elif clip.lower() in ("bounds", "bounding box", "bbox", "extent"):
         min_x, min_y, max_x, max_y = vertices.total_bounds
@@ -331,16 +317,15 @@ def clip_voronoi_frames_to_extent(regions, vertices, clip="extent"):
         "alpha shape",
         "alpha_shape",
     ):
-        from .alpha_shapes import alpha_shape_auto
         from ..weights.distance import get_points_array
+        from .alpha_shapes import alpha_shape_auto
 
         coordinates = get_points_array(vertices.geometry)
         clipper = geopandas.GeoDataFrame(geometry=[alpha_shape_auto(coordinates)])
     else:
         raise ValueError(
-            "Clip type '{}' not understood. Try one "
-            " of the supported options: [None, 'extent', "
-            "'chull', 'ahull'].".format(clip)
+            f"Clip type '{clip}' not understood. Try one of the supported options: "
+            "[None, 'extent', 'chull', 'ahull']."
         )
     clipped_regions = geopandas.overlay(regions, clipper, how="intersection")
     return clipped_regions


### PR DESCRIPTION
xref #589 

This PR formats, lints, & [removes docstring spaces](https://github.com/pysal/libpysal/pull/607#discussion_r1371335093) from `./cg/*.py`. Even though I am trying to do this in coherent sections (left out all `cg` subdirs) some of the PRs are going to be pains to review. I can split into file level PRs if desired.