### PR TITLE
fast-path for initialisation of Graph for adjacency that is known to be sorted

### DIFF
--- a/libpysal/graph/_set_ops.py
+++ b/libpysal/graph/_set_ops.py
@@ -79,7 +79,6 @@ class SetOpsMixin:
                 self.unique_ids,
                 np.ones(intersection.shape[0], dtype=np.int8),
             ),
-            is_sorted=True,
         )
 
     def symmetric_difference(self, right):
@@ -104,7 +103,6 @@ class SetOpsMixin:
                 self.unique_ids,
                 np.ones(sym_diff.shape[0], dtype=np.int8),
             ),
-            is_sorted=True,
         )
 
     def union(self, right):
@@ -130,7 +128,6 @@ class SetOpsMixin:
                 self.unique_ids,
                 np.ones(union.shape[0], dtype=np.int8),
             ),
-            is_sorted=True,
         )
 
     def difference(self, right):
@@ -151,7 +148,6 @@ class SetOpsMixin:
                 self.unique_ids,
                 np.ones(diff.shape[0], dtype=np.int8),
             ),
-            is_sorted=True,
         )
 
     def issubgraph(self, right):

--- a/libpysal/graph/_set_ops.py
+++ b/libpysal/graph/_set_ops.py
@@ -78,7 +78,7 @@ class SetOpsMixin:
                 intersection.get_level_values("neighbor"),
                 self.unique_ids,
                 np.ones(intersection.shape[0], dtype=np.int8),
-            ),
+            )
         )
 
     def symmetric_difference(self, right):
@@ -102,7 +102,7 @@ class SetOpsMixin:
                 sym_diff.get_level_values("neighbor"),
                 self.unique_ids,
                 np.ones(sym_diff.shape[0], dtype=np.int8),
-            ),
+            )
         )
 
     def union(self, right):
@@ -127,7 +127,7 @@ class SetOpsMixin:
                 union.get_level_values("neighbor"),
                 self.unique_ids,
                 np.ones(union.shape[0], dtype=np.int8),
-            ),
+            )
         )
 
     def difference(self, right):
@@ -147,7 +147,7 @@ class SetOpsMixin:
                 diff.get_level_values("neighbor"),
                 self.unique_ids,
                 np.ones(diff.shape[0], dtype=np.int8),
-            ),
+            )
         )
 
     def issubgraph(self, right):

--- a/libpysal/graph/_set_ops.py
+++ b/libpysal/graph/_set_ops.py
@@ -78,7 +78,8 @@ class SetOpsMixin:
                 intersection.get_level_values("neighbor"),
                 self.unique_ids,
                 np.ones(intersection.shape[0], dtype=np.int8),
-            )
+            ),
+            is_sorted=True,
         )
 
     def symmetric_difference(self, right):
@@ -102,7 +103,8 @@ class SetOpsMixin:
                 sym_diff.get_level_values("neighbor"),
                 self.unique_ids,
                 np.ones(sym_diff.shape[0], dtype=np.int8),
-            )
+            ),
+            is_sorted=True,
         )
 
     def union(self, right):
@@ -127,7 +129,8 @@ class SetOpsMixin:
                 union.get_level_values("neighbor"),
                 self.unique_ids,
                 np.ones(union.shape[0], dtype=np.int8),
-            )
+            ),
+            is_sorted=True,
         )
 
     def difference(self, right):
@@ -147,7 +150,8 @@ class SetOpsMixin:
                 diff.get_level_values("neighbor"),
                 self.unique_ids,
                 np.ones(diff.shape[0], dtype=np.int8),
-            )
+            ),
+            is_sorted=True,
         )
 
     def issubgraph(self, right):

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -271,7 +271,7 @@ class Graph(SetOpsMixin):
             libpysal.graph.Graph based on sparse
         """
 
-        return cls.from_arrays(*_sparse_to_arrays(sparse, ids), is_sorted=True)
+        return cls.from_arrays(*_sparse_to_arrays(sparse, ids))
 
     @classmethod
     def from_arrays(cls, focal_ids, neighbor_ids, weight, **kwargs):
@@ -399,10 +399,10 @@ class Graph(SetOpsMixin):
             # use shapely-based constructors
             if rook:
                 return cls.from_arrays(
-                    *_rook(geometry, ids=ids, by_perimeter=by_perimeter), is_sorted=True
+                    *_rook(geometry, ids=ids, by_perimeter=by_perimeter)
                 )
             return cls.from_arrays(
-                *_queen(geometry, ids=ids, by_perimeter=by_perimeter), is_sorted=True
+                *_queen(geometry, ids=ids, by_perimeter=by_perimeter)
             )
 
         # use vertex-based constructor
@@ -486,7 +486,7 @@ class Graph(SetOpsMixin):
             coincident=coincident,
         )
 
-        return cls.from_arrays(head, tail, weight, is_sorted=True)
+        return cls.from_arrays(head, tail, weight)
 
     @classmethod
     def build_knn(cls, data, k, metric="euclidean", p=2, coincident="raise"):
@@ -534,7 +534,7 @@ class Graph(SetOpsMixin):
             coincident=coincident,
         )
 
-        return cls.from_arrays(head, tail, weight, is_sorted=True)
+        return cls.from_arrays(head, tail, weight)
 
     @classmethod
     def build_triangulation(
@@ -717,7 +717,6 @@ class Graph(SetOpsMixin):
             adjacency.index.values,
             adjacency.neighbor.values,
             adjacency.weight.values,
-            is_sorted=True,
         )
 
     @classmethod


### PR DESCRIPTION
Closes #632 

When we know that the adjacency series is sorted as it is supposed to, we can skip sorting in `__init__`. This is particularly noticeable with large graphs of tens of millions edges. 

There may be some cases that we know are sorted and could use this. I thought that everything that goes through `_resolve_islands` is sorted but if I pass `is_sorted=True` everywhere, I get some strange failures. So better be safe than sorry in this case. Sorting is sensitive here.