### PR TITLE
pass kwargs to explore

### DIFF
--- a/libpysal/graph/_plotting.py
+++ b/libpysal/graph/_plotting.py
@@ -149,6 +149,7 @@ def _explore_graph(
     node_kws=None,
     focal_kws=None,
     m=None,
+    **kwargs,
 ):
     """Plot graph as an interactive Folium Map
 
@@ -177,6 +178,10 @@ def _explore_graph(
         passing a subset of nodes with the `focal` argument
     m : Folilum.Map, optional
         folium map objecto to plot on top of, by default None
+    **kwargs : dict, optional
+        additional keyword arguments are passed directly to geopandas.explore, when
+        ``m=None`` by default None
+
 
     Returns
     -------
@@ -230,7 +235,11 @@ def _explore_graph(
         ["focal", "neighbor", "weight", "geometry"]
     ]
 
-    m = edges.explore(m=m, **edge_kws) if m is not None else edges.explore(**edge_kws)
+    m = (
+        edges.explore(m=m, **edge_kws)
+        if m is not None
+        else edges.explore(**edge_kws, **kwargs)
+    )
 
     if nodes is True:
         if focal is not None:

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1288,6 +1288,7 @@ class Graph(SetOpsMixin):
         node_kws=None,
         focal_kws=None,
         m=None,
+        **kwargs,
     ):
         """Plot graph as an interactive Folium Map
 
@@ -1314,6 +1315,9 @@ class Graph(SetOpsMixin):
             passing a subset of nodes with the `focal` argument
         m : Folilum.Map, optional
             folium map objecto to plot on top of, by default None
+        **kwargs : dict, optional
+            additional keyword arguments are passed directly to geopandas.explore, when
+            ``m=None`` by default None
 
         Returns
         -------
@@ -1330,6 +1334,7 @@ class Graph(SetOpsMixin):
             node_kws=node_kws,
             focal_kws=focal_kws,
             m=m,
+            **kwargs,
         )
 
 

--- a/libpysal/graph/tests/test_plotting.py
+++ b/libpysal/graph/tests/test_plotting.py
@@ -368,3 +368,9 @@ class TestExplore:
         assert s.count("LineString") == 6
         # geoms
         assert s.count("Polygon") == 5
+
+    def test_explore_kwargs(self):
+        m = self.G_str.explore(self.nybb_str, tiles="OpenStreetMap HOT")
+        s = fetch_map_string(m)
+
+        assert "tile.openstreetmap.fr/hot" in s


### PR DESCRIPTION
Follow-up on #617

We were not able to change anything about the map as we forgot to pass kwargs though like we did in `esda`. But stuff like `tiles`  or `prefer_canvas` shall work out of the box.