### PR TITLE
fix index check for precomputed graph distances

### DIFF
--- a/libpysal/graph/_utils.py
+++ b/libpysal/graph/_utils.py
@@ -233,11 +233,12 @@ def _vec_euclidean_distances(X, Y):
 
 def _evaluate_index(data):
     """Helper to get ids from any input."""
-    return (
-        data.index
-        if isinstance(data, (pd.Series, pd.DataFrame))
-        else pd.RangeIndex(0, len(data))
-    )
+    if isinstance(data, (pd.Series, pd.DataFrame)):
+        return data.index
+    elif hasattr(data, 'shape'):
+        return pd.RangeIndex(0, data.shape[0])
+    else:
+        return pd.RangeIndex(0, len(data))
 
 
 def _resolve_islands(heads, tails, ids, weights):

--- a/libpysal/graph/tests/test_builders.py
+++ b/libpysal/graph/tests/test_builders.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_almost_equal
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix
 from shapely import get_coordinates
 
 from libpysal import graph

--- a/libpysal/graph/tests/test_builders.py
+++ b/libpysal/graph/tests/test_builders.py
@@ -4,8 +4,8 @@ import numpy as np
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_almost_equal
-from shapely import get_coordinates
 from scipy.sparse.csr import csr_matrix
+from shapely import get_coordinates
 
 from libpysal import graph
 
@@ -202,7 +202,9 @@ class TestKernel:
         sklearn = pytest.importorskip("sklearn")
         df = gpd.read_file(geodatasets.get_path("nybb"))
         df = df.to_crs(df.estimate_utm_crs())
-        distmat = csr_matrix(sklearn.metrics.pairwise.euclidean_distances(get_coordinates(df.centroid)))
+        distmat = csr_matrix(
+            sklearn.metrics.pairwise.euclidean_distances(get_coordinates(df.centroid))
+        )
         G = graph.Graph.build_kernel(distmat, metric="precomputed")
         expected = np.array(
             [

--- a/libpysal/graph/tests/test_builders.py
+++ b/libpysal/graph/tests/test_builders.py
@@ -6,7 +6,6 @@ import pytest
 from numpy.testing import assert_array_almost_equal
 from shapely import get_coordinates
 from scipy.sparse.csr import csr_matrix
-from sklearn.metrics.pairwise import euclidean_distances
 
 from libpysal import graph
 

--- a/libpysal/graph/tests/test_builders.py
+++ b/libpysal/graph/tests/test_builders.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 from numpy.testing import assert_array_almost_equal
 from shapely import get_coordinates
+from scipy.sparse.csr import csr_matrix
 from sklearn.metrics.pairwise import euclidean_distances
 
 from libpysal import graph
@@ -199,9 +200,10 @@ class TestKernel:
         self.gdf_str = self.gdf.set_index("placeid")
 
     def test_kernel_precompute(self):
+        sklearn = pytest.importorskip("sklearn")
         df = gpd.read_file(geodatasets.get_path("nybb"))
         df = df.to_crs(df.estimate_utm_crs())
-        distmat = euclidean_distances(get_coordinates(df.centroid))
+        distmat = csr_matrix(sklearn.metrics.pairwise.euclidean_distances(get_coordinates(df.centroid)))
         G = graph.Graph.build_kernel(distmat, metric="precomputed")
         expected = np.array(
             [

--- a/libpysal/graph/tests/test_builders.py
+++ b/libpysal/graph/tests/test_builders.py
@@ -1,8 +1,12 @@
-import pytest
-
-import geopandas as gpd
-import pandas as pd
 import geodatasets
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+from numpy.testing import assert_array_almost_equal
+from shapely import get_coordinates
+from sklearn.metrics.pairwise import euclidean_distances
+
 from libpysal import graph
 
 TRIANGULATIONS = ["delaunay", "gabriel", "relative_neighborhood", "voronoi"]
@@ -193,6 +197,38 @@ class TestKernel:
             ignore_index=True
         )
         self.gdf_str = self.gdf.set_index("placeid")
+
+    def test_kernel_precompute(self):
+        df = gpd.read_file(geodatasets.get_path("nybb"))
+        df = df.to_crs(df.estimate_utm_crs())
+        distmat = euclidean_distances(get_coordinates(df.centroid))
+        G = graph.Graph.build_kernel(distmat, metric="precomputed")
+        expected = np.array(
+            [
+                0.07131664,
+                0.14998932,
+                0.09804811,
+                0.0402638,
+                0.07131664,
+                0.18556845,
+                0.17529176,
+                0.16394507,
+                0.14998932,
+                0.18556845,
+                0.17495794,
+                0.11561449,
+                0.09804811,
+                0.17529176,
+                0.17495794,
+                0.19116432,
+                0.0402638,
+                0.16394507,
+                0.11561449,
+                0.19116432,
+            ]
+        )
+
+        assert_array_almost_equal(G.adjacency.values, expected, 3)
 
     def test_kernel_intids(self):
         G = graph.Graph.build_kernel(self.gdf)


### PR DESCRIPTION
small tweak, but the existing code will fail when trying to instantiate a kernel graph from a precomputed (sparse) distance matrix (because it has no len)

when passing a precomputed distance matrix its also handy to be able to pass ids as well. I think that would be a small change in this function too, but not sure if we disallowed that for some reason