### PR TITLE
format & lint – `cg/ops/tests*.py`

### DIFF
--- a/libpysal/cg/ops/tests/test_accessors.py
+++ b/libpysal/cg/ops/tests/test_accessors.py
@@ -211,9 +211,45 @@ class TestAccessors:
         with pytest.raises(AttributeError):
             to_test.parts(self.points)
 
-        to_test.parts(self.lines)
-        pgon_parts = to_test.parts(self.polygons)
+        line_parts = to_test.parts(self.lines)
+        line_answers = [
+            [
+                [
+                    (-0.009053924887015952, -0.25832280562918325),
+                    (0.007481157395930582, -0.2589587703323735),
+                    (0.007481157395930582, -0.2589587703323735),
+                ]
+            ],
+            [
+                [
+                    (0.10923550990637088, -0.2564149115196125),
+                    (0.12895041570526866, -0.2564149115196125),
+                ]
+            ],
+            [
+                [
+                    (0.050726757212867735, -0.3130157701035449),
+                    (0.050726757212867735, -0.356261369920482),
+                    (0.06153815716710198, -0.3448140052630575),
+                    (0.06153815716710198, -0.3448140052630575),
+                ]
+            ],
+            [
+                [
+                    (-0.0414881247497188, -0.41286222850441445),
+                    (-0.012233748402967204, -0.4402087107415953),
+                    (0.027196063194828424, -0.46055958124368335),
+                    (0.07489341593409732, -0.4586516871341126),
+                    (0.11241533342232213, -0.43639292252245376),
+                    (0.1391258509563127, -0.4058666167693217),
+                ]
+            ],
+        ]
+        for part, answer in zip(line_parts, line_answers):
+            for piece, sub_answer in zip(part, answer):
+                np.testing.assert_allclose(piece, sub_answer, rtol=RTOL, atol=ATOL)
 
+        pgon_parts = to_test.parts(self.polygons)
         pgon_answers = [
             [
                 [
@@ -275,7 +311,6 @@ class TestAccessors:
                 ]
             ],
         ]
-
         for part, answer in zip(pgon_parts, pgon_answers, strict=True):
             for piece, sub_answer in zip(part, answer, strict=True):
                 np.testing.assert_allclose(piece, sub_answer, rtol=RTOL, atol=ATOL)

--- a/libpysal/cg/ops/tests/test_accessors.py
+++ b/libpysal/cg/ops/tests/test_accessors.py
@@ -245,8 +245,8 @@ class TestAccessors:
                 ]
             ],
         ]
-        for part, answer in zip(line_parts, line_answers):
-            for piece, sub_answer in zip(part, answer):
+        for part, answer in zip(line_parts, line_answers, strict=True):
+            for piece, sub_answer in zip(part, answer, strict=True):
                 np.testing.assert_allclose(piece, sub_answer, rtol=RTOL, atol=ATOL)
 
         pgon_parts = to_test.parts(self.polygons)

--- a/libpysal/cg/ops/tests/test_accessors.py
+++ b/libpysal/cg/ops/tests/test_accessors.py
@@ -1,10 +1,10 @@
 import numpy as np
 import pytest
 
-from ....common import ATOL, RTOL, pandas
+from ....common import ATOL, RTOL
 from ....examples import get_path
 from ....io.geotable.file import read_files as rf
-from ...shapes import Chain, LineSegment, Point, Polygon, Rectangle
+from ...shapes import LineSegment, Rectangle
 from .. import _accessors as to_test
 
 
@@ -52,7 +52,7 @@ class TestAccessors:
         ]
 
         bboxes = to_test.bbox(self.polygons).tolist()
-        for ans, bbox in zip(answer, bboxes):
+        for ans, bbox in zip(answer, bboxes, strict=True):
             np.testing.assert_allclose(ans, bbox, rtol=RTOL, atol=ATOL)
 
     def test_bounding_box(self):
@@ -97,9 +97,9 @@ class TestAccessors:
             ],
         ]
 
-        for bbox, answer in zip(line_bboxes, line_answers):
+        for bbox, answer in zip(line_bboxes, line_answers, strict=True):
             np.testing.assert_allclose(bbox, answer, atol=ATOL, rtol=RTOL)
-        for bbox, answer in zip(pgon_bboxes, pgon_answers):
+        for bbox, answer in zip(pgon_bboxes, pgon_answers, strict=True):
             np.testing.assert_allclose(bbox, answer, atol=ATOL, rtol=RTOL)
         for rectangle in line_rects + pgon_rects:
             assert isinstance(rectangle, Rectangle)
@@ -118,7 +118,7 @@ class TestAccessors:
             (0.04759584610455384, -0.44147205133285744),
         ]
 
-        for ct, answer in zip(centroids, centroid_answers):
+        for ct, answer in zip(centroids, centroid_answers, strict=True):
             np.testing.assert_allclose(ct, answer, rtol=RTOL, atol=ATOL)
 
     def test_holes(self):
@@ -186,8 +186,8 @@ class TestAccessors:
                 ],
             ],
         ]
-        for hole, answer in zip(holes, answers):
-            for sub_hole, sub_answer in zip(hole, answer):
+        for hole, answer in zip(holes, answers, strict=True):
+            for sub_hole, sub_answer in zip(hole, answer, strict=True):
                 np.testing.assert_allclose(sub_hole, sub_answer, rtol=RTOL, atol=ATOL)
 
     def test_len(self):
@@ -211,7 +211,7 @@ class TestAccessors:
         with pytest.raises(AttributeError):
             to_test.parts(self.points)
 
-        line_parts = to_test.parts(self.lines)
+        to_test.parts(self.lines)
         pgon_parts = to_test.parts(self.polygons)
 
         pgon_answers = [
@@ -275,42 +275,9 @@ class TestAccessors:
                 ]
             ],
         ]
-        line_answers = [
-            [
-                [
-                    (-0.009053924887015952, -0.25832280562918325),
-                    (0.007481157395930582, -0.2589587703323735),
-                    (0.007481157395930582, -0.2589587703323735),
-                ]
-            ],
-            [
-                [
-                    (0.10923550990637088, -0.2564149115196125),
-                    (0.12895041570526866, -0.2564149115196125),
-                ]
-            ],
-            [
-                [
-                    (0.050726757212867735, -0.3130157701035449),
-                    (0.050726757212867735, -0.356261369920482),
-                    (0.06153815716710198, -0.3448140052630575),
-                    (0.06153815716710198, -0.3448140052630575),
-                ]
-            ],
-            [
-                [
-                    (-0.0414881247497188, -0.41286222850441445),
-                    (-0.012233748402967204, -0.4402087107415953),
-                    (0.027196063194828424, -0.46055958124368335),
-                    (0.07489341593409732, -0.4586516871341126),
-                    (0.11241533342232213, -0.43639292252245376),
-                    (0.1391258509563127, -0.4058666167693217),
-                ]
-            ],
-        ]
 
-        for part, answer in zip(pgon_parts, pgon_answers):
-            for piece, sub_answer in zip(part, answer):
+        for part, answer in zip(pgon_parts, pgon_answers, strict=True):
+            for piece, sub_answer in zip(part, answer, strict=True):
                 np.testing.assert_allclose(piece, sub_answer, rtol=RTOL, atol=ATOL)
 
     def test_perimeter(self):
@@ -333,7 +300,7 @@ class TestAccessors:
             to_test.segments(self.polygons)
 
         line_segments = to_test.segments(self.lines)
-        flattened = [l[0] for l in line_segments]
+        flattened = [l_[0] for l_ in line_segments]
 
         answers = [
             [
@@ -390,8 +357,8 @@ class TestAccessors:
             ],
         ]
 
-        for parts, points in zip(flattened, answers):
-            for piece, answer in zip(parts, points):
+        for parts, points in zip(flattened, answers, strict=True):
+            for piece, answer in zip(parts, points, strict=True):
                 assert isinstance(piece, LineSegment)
                 p1, p2 = piece.p1, piece.p2
                 np.testing.assert_allclose([p1, p2], answer)
@@ -481,7 +448,7 @@ class TestAccessors:
                 (-0.04527237752903268, -0.413550752273984),
             ],
         ]
-        for part, answer in zip(line_verts, line_answers):
+        for part, answer in zip(line_verts, line_answers, strict=True):
             np.testing.assert_allclose(part, answer, atol=ATOL, rtol=RTOL)
-        for part, answer in zip(pgon_verts, pgon_answers):
+        for part, answer in zip(pgon_verts, pgon_answers, strict=True):
             np.testing.assert_allclose(part, answer, atol=ATOL, rtol=RTOL)

--- a/libpysal/cg/ops/tests/test_shapely.py
+++ b/libpysal/cg/ops/tests/test_shapely.py
@@ -1,17 +1,19 @@
-import pytest
-from .. import _shapely as sht
-from ...shapes import Point, Chain, Polygon
-
-# from ... import  comparators as comp
-# from ... import shapely as she
-from ....io.geotable import read_files as rf
-from ....examples import get_path
-import numpy as np
 from warnings import warn
+
+import numpy as np
+import pytest
+
+from ....examples import get_path
+from ....io.geotable import read_files as rf
+
+# from ... import comparators as comp
+# from ... import shapely as she
+from ...shapes import Chain
+from .. import _shapely as sht
 
 
 @pytest.mark.skip("Skipping shapely during reorg.")
-class Test_Shapely:
+class TestShapely:
     def setup_method(self):
         self.polygons = rf(get_path("Polygon.shp"))
         self.points = rf(get_path("Point.shp"))
@@ -25,20 +27,20 @@ class Test_Shapely:
 
     def compare(self, func_name, df, **kwargs):
         geom_list = df.geometry.tolist()
-        shefunc = she.__dict__[func_name]
-        shtfunc = sht.__dict__[func_name]
+        shefunc = she.__dict__[func_name]  # noqa F821
+        shtfunc = sht.__dict__[func_name]  # noqa F821
 
         try:
             she_vals = (shefunc(geom, **kwargs) for geom in geom_list)
             sht_vals = shtfunc(df, inplace=False, **kwargs)
-            sht_list = sht_vals["shape_{}".format(func_name)].tolist()
-            for tabular, shapely in zip(sht_list, she_vals):
-                if comp.is_shape(tabular) and comp.is_shape(shapely):
-                    comp.equal(tabular, shapely)
+            sht_list = sht_vals[f"shape_{func_name}"].tolist()
+            for tabular, shapely in zip(sht_list, she_vals, strict=True):
+                if comp.is_shape(tabular) and comp.is_shape(shapely):  # noqa F821
+                    comp.equal(tabular, shapely)  # noqa F821
                 else:
                     assert tabular == shapely
         except NotImplementedError as e:
-            warn("The shapely/PySAL bridge is not implemented: {}.".format(e))
+            warn(f"The shapely/PySAL bridge is not implemented: {e}.", stacklevel=2)
             return True
 
     def test_to_wkb(self):

--- a/libpysal/cg/ops/tests/test_tabular.py
+++ b/libpysal/cg/ops/tests/test_tabular.py
@@ -1,12 +1,10 @@
 import numpy as np
 
-from ....common import ATOL, RTOL, pandas
 from ....common import requires as _requires
 from ....examples import get_path
 from ....io import geotable as pdio
-from ... import ops as GIS
+from ... import ops as GIS  # noqa N812
 from ...shapes import Polygon
-from .. import tabular as ta
 
 
 class TestTabular:
@@ -35,7 +33,7 @@ class TestTabular:
         assert isinstance(geodf, gpd.GeoDataFrame)
         new_df = GIS.tabular.to_df(geodf)
         assert isinstance(new_df, pd.DataFrame)
-        for new, old in zip(new_df.geometry, self.columbus.geometry):
+        for new, old in zip(new_df.geometry, self.columbus.geometry, strict=True):
             assert new == old
 
     def test_spatial_join(self):
@@ -49,11 +47,11 @@ class TestTabular:
         assert out[0].area == 2.0
         assert out[1].area == 2.0
 
-        answer_vertices0 = set([(0, 0), (0, 1), (0, 2), (1, 2), (1, 1), (1, 0), (0, 0)])
-        answer_vertices1 = set([(2, 1), (2, 0), (1, 0), (1, 1), (1, 2), (2, 2), (2, 1)])
+        answer_vertices0 = {(0, 0), (0, 1), (0, 2), (1, 2), (1, 1), (1, 0), (0, 0)}
+        answer_vertices1 = {(2, 1), (2, 0), (1, 0), (1, 1), (1, 2), (2, 2), (2, 1)}
 
-        s0 = set([tuple(map(int, t)) for t in out[0].vertices])
-        s1 = set([tuple(map(int, t)) for t in out[1].vertices])
+        s0 = {tuple(map(int, t)) for t in out[0].vertices}
+        s1 = {tuple(map(int, t)) for t in out[1].vertices}
 
         assert s0 == answer_vertices0
         assert s1 == answer_vertices1


### PR DESCRIPTION
xref https://github.com/pysal/libpysal/issues/589

This PR builds on top of #610 (should review and merge that one first) and formats & lints `cg/ops/tests*.py`