### PR TITLE
format, lint, numpydoc – `cg/ops/*.py`

### DIFF
--- a/libpysal/cg/ops/_accessors.py
+++ b/libpysal/cg/ops/_accessors.py
@@ -1,3 +1,5 @@
+# ruff: noqa: F822
+
 import functools as _f
 
 __all__ = [
@@ -17,11 +19,10 @@ __all__ = [
 def get_attr(df, geom_col="geometry", inplace=False, attr=None):
     outval = df[geom_col].apply(lambda x: x.__getattribute__(attr))
     if inplace:
-        outcol = "shape_{}".format(func.__name__)
+        outcol = f"shape_{func.__name__}"  # noqa F821
         df[outcol] = outval
         return None
     return outval
-
 
 
 _doc_template = """
@@ -40,19 +41,16 @@ inplace : bool
 
 Returns
 -------
-
 ``None`` if inplace is set to ``True`` and operation is conducted
 on ``df`` in memory. Otherwise, returns a pandas.Series.
 
 See Also
 --------
-
 For further documentation about the attributes of the object in question, refer
 to shape classes in ``pysal.cg.shapes``.
-
 """
 
-_accessors = dict()
+_accessors = {}
 for k in __all__:
     _accessors[k] = _f.partial(get_attr, attr=k)
     _accessors[k].__doc__ = _doc_template.format(n=k)

--- a/libpysal/cg/ops/_shapely.py
+++ b/libpysal/cg/ops/_shapely.py
@@ -1,5 +1,8 @@
+# ruff: noqa: F822
+
 import functools as _f
 from warnings import warn
+
 from ...common import requires as _requires
 
 __all__ = [
@@ -45,7 +48,7 @@ def _atomic_op(df, geom_col="geometry", inplace=False, _func=None, **kwargs):
     """Atomic operation internal function."""
 
     outval = df[geom_col].apply(lambda x: _func(x, **kwargs))
-    outcol = "shape_{}".format(_func.__name__)
+    outcol = f"shape_{_func.__name__}"
     if not inplace:
         new = df.copy()
         new[outcol] = outval
@@ -76,14 +79,11 @@ returns a series.
 
 Notes
 -----
-
 Some atomic operations require an 'other' argument.
 
 See Also
 --------
-
 pysal.contrib.shapely_ext.{n}
-
 """
 
 # ensure that the construction of atomics is done only if we can use shapely
@@ -123,10 +123,8 @@ def cascaded_union(df, geom_col="geometry", **groupby_kws):
 
     See Also
     --------
-    
     pysal.shapely_ext.cascaded_union
     pandas.DataFrame.groupby
-    
     """
 
     by = groupby_kws.pop("by", None)
@@ -159,19 +157,17 @@ def unary_union(df, geom_col="geometry", **groupby_kws):
 
     See Also
     --------
-    
     pysal.shapely_ext.unary_union
     pandas.DataFrame.groupby
-    
     """
 
     by = groupby_kws.pop("by", None)
     level = groupby_kws.pop("level", None)
     if by is not None or level is not None:
         df = df.groupby(**groupby_kws)
-        out = df[geom_col].apply(_cascaded_union)
+        out = df[geom_col].apply(_cascaded_union)  # noqa F821
     else:
-        out = _cascaded_union(df[geom_col].tolist())
+        out = _cascaded_union(df[geom_col].tolist())  # noqa F821
     return out
 
 
@@ -179,11 +175,11 @@ def unary_union(df, geom_col="geometry", **groupby_kws):
 def _cascaded_intersection(shapes):
     it = iter(shapes)
     outshape = next(it)
-    for i, shape in enumerate(it):
+    for _i, shape in enumerate(it):
         try:
             outshape = _s.intersection(shape, outshape)
         except NotImplementedError:
-            warn("An intersection is empty!")
+            warn("An intersection is empty!", stacklevel=2)
             return None
     return outshape
 
@@ -204,14 +200,13 @@ def cascaded_intersection(df, geom_col="geometry", **groupby_kws):
     Returns
     -------
     out : {libpysal.cg.{Point, Chain, Polygon}, pandas.DataFrame}
-        A PySAL shape or a dataframe of shapes resulting from the intersection operation.
+        A PySAL shape or a dataframe of shapes resulting
+        from the intersection operation.
 
     See Also
     --------
-    
     pysal.shapely_ext.cascaded_intersection
     pandas.DataFrame.groupby
-    
     """
 
     by = groupby_kws.pop("by", None)

--- a/libpysal/cg/ops/atomic.py
+++ b/libpysal/cg/ops/atomic.py
@@ -2,7 +2,7 @@ from . import _accessors as _a
 from . import _shapely as _s
 
 # prefer access to shapely computation
-_all = dict()
+_all = {}
 _all.update(_s.__dict__)
 _all.update(_a.__dict__)
 

--- a/libpysal/cg/ops/tabular.py
+++ b/libpysal/cg/ops/tabular.py
@@ -1,8 +1,8 @@
-from ...common import requires as _requires
-from ...io.geotable.utils import to_gdf, to_df
-from warnings import warn as _Warn
 import functools as _f
-import sys as _sys
+from warnings import warn
+
+from ...common import requires as _requires
+from ...io.geotable.utils import to_df, to_gdf
 
 try:
     import pandas as _pd
@@ -11,7 +11,6 @@ try:
     @_f.wraps(_pd.merge)
     def join(*args, **kwargs):
         return _pd.merge(*args, **kwargs)
-
 
 except ImportError:
     pass
@@ -53,13 +52,12 @@ def spatial_join(
         the suffix to apply to overlapping column names from ``df1``.;
         and (4) ``'rsuffix'`` defaults to ``right'``),
         the suffix to apply to overlapping column names from ``df2``.
-    
+
     Returns
     -------
     df : pandas.DataFrame
         A pandas.DataFrame with a new set of polygons
         and attributes resulting from the overlay.
-    
     """
 
     import geopandas as gpd
@@ -103,13 +101,12 @@ def spatial_overlay(
         Default is ``'geometry'``.
     **kwargs : dict
         Optional keyword arguments passed in ``geopandas.tools.overlay``.
-    
+
     Returns
     -------
     df : pandas.DataFrame
         A pandas.DataFrame with a new set of polygons
         and attributes resulting from the overlay.
-    
     """
 
     import geopandas as gpd
@@ -130,13 +127,13 @@ def dissolve(df, by="", **groupby_kws):
     return union(df, by=by, **groupby_kws)
 
 
-def clip(return_exterior=False):
+def clip(return_exterior=False):  # noqa ARG001
     # return modified entries of the df that are within an envelope
     # provide an option to null out the geometries instead of not returning
     raise NotImplementedError
 
 
-def erase(return_interior=True):
+def erase(return_interior=True):  # noqa ARG001
     # return modified entries of the df that are outside of an envelope
     # provide an option to null out the geometries instead of not returning
     raise NotImplementedError
@@ -145,7 +142,10 @@ def erase(return_interior=True):
 @_requires("shapely")
 def union(df, **kws):
     if "by" in kws:
-        warn("When a 'by' argument is provided, you should be using 'dissolve'.")
+        warn(
+            "When a 'by' argument is provided, you should be using 'dissolve'.",
+            stacklevel=2,
+        )
         return dissolve(df, **kws)
     from ._shapely import cascaded_union as union
 


### PR DESCRIPTION
xref https://github.com/pysal/libpysal/issues/589

This PR formats, lints, & https://github.com/pysal/libpysal/pull/607#discussion_r1371335093 from `./cg/ops/*.py`.