### PR TITLE
remove `xarray` as hard dependency

### DIFF
--- a/ci/310-oldest.yaml
+++ b/ci/310-oldest.yaml
@@ -12,7 +12,6 @@ dependencies:
   - requests=2.27
   - scipy=1.8
   - shapely=2.0.1
-  - xarray=2022.3
   # testing
   - codecov
   - matplotlib>=3.6
@@ -29,6 +28,7 @@ dependencies:
   - scikit-learn=1.1
   - sqlalchemy=2.0
   - zstd
+  - xarray=2022.3
   - pip
   - pip:
       - platformdirs==2.0.2

--- a/ci/310.yaml
+++ b/ci/310.yaml
@@ -12,7 +12,6 @@ dependencies:
   - requests
   - scipy
   - shapely
-  - xarray
   # testing
   - codecov
   - matplotlib
@@ -28,4 +27,5 @@ dependencies:
   - pyarrow
   - scikit-learn
   - sqlalchemy
+  - xarray
   - zstd

--- a/ci/311.yaml
+++ b/ci/311.yaml
@@ -12,7 +12,6 @@ dependencies:
   - requests
   - scipy
   - shapely
-  - xarray
   # testing
   - codecov
   - matplotlib
@@ -28,4 +27,5 @@ dependencies:
   - pyarrow
   - scikit-learn
   - sqlalchemy
+  - xarray
   - zstd

--- a/ci/312-dev.yaml
+++ b/ci/312-dev.yaml
@@ -27,6 +27,7 @@ dependencies:
   - pyproj
   - sqlalchemy
   - zstd
+  - xarray
   - pip
   - pip:
       # dev versions of packages
@@ -34,6 +35,5 @@ dependencies:
       - pandas
       - scikit-learn
       - scipy
-      - xarray
       - git+https://github.com/geopandas/geopandas.git@main
       - git+https://github.com/shapely/shapely.git@main

--- a/ci/312-dev.yaml
+++ b/ci/312-dev.yaml
@@ -27,7 +27,6 @@ dependencies:
   - pyproj
   - sqlalchemy
   - zstd
-  - xarray
   - pip
   - pip:
       # dev versions of packages
@@ -35,5 +34,6 @@ dependencies:
       - pandas
       - scikit-learn
       - scipy
+      - xarray
       - git+https://github.com/geopandas/geopandas.git@main
       - git+https://github.com/shapely/shapely.git@main

--- a/ci/312-no-optional.yaml
+++ b/ci/312-no-optional.yaml
@@ -11,7 +11,6 @@ dependencies:
   - platformdirs
   - requests
   - scipy
-  - xarray
   # testing
   - codecov
   - matplotlib

--- a/ci/312.yaml
+++ b/ci/312.yaml
@@ -12,7 +12,6 @@ dependencies:
   - requests
   - scipy
   - shapely
-  - xarray
   # testing
   - codecov
   - matplotlib
@@ -29,6 +28,7 @@ dependencies:
   - scikit-learn
   - sqlalchemy
   - zstd
+  - xarray
   # for docs build action (this env only)
   - mkdocs-jupyter
   - myst-parser

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,6 @@ dependencies:
   - requests
   - scipy
   - shapely
-  - xarray
   # optional libpysal deps
   - geodatasets
   - joblib
@@ -25,4 +24,5 @@ dependencies:
   - pyarrow
   - scikit-learn
   - sqlalchemy
+  - xarray
   - zstd

--- a/libpysal/weights/tests/test_contiguity.py
+++ b/libpysal/weights/tests/test_contiguity.py
@@ -1,11 +1,11 @@
-from warnings import warn
+# ruff: noqa: N815
 
 import numpy as np
 import pytest
 
 from ... import examples as pysal_examples
 from ...io import geotable as pdio
-from ...io.fileio import FileIO as ps_open
+from ...io.fileio import FileIO
 from .. import contiguity as c
 from .. import util
 from ..weights import W
@@ -14,7 +14,7 @@ from ..weights import W
 class ContiguityMixin:
     polygon_path = pysal_examples.get_path("columbus.shp")
     point_path = pysal_examples.get_path("baltim.shp")
-    f = ps_open(polygon_path)  # our file handler
+    f = FileIO(polygon_path)  # our file handler
     polygons = f.read()  # our iterable
     f.seek(0)  # go back to head of file
     cls = object  # class constructor
@@ -29,9 +29,9 @@ class ContiguityMixin:
     known_w_da = dict()
     try:
         from .. import raster
+
         da = raster.testDataArray((1, 4, 4), missing_vals=False)
-    except ImportError as e:
-        warn('unable to import raster utils, likely from missing xarray')
+    except ImportError:
         da = None
 
     def setup_method(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "requests>=2.27",
     "scipy>=1.8",
     "shapely>=2.0.1",
-    "xarray>=2022.3",
 ]
 
 [project.urls]
@@ -49,6 +48,7 @@ plus = [
     "pyarrow>=7.0",
     "scikit-learn>=1.1",
     "sqlalchemy>=2.0",
+    "xarray>=2022.3",
     "zstd",
 ]
 dev = [


### PR DESCRIPTION
This PR removes `xarray` as hard dependency, which is causing [feedstock failures](https://github.com/conda-forge/libpysal-feedstock/pull/22)
* xref – https://github.com/pysal/libpysal/pull/585#issuecomment-1793482193
* xref – https://github.com/conda-forge/libpysal-feedstock/pull/22#issuecomment-1793339557