### PR TITLE
lint & format `io/iohandlers{g-m}`.py

### DIFF
--- a/libpysal/io/iohandlers/gal.py
+++ b/libpysal/io/iohandlers/gal.py
@@ -1,7 +1,10 @@
-from .. import fileio
-from ...weights.weights import W, WSP
-from scipy import sparse
+# ruff: noqa: SIM115
+
 import numpy as np
+from scipy import sparse
+
+from ...weights.weights import WSP, W
+from .. import fileio
 
 __author__ = "Charles R Schmidt <schmidtc@gmail.com>"
 __all__ = ["GalIO"]
@@ -18,9 +21,9 @@ class GalIO(fileio.FileIO):
         fileio.FileIO.__init__(self, *args, **kwargs)
         self.file = open(self.dataPath, self.mode)
 
-    def read(self, n=-1, sparse=False):
+    def read(self, n=-1, sparse=False):  # noqa ARG002
         """Read in a ``.gal`` file.
-        
+
         Parameters
         ----------
         n : int
@@ -28,7 +31,7 @@ class GalIO(fileio.FileIO):
         sparse: bool
             If ``True`` return a ``scipy`` sparse object. If ``False``
             return PySAL `W` object. Default is ``False``.
-        
+
         Returns
         -------
         w : {libpysal.weights.W, libpysal.weights.WSP}
@@ -52,12 +55,12 @@ class GalIO(fileio.FileIO):
 
     def _set_data_type(self, typ):
         """
-        
+
         Raises
         ------
         TypeError
             Raised when ``typ`` is not a callable.
-        
+
         """
         if callable(typ):
             self._typ = typ
@@ -73,12 +76,12 @@ class GalIO(fileio.FileIO):
         -------
         w : {libpysal.weights.W, libpysal.weights.WSP}
             A PySAL `W` object or a thin PySAL `WSP`.
-        
+
         Raises
         ------
         StopIteration
             Raised at the EOF.
-        
+
         Examples
         --------
 
@@ -93,10 +96,10 @@ class GalIO(fileio.FileIO):
         >>> w = testfile.read()
         >>> w.n == 100
         True
-        
+
         >>> print(round(w.sd,6))
         1.515124
-        
+
         >>> testfile = libpysal.io.open(libpysal.examples.get_path('sids2.gal'), 'r')
 
         Return a sparse matrix for the `W` information.
@@ -108,7 +111,6 @@ class GalIO(fileio.FileIO):
         """
 
         if self._sparse:
-
             if self.pos > 0:
                 raise StopIteration
 
@@ -128,18 +130,18 @@ class GalIO(fileio.FileIO):
             counter = 0
             typ = self.data_type
 
-            for i in range(n):
-                id, n_neighbors = self.file.readline().strip().split()
-                id = typ(id)
+            for _ in range(n):
+                id_, n_neighbors = self.file.readline().strip().split()
+                id_ = typ(id)
                 n_neighbors = int(n_neighbors)
                 neighbors_i = list(map(typ, self.file.readline().strip().split()))
                 nn = len(neighbors_i)
-                extend([id] * nn)
+                extend([id_] * nn)
                 counter += nn
 
                 for id_neigh in neighbors_i:
                     append(id_neigh)
-                idsappend(id)
+                idsappend(id_)
 
             self.pos += 1
             row = np.array(row)
@@ -153,7 +155,6 @@ class GalIO(fileio.FileIO):
             w = WSP(spmat)
 
         else:
-
             if self.pos > 0:
                 raise StopIteration
 
@@ -171,13 +172,13 @@ class GalIO(fileio.FileIO):
             w = {}
             typ = self.data_type
 
-            for i in range(n):
-                id, n_neighbors = self.file.readline().strip().split()
-                id = typ(id)
+            for _ in range(n):
+                id_, n_neighbors = self.file.readline().strip().split()
+                id_ = typ(id_)
                 n_neighbors = int(n_neighbors)
                 neighbors_i = list(map(typ, self.file.readline().strip().split()))
-                neighbors[id] = neighbors_i
-                ids.append(id)
+                neighbors[id_] = neighbors_i
+                ids.append(id_)
 
             self.pos += 1
 
@@ -197,7 +198,7 @@ class GalIO(fileio.FileIO):
         ------
         TypeError
             Raised when the input ``obj`` is not a PySAL `W`.
-        
+
         Examples
         --------
 
@@ -238,18 +239,18 @@ class GalIO(fileio.FileIO):
         Clean up the temporary file created for this example.
 
         >>> os.remove(fname)
-        
+
         """
 
         self._complain_ifclosed(self.closed)
 
         if issubclass(type(obj), W):
-            IDS = obj.id_order
+            ids = obj.id_order
             self.file.write("%d\n" % (obj.n))
 
-            for id in IDS:
-                neighbors = obj.neighbors[id]
-                self.file.write("%s %d\n" % (str(id), len(neighbors)))
+            for id_ in ids:
+                neighbors = obj.neighbors[id_]
+                self.file.write("%s %d\n" % (str(id_), len(neighbors)))
                 self.file.write(" ".join(map(str, neighbors)) + "\n")
             self.pos += 1
         else:

--- a/libpysal/io/iohandlers/geobugs_txt.py
+++ b/libpysal/io/iohandlers/geobugs_txt.py
@@ -1,5 +1,7 @@
-from .. import fileio
+# ruff: noqa: SIM115
+
 from ...weights import W
+from .. import fileio
 
 __author__ = "Myunghwa Hwang <mhwang4@gmail.com>"
 __all__ = ["GeoBUGSTextIO"]
@@ -11,11 +13,11 @@ class GeoBUGSTextIO(fileio.FileIO):
     `GeoBUGS` generates a spatial weights matrix as an R object and writes
     it out as an ASCII text representation of the R object. An exemplary
     `GeoBUGS` text file is as follows.
-    
+
     ```
     list([CARD], [ADJ], [WGT], [SUMNUMNEIGH])
     ```
-    
+
     where ``[CARD]`` and ``[ADJ]`` are required but the others are optional.
     PySAL assumes ``[CARD]`` and ``[ADJ]`` always exist in an input text file.
     It can read a `GeoBUGS` text file, even when its content is not written
@@ -31,7 +33,7 @@ class GeoBUGSTextIO(fileio.FileIO):
 
     [ADJ]:
         adj = c ([a list of comma-splitted neighbor IDs])
-        
+
         If caridnality is zero, neighbor IDs are skipped. The ordering of
         observations is the same in both ``[CARD]`` and ``[ADJ]``.
         Neighbor IDs are record numbers starting from one.
@@ -48,7 +50,7 @@ class GeoBUGSTextIO(fileio.FileIO):
 
     Notes
     -----
-    
+
     For the files generated from R the ``spdep``, ``nb2WB``, and ``dput``
     functions. It is assumed that the value for the control parameter of
     the ``dput`` function is ``NULL``. Please refer to R ``spdep`` and
@@ -56,7 +58,7 @@ class GeoBUGSTextIO(fileio.FileIO):
 
     References
     ----------
-    
+
     * **Thomas, A., Best, N., Lunn, D., Arnold, R., and Spiegelhalter, D.**
         (2004) GeoBUGS User Manual. R spdep nb2WB function help file.
 
@@ -70,7 +72,7 @@ class GeoBUGSTextIO(fileio.FileIO):
         fileio.FileIO.__init__(self, *args, **kwargs)
         self.file = open(self.dataPath, self.mode)
 
-    def read(self, n=-1):
+    def read(self, n=-1):  # noqa ARG002
         """Read a GeoBUGS text file.
 
         Returns
@@ -119,17 +121,17 @@ class GeoBUGSTextIO(fileio.FileIO):
 
     def _read(self):
         """Reads in a `GeoBUGSTextIO` object.
-        
+
         Raises
         ------
         StopIteration
             Raised at the EOF.
-        
+
         Returns
         -------
         w : libpysal.weights.W
             A PySAL `W` object.
-        
+
         """
 
         if self.pos > 0:
@@ -214,7 +216,7 @@ class GeoBUGSTextIO(fileio.FileIO):
         ------
         TypeError
             Raised when the input ``obj`` is not a PySAL `W`.
-        
+
         Examples
         --------
 
@@ -240,7 +242,7 @@ class GeoBUGSTextIO(fileio.FileIO):
 
         >>> o = libpysal.io.open(fname, 'w', 'geobugs_text')
 
-        Write the Weights object into the open file. 
+        Write the Weights object into the open file.
 
         >>> o.write(w)
         >>> o.close()
@@ -263,7 +265,6 @@ class GeoBUGSTextIO(fileio.FileIO):
         self._complain_ifclosed(self.closed)
 
         if issubclass(type(obj), W):
-
             cardinalities, neighbors, weights = [], [], []
             for i in obj.id_order:
                 cardinalities.append(obj.cardinalities[i])

--- a/libpysal/io/iohandlers/geoda_txt.py
+++ b/libpysal/io/iohandlers/geoda_txt.py
@@ -1,31 +1,31 @@
+# ruff: noqa: A003, N802, N806, SIM115
+
 from .. import tables
 
 __author__ = "Charles R Schmidt <schmidtc@gmail.com>"
 __all__ = ["GeoDaTxtReader"]
 
-from typing import Union
-
 
 class GeoDaTxtReader(tables.DataTable):
     """GeoDa Text File Export Format.
-    
+
     Examples
     --------
-    
+
     >>> import libpysal
     >>> f = libpysal.io.open(libpysal.examples.get_path('stl_hom.txt'),'r')
     >>> f.header
     ['FIPSNO', 'HR8488', 'HR8893', 'HC8488']
-    
+
     >>> len(f)
     78
-    
+
     >>> f.dat[0]
     ['17107', '1.290722', '1.624458', '2']
-    
+
     >>> f.dat[-1]
     ['29223', '0', '8.451537', '0']
-    
+
     >>> f._spec
     [int, float, float, int]
 
@@ -37,7 +37,6 @@ class GeoDaTxtReader(tables.DataTable):
     MODES = ["r"]
 
     def __init__(self, *args, **kwargs):
-
         tables.DataTable.__init__(self, *args, **kwargs)
         self.__idx = {}
         self.__len = None
@@ -46,17 +45,16 @@ class GeoDaTxtReader(tables.DataTable):
 
     def _open(self):
         """
-        
+
         Raises
         ------
         TypeError
             Raised when the input 'geoda_txt' is not valid.
-        
+
         """
 
         if self.mode == "r":
-
-            self.fileObj = open(self.dataPath, "r")
+            self.fileObj = open(self.dataPath)
             n, k = self.fileObj.readline().strip().split(",")
             n, k = int(n), int(k)
             header = self.fileObj.readline().strip().split(",")
@@ -65,7 +63,7 @@ class GeoDaTxtReader(tables.DataTable):
             try:
                 assert len(self.header) == k
             except AssertionError:
-                raise TypeError("This is not a valid 'geoda_txt' file.")
+                raise TypeError("This is not a valid 'geoda_txt' file.") from None
 
             dat = self.fileObj.readlines()
 
@@ -76,7 +74,7 @@ class GeoDaTxtReader(tables.DataTable):
     def __len__(self) -> int:
         return self.__len
 
-    def _read(self) -> Union[list, None]:
+    def _read(self) -> list | None:
         if self.pos < len(self):
             row = self.dat[self.pos]
             self.pos += 1

--- a/libpysal/io/iohandlers/geoda_txt.py
+++ b/libpysal/io/iohandlers/geoda_txt.py
@@ -1,4 +1,4 @@
-# ruff: noqa: A003, N802, N806, SIM115
+# ruff: noqa: N802, N806, SIM115
 
 from .. import tables
 
@@ -30,8 +30,6 @@ class GeoDaTxtReader(tables.DataTable):
     [int, float, float, int]
 
     """
-
-    __doc__ = tables.DataTable.__doc__
 
     FORMATS = ["geoda_txt"]
     MODES = ["r"]
@@ -112,3 +110,6 @@ class GeoDaTxtReader(tables.DataTable):
                 spec.append(str)
 
         return spec
+
+
+GeoDaTxtReader.__doc__ = tables.DataTable.__doc__

--- a/libpysal/io/iohandlers/mat.py
+++ b/libpysal/io/iohandlers/mat.py
@@ -1,7 +1,10 @@
+# ruff: noqa: N802, N815, SIM115
+
 import scipy.io as sio
-from .. import fileio
+
 from ...weights import W
 from ...weights.util import full, full2W
+from .. import fileio
 
 __author__ = "Myunghwa Hwang <mhwang4@gmail.com>"
 __all__ = ["MatIO"]
@@ -19,13 +22,13 @@ class MatIO(fileio.FileIO):
 
     Notes
     -----
-    
+
     If a given weights object contains too many observations to write it out as
     a full matrix, PySAL writes out the object as a sparse matrix.
 
     References
     ----------
-    
+
     `MathWorks <http://www.mathworks.com/help/pdf_doc/matlab/matfile_format.pdf>`_
     (2011) "MATLAB 7 MAT-File Format."
 
@@ -48,19 +51,19 @@ class MatIO(fileio.FileIO):
 
     varName = property(fget=_get_varName, fset=_set_varName)
 
-    def read(self, n=-1):
+    def read(self, n=-1):  # noqa ARG002
         """
-        
+
         Parameters
         ----------
         n : int
             Read at most ``n`` objects. Default is ``-1``.
-        
+
         Returns
         -------
         w : libpysal.weights.W
             A PySAL `W` object.
-        
+
         """
 
         self._complain_ifclosed(self.closed)
@@ -76,17 +79,17 @@ class MatIO(fileio.FileIO):
 
     def _read(self):
         """Reads MATLAB ``.mat`` file.
-        
+
         Returns
         -------
         w : libpysal.weights.W
             A PySAL `W` object.
-        
+
         Raises
         ------
         StopIteration
             Raised at the EOF.
-        
+
         Examples
         --------
 
@@ -135,7 +138,7 @@ class MatIO(fileio.FileIO):
         ----------
         obj : libpysal.weights.W
             A PySAL `W` object.
-        
+
         Raises
         ------
         TypeError

--- a/libpysal/io/iohandlers/mtx.py
+++ b/libpysal/io/iohandlers/mtx.py
@@ -1,6 +1,9 @@
+# ruff: noqa: SIM115
+
 import scipy.io as sio
+
+from ...weights.weights import WSP, W
 from .. import fileio
-from ...weights.weights import W, WSP
 
 __author__ = "Myunghwa Hwang <mhwang4@gmail.com>"
 __all__ = ["MtxIO"]
@@ -19,7 +22,7 @@ class MtxIO(fileio.FileIO):
 
     With the above assumptions, the structure of a MTX file containing a spatial
     weights matrix can be defined as follows:
-    
+
     ```
     %%MatrixMarket matrix coordinate real general <--- header 1 (constant)
     % Comments starts                             <---
@@ -30,7 +33,7 @@ class MtxIO(fileio.FileIO):
     ...                                              | L entry lines
     IL   JL   A(IL,JL)                            <---
     ```
-    
+
     In the MTX format, the index for rows or columns starts with 1.
 
     PySAL uses ``mtx`` tools in
@@ -40,7 +43,7 @@ class MtxIO(fileio.FileIO):
 
     References
     ----------
-    
+
     `MTX format specification <http://math.nist.gov/MatrixMarket/formats.html>`_
 
     `Matrix Market files
@@ -56,9 +59,9 @@ class MtxIO(fileio.FileIO):
         fileio.FileIO.__init__(self, *args, **kwargs)
         self.file = open(self.dataPath, self.mode + "b")
 
-    def read(self, n=-1, sparse=False):
+    def read(self, n=-1, sparse=False):  # noqa ARG002
         """
-        
+
         Parameters
         ----------
         n : int
@@ -66,12 +69,12 @@ class MtxIO(fileio.FileIO):
         sparse : bool
             Flag for returning a sparse weights matrix (``True``).
             Default is ``False``.
-        
+
         Returns
         -------
         w : libpysal.weights.W
             A PySAL `W` object.
-        
+
         """
 
         self._sparse = sparse
@@ -85,17 +88,17 @@ class MtxIO(fileio.FileIO):
 
     def _read(self):
         """Reads MatrixMarket ``.mtx`` file.
-        
+
         Returns
         -------
         w : {libpysal.weights.W, libpysal.weights.WSP}
             A PySAL `W` object.
-        
+
         Raises
         ------
         StopIteration
             Raised at the EOF.
-        
+
         Examples
         --------
 
@@ -143,7 +146,7 @@ class MtxIO(fileio.FileIO):
           0.     0.     0.     0.     0.     0.     0.     0.     0.     0.
           0.     0.     0.     0.     0.     0.     0.     0.     0.     0.
           0.     0.     0.     0.     0.     0.     0.     0.     0.    ]]
-        
+
         """
 
         if self.pos > 0:
@@ -154,10 +157,7 @@ class MtxIO(fileio.FileIO):
         ids = list(range(1, mtx.shape[0] + 1))
         wsp = WSP(mtx, ids)
 
-        if self._sparse:
-            w = wsp
-        else:
-            w = wsp.to_W()
+        w = wsp if self._sparse else wsp.to_W()
         self.pos += 1
 
         return w
@@ -169,7 +169,7 @@ class MtxIO(fileio.FileIO):
         ----------
         obj : libpysal.weights.W
             A PySAL `W` object.
-        
+
         Raises
         ------
         TypeError


### PR DESCRIPTION
xref https://github.com/pysal/libpysal/issues/589

This PR:

* breaks out https://github.com/pysal/libpysal/pull/630 (part 2 of $n$)
* formats and lints `io/iohandlers{g-m}.py`