### PR TITLE
GHA: include reverse dependency testing

### DIFF
--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -34,11 +34,12 @@ jobs:
               hdbscan
               pandana
               astropy
+              geodatasets
             install_pip: >-
               opencv-contrib-python
               KDEpy
             installation_command: >-
-              pip install .; python -c 'import libpysal; libpysal.examples.fetch_all()'
+              pip install .; python -c 'import libpysal; libpysal.examples.builtin_datasets.keys()'
             fail_on_failure: false
             verbose: true
             parallel: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -27,6 +27,9 @@ jobs:
               h3-py
               hdbscan
               pandana
+            install_pip: >-
+              opencv-contrib-python
+              KDEpy
             installation_command: >-
               pip install .; python -c 'import libpysal; libpysal.examples.fetch_all()'
             fail_on_failure: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -27,6 +27,7 @@ jobs:
               h3-py
               hdbscan
               pandana
+              astropy
             install_pip: >-
               opencv-contrib-python
               KDEpy
@@ -34,3 +35,4 @@ jobs:
               pip install .; python -c 'import libpysal; libpysal.examples.fetch_all()'
             fail_on_failure: false
             verbose: false
+            parallel: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -41,5 +41,5 @@ jobs:
             installation_command: >-
               pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()'
             fail_on_failure: false
-            verbose: true
-            parallel: false
+            verbose: false
+            parallel: true

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -20,7 +20,9 @@ jobs:
               cenpy
               autoesda
               region
-            include: mapclassify
+            include: >-
+              mapclassify
+              libpysal
             whitelist: >-
               esda
               spreg

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -37,7 +37,7 @@ jobs:
               opencv-contrib-python
               KDEpy
             installation_command: >-
-              pip install .; python -c 'import libpysal; print(libpysal.examples.builtin_datasets.keys()); print(examples.get_path("columbus.shp"))'
+              pip install .; python -c 'import libpysal; print(libpysal.examples.builtin_datasets.keys()); print(libpysal.examples.get_path("columbus.shp"))'
             fail_on_failure: false
             verbose: true
             parallel: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -22,5 +22,7 @@ jobs:
             include: mapclassify
             install: >-
                 setuptools-scm
+            installation_command: >-
+              pip install .; python -c 'import libpysal; libpysal.examples.fetch_all()'
             fail_on_failure: false
             verbose: true

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -21,6 +21,10 @@ jobs:
               autoesda
               region
             include: mapclassify
+            whitelist: >-
+              esda
+              spreg
+              spaghetti
             install: >-
               setuptools-scm
               py-opencv

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -19,10 +19,15 @@ jobs:
               tigernet
               cenpy
               autoesda
+              region
             include: mapclassify
             install: >-
-                setuptools-scm
+              setuptools-scm
+              py-opencv
+              h3-py
+              hdbscan
+              pandana
             installation_command: >-
               pip install .; python -c 'import libpysal; libpysal.examples.fetch_all()'
             fail_on_failure: false
-            verbose: true
+            verbose: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -20,6 +20,8 @@ jobs:
               cenpy
               autoesda
               region
+              greedy
+              pysal
             include: >-
               mapclassify
             install: >-
@@ -36,5 +38,5 @@ jobs:
             installation_command: >-
               pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()'
             fail_on_failure: false
-            verbose: false
+            verbose: true
             parallel: true

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -1,7 +1,16 @@
 name: Test reverse dependencies
 on:
-  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * 1,4"
   workflow_dispatch:
+    inputs:
+      version:
+        description: Manual reverse dependency testing
+        default: test
+        required: false
+
 jobs:
   reverse_dependencies:
     name: Reverse dependency testing
@@ -11,7 +20,7 @@ jobs:
         with:
             fetch-depth: 0
 
-      - uses: scientific-python/reverse-dependency-testing@main
+      - uses: scientific-python/reverse-dependency-testing-action@main
         with:
             package_name: libpysal
             ignore: >-
@@ -40,6 +49,6 @@ jobs:
               KDEpy
             installation_command: >-
               pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()'
-            fail_on_failure: false
-            verbose: false
+            fail_on_failure: true
+            verbose: true
             parallel: true

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -22,9 +22,6 @@ jobs:
               region
             include: >-
               mapclassify
-              libpysal
-            whitelist: >-
-              esda
             install: >-
               setuptools-scm
               py-opencv
@@ -37,7 +34,7 @@ jobs:
               opencv-contrib-python
               KDEpy
             installation_command: >-
-              pip install -e .; python -c 'import libpysal; print(libpysal.examples.builtin_datasets.keys()); print(libpysal.examples.get_path("columbus.shp"))'
+              pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()'
             fail_on_failure: false
-            verbose: true
-            parallel: false
+            verbose: false
+            parallel: true

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -22,6 +22,7 @@ jobs:
               region
               greedy
               pysal
+              mesa-geo
             include: >-
               mapclassify
             install: >-
@@ -32,6 +33,8 @@ jobs:
               pandana
               astropy
               geodatasets
+              bokeh
+              pulp
             install_pip: >-
               opencv-contrib-python
               KDEpy

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -39,7 +39,7 @@ jobs:
               opencv-contrib-python
               KDEpy
             installation_command: >-
-              pip install .; python -c 'import libpysal; libpysal.examples.builtin_datasets.keys()'
+              pip install .; python -c 'import libpysal; print(libpysal.examples.builtin_datasets)'
             fail_on_failure: false
             verbose: true
             parallel: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -38,5 +38,5 @@ jobs:
             installation_command: >-
               pip install .; python -c 'import libpysal; libpysal.examples.fetch_all()'
             fail_on_failure: false
-            verbose: false
+            verbose: true
             parallel: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -11,7 +11,7 @@ jobs:
         with:
             fetch-depth: 0
 
-      - uses: scientific-python/reverse-dependency-testing@main
+      - uses: martinfleis/reverse-dependency-testing@verbose
         with:
             package_name: libpysal
             ignore: >-
@@ -23,3 +23,4 @@ jobs:
             install: >-
                 setuptools-scm
             fail_on_failure: false
+            verbose: true

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -11,7 +11,7 @@ jobs:
         with:
             fetch-depth: 0
 
-      - uses: martinfleis/reverse-dependency-testing@verbose
+      - uses: scientific-python/reverse-dependency-testing@main
         with:
             package_name: libpysal
             ignore: >-

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -37,7 +37,7 @@ jobs:
               opencv-contrib-python
               KDEpy
             installation_command: >-
-              pip install .; python -c 'import libpysal; print(libpysal.examples.builtin_datasets.keys()); print(libpysal.examples.get_path("columbus.shp"))'
+              pip install -e .; python -c 'import libpysal; print(libpysal.examples.builtin_datasets.keys()); print(libpysal.examples.get_path("columbus.shp"))'
             fail_on_failure: false
             verbose: true
             parallel: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -42,4 +42,4 @@ jobs:
               pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()'
             fail_on_failure: false
             verbose: true
-            parallel: true
+            parallel: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -25,8 +25,6 @@ jobs:
               libpysal
             whitelist: >-
               esda
-              spreg
-              spaghetti
             install: >-
               setuptools-scm
               py-opencv
@@ -39,7 +37,7 @@ jobs:
               opencv-contrib-python
               KDEpy
             installation_command: >-
-              pip install .; python -c 'import libpysal; print(libpysal.examples.builtin_datasets)'
+              pip install .; python -c 'import libpysal; print(libpysal.examples.builtin_datasets.keys(); print(examples.get_path("columbus.shp")))'
             fail_on_failure: false
             verbose: true
             parallel: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -1,0 +1,25 @@
+name: Test reverse dependencies
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  reverse_dependencies:
+    name: Reverse dependency testing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+
+      - uses: scientific-python/reverse-dependency-testing@main
+        with:
+            package_name: libpysal
+            ignore: >-
+              fine
+              tigernet
+              cenpy
+              autoesda
+            include: mapclassify
+            install: >-
+                setuptools-scm
+            fail_on_failure: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -37,7 +37,7 @@ jobs:
               opencv-contrib-python
               KDEpy
             installation_command: >-
-              pip install .; python -c 'import libpysal; print(libpysal.examples.builtin_datasets.keys(); print(examples.get_path("columbus.shp")))'
+              pip install .; python -c 'import libpysal; print(libpysal.examples.builtin_datasets.keys()); print(examples.get_path("columbus.shp"))'
             fail_on_failure: false
             verbose: true
             parallel: false


### PR DESCRIPTION
This is very much WIP because to make this work we need to ensure that the state of CI in downstream PySAL packages is as it should be. 

Once this works, it ensures that libpysal release does not break anything in the rest of the federation (xref #631). I'll see if there's some more work needed on the side of the action (I created the beta version during the Scientific Python summit, so have admin rights over it). But it will likely require changes in downstream (e.g. you can see that `tobler` does not properly skip H3 tests etc.).

The trigger is temporary to make sure we can properly test it here. We can then discuss when this should run but it should run before any release for sure and in the optimal situation should be required to pass for a release.