### PR TITLE
lint & format `io/iohandlers{a-d}.py`

### DIFF
--- a/libpysal/io/iohandlers/arcgis_dbf.py
+++ b/libpysal/io/iohandlers/arcgis_dbf.py
@@ -1,6 +1,8 @@
-from .. import fileio
-from ...weights.weights import W
+# ruff: noqa: N802, N803, N806, N815
+
 from ...weights.util import remap_ids
+from ...weights.weights import W
+from .. import fileio
 
 __author__ = "Myunghwa Hwang <mhwang4@gmail.com>"
 __all__ = ["ArcGISDbfIO"]
@@ -29,7 +31,7 @@ class ArcGISDbfIO(fileio.FileIO):
     record numbers, instead of original ids.
 
     An exemplary structure of an ArcGIS dbf file is as follows:
-    
+
     ```
     [Line 1]    Field1    RECORD_ID    NID    WEIGHT
     [Line 2]    0         72           76     1
@@ -41,7 +43,7 @@ class ArcGISDbfIO(fileio.FileIO):
 
     References
     ----------
-    
+
     http://webhelp.esri.com/arcgisdesktop/9.3/index.cfm?TopicName=Convert_Spatial_Weights_Matrix_to_Table_(Spatial_Statistics)
 
     """
@@ -64,7 +66,7 @@ class ArcGISDbfIO(fileio.FileIO):
 
     varName = property(fget=_get_varName, fset=_set_varName)
 
-    def read(self, n=-1):
+    def read(self, n=-1):  # noqa ARG002
         self._complain_ifclosed(self.closed)
         return self._read()
 
@@ -74,12 +76,12 @@ class ArcGISDbfIO(fileio.FileIO):
 
     def _read(self):
         """Reads ArcGIS dbf file
-        
+
         Returns
         -------
         w : libpysal.weights.W
             A ``libpysal.weights.W`` object.
-        
+
         Raises
         ------
         StopIteration
@@ -88,7 +90,7 @@ class ArcGISDbfIO(fileio.FileIO):
             Raised when the weights data structure is incorrect.
         TypeError
             Raised when the IDs are not integers.
-        
+
         Examples
         --------
 
@@ -237,10 +239,10 @@ class ArcGISDbfIO(fileio.FileIO):
             id_spec = ("N", len(str(max(obj.id_order))), 0)
             self.file.field_spec = [id_spec, id_spec, ("N", 13, 6)]
 
-            for id in obj.id_order:
-                neighbors = list(zip(obj.neighbors[id], obj.weights[id]))
+            for id_ in obj.id_order:
+                neighbors = list(zip(obj.neighbors[id_], obj.weights[id_], strict=True))
                 for neighbor, weight in neighbors:
-                    self.file.write([id, neighbor, weight])
+                    self.file.write([id_, neighbor, weight])
                     self.pos = self.file.pos
 
         else:

--- a/libpysal/io/iohandlers/arcgis_txt.py
+++ b/libpysal/io/iohandlers/arcgis_txt.py
@@ -1,9 +1,10 @@
 import os.path
-from . import gwt
+from warnings import warn
+
 from ...weights import W
 from ...weights.util import remap_ids
 from .. import fileio
-from warnings import warn
+from . import gwt
 
 __author__ = "Myunghwa Hwang <mhwang4@gmail.com>"
 __all__ = ["ArcGISTextIO"]
@@ -15,7 +16,7 @@ class ArcGISTextIO(gwt.GwtIO):
     Statistics tools. This format is a simple text file with ASCII encoding and
     can be directly used with the tools under the category of "Mapping Clusters."
     But, it cannot be used with the "Generate Spatial Weights Matrix" tool.
-    
+
     The first line of the ArcGIS text file is a header including the name of
     a data column that holded the ID variable in the original source data table.
     After this header line, it includes three data columns for origin ID,
@@ -26,7 +27,7 @@ class ArcGISTextIO(gwt.GwtIO):
     numbers, instead of original IDs.
 
     An exemplary structure of an ArcGIS text file is as follows:
-    
+
     [Line 1]    StationID
     [Line 2]    1    1    0.0
     [Line 3]    1    2    0.1
@@ -36,7 +37,7 @@ class ArcGISTextIO(gwt.GwtIO):
     [Line 7]    3    1    0.16667
     [Line 8]    3    2    0.06667
     [Line 9]    3    3    0.0
-    
+
 
     As shown in the above example, this file format allows explicit specification
     of weights for self-neighbors. When no entry is available for self-neighbors,
@@ -49,7 +50,7 @@ class ArcGISTextIO(gwt.GwtIO):
 
     Notes
     -----
-    
+
     When there is a ``.dbf`` file whose name is identical to the name of the source
     text file, `ArcGISTextIO` checks the data type of the ID data column and uses it
     for reading and writing the text file. Otherwise, it considers IDs are strings.
@@ -65,20 +66,20 @@ class ArcGISTextIO(gwt.GwtIO):
 
     def _read(self):
         """Read in an ArcGIS text file.
-        
+
         Returns
         -------
         w : libpysal.weights.W
             A PySAL `W` object.
-        
+
         Raises
         ------
         StopIteration
             Raised at the EOF.
-        
+
         TypeError
             Raised when the IDs are not integers.
-        
+
         Examples
         --------
 
@@ -126,15 +127,15 @@ class ArcGISTextIO(gwt.GwtIO):
                     msg = "ID_VAR:'%s' was in in the DBF header, "
                     msg += "proceeding with unordered string IDs."
                     msg = msg % id_var
-                    warn(msg, RuntimeWarning)
+                    warn(msg, RuntimeWarning, stacklevel=2)
             else:
                 msg = "DBF relating to ArcGIS TEXT was not found, "
                 msg += "proceeding with unordered string IDs."
-                warn(msg, RuntimeWarning)
-        except:
+                warn(msg, RuntimeWarning, stacklevel=2)
+        except:  # noqa E722
             msg = "Exception occurred will reading DBF, "
             msg += "proceeding with unordered string IDs."
-            warn(msg, RuntimeWarning)
+            warn(msg, RuntimeWarning, stacklevel=2)
 
         if (id_type is not int) or (id_order and type(id_order)[0] is not int):
             raise TypeError("The data type for IDs should be integer.")
@@ -158,7 +159,7 @@ class ArcGISTextIO(gwt.GwtIO):
 
         return w
 
-    def write(self, obj, useIdIndex=False):
+    def write(self, obj, useIdIndex=False):  # noqa N803
         """
 
         Parameters
@@ -174,7 +175,7 @@ class ArcGISTextIO(gwt.GwtIO):
             Raised when the IDs in input ``obj`` are not integers.
         TypeError
             Raised when the input ``obj`` is not a PySAL `W`.
-        
+
         Examples
         --------
 
@@ -217,7 +218,7 @@ class ArcGISTextIO(gwt.GwtIO):
         Clean up the temporary file created for this example.
 
         >>> os.remove(fname)
-        
+
         """
 
         self._complain_ifclosed(self.closed)

--- a/libpysal/io/iohandlers/csvWrapper.py
+++ b/libpysal/io/iohandlers/csvWrapper.py
@@ -1,7 +1,9 @@
-from .. import tables
+# ruff: noqa: N801, N802, N806, N999, SIM115
+
+
 import csv
 
-from typing import Union
+from .. import tables
 
 __author__ = "Charles R Schmidt <schmidtc@gmail.com>"
 __all__ = ["csvWrapper"]
@@ -12,7 +14,7 @@ class csvWrapper(tables.DataTable):
 
     Examples
     --------
-    
+
     >>> import libpysal
     >>> stl = libpysal.examples.load_example('stl')
     >>> file_name = stl.get_path('stl_hom.csv')
@@ -41,7 +43,7 @@ class csvWrapper(tables.DataTable):
      'RDAC80',
      'RDAC85',
      'RDAC90']
-    
+
     >>> f._spec
     [str,
      str,
@@ -65,16 +67,15 @@ class csvWrapper(tables.DataTable):
      float,
      float,
      float]
-    
+
     """
 
-    __doc__ = tables.DataTable.__doc__
+    __doc__ = tables.DataTable.__doc__  # noqa A003
     FORMATS = ["csv"]
     READ_MODES = ["r", "Ur", "rU", "U"]
     MODES = READ_MODES[:]
 
     def __init__(self, *args, **kwargs):
-
         tables.DataTable.__init__(self, *args, **kwargs)
         self.__idx = {}
         self.__len = None
@@ -84,7 +85,6 @@ class csvWrapper(tables.DataTable):
         return self.__len
 
     def _open(self):
-
         self.fileObj = open(self.dataPath, self.mode)
         if self.mode in self.READ_MODES:
             self.dataObj = csv.reader(self.fileObj)
@@ -99,7 +99,6 @@ class csvWrapper(tables.DataTable):
             self.__len = len(data)
 
     def _determineHeader(self, data: list) -> bool:
-
         HEADER = True
 
         headSpec = self._determineSpec([data[0]])
@@ -112,7 +111,6 @@ class csvWrapper(tables.DataTable):
 
     @staticmethod
     def _determineSpec(data: list) -> list:
-
         cols = len(data[0])
         spec = []
 
@@ -139,8 +137,7 @@ class csvWrapper(tables.DataTable):
 
         return spec
 
-    def _read(self) -> Union[list, None]:
-
+    def _read(self) -> list | None:
         if self.pos < len(self):
             row = self.data[self.pos]
             self.pos += 1

--- a/libpysal/io/iohandlers/dat.py
+++ b/libpysal/io/iohandlers/dat.py
@@ -1,5 +1,5 @@
-from . import gwt
 from ...weights import W
+from . import gwt
 
 __author__ = "Myunghwa Hwang <mhwang4@gmail.com>"
 __all__ = ["DatIO"]
@@ -11,7 +11,7 @@ class DatIO(gwt.GwtIO):
     This ``.dat`` format is a simple text file with a ``.DAT`` or ``.dat``
     extension. Without a header line, it includes three data columns
     for origin ID, destination ID, and weight values as follows:
-    
+
     ```
     [Line 1]    2    1    0.25
     [Line 2]    5    1    0.50
@@ -28,17 +28,17 @@ class DatIO(gwt.GwtIO):
 
     def _read(self):
         """Reads in a ``.dat`` file as a PySAL `W` object.
-        
+
         Returns
         -------
         w : libpysal.weights.W
             A PySAL `W` object.
-        
+
         Raises
         ------
         StopIteration
             Raised at the EOF.
-        
+
         Examples
         --------
 
@@ -125,7 +125,7 @@ class DatIO(gwt.GwtIO):
         Clean up the temporary file created for this example.
 
         >>> os.remove(fname)
-        
+
         """
 
         self._complain_ifclosed(self.closed)
@@ -133,5 +133,4 @@ class DatIO(gwt.GwtIO):
         if issubclass(type(obj), W):
             self._writelines(obj)
         else:
-
             raise TypeError("Expected a PySAL weights object, got: %s." % (type(obj)))

--- a/libpysal/io/iohandlers/db.py
+++ b/libpysal/io/iohandlers/db.py
@@ -1,11 +1,12 @@
-from .. import fileio
 from shapely import wkb
+
+from .. import fileio
 
 errmsg = ""
 
 try:
-    from sqlalchemy.ext.automap import automap_base
     from sqlalchemy import create_engine
+    from sqlalchemy.ext.automap import automap_base
     from sqlalchemy.orm import Session
 
     nosql_mode = False


### PR DESCRIPTION
xref https://github.com/pysal/libpysal/issues/589

This PR
* breaks out #630 (part 1 of $n$)
* formats and lints `io/iohandlers{a-d}.py`