### PR TITLE
GHA: allow multi-core testing again

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -53,15 +53,28 @@ jobs:
 
       - name: Install libpysal
         run: |
-          pip install .; python -c 'import libpysal; libpysal.examples.fetch_all()'
+          pip install .
 
       - name: Spatial versions
         run: |
           python -c 'import geopandas; geopandas.show_versions();'
 
+      - name: Download test files
+        run: |
+          python -c '
+          import geodatasets
+          import libpysal
+
+          geodatasets.fetch("nybb")
+          geodatasets.fetch("geoda liquor_stores")
+          geodatasets.fetch("eea large_rivers")
+          geodatasets.fetch("geoda groceries")
+          geodatasets.fetch("geoda columbus")
+          libpysal.examples.fetch_all()
+          '
       - name: Test libpysal
         run: |
-          pytest -v --color yes --cov libpysal --cov-append --cov-report term-missing --cov-report xml .
+          pytest -v --color yes -n auto --cov libpysal --cov-append --cov-report term-missing --cov-report xml .
 
       - name: Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
Closes #606 

The issue comes from pooch. Multiple workers are trying to download the archive at the same time, corrupting the file in the process. Or second worker is trying to read partially downloaded archive that the first one is still writing. We do avoid this with libpysal.examples by fetching them ahead of the time. We can do the same with geodatasets.