### PR TITLE
ENH: add subgraph method to Graph to get subsets

### DIFF
--- a/libpysal/graph/_utils.py
+++ b/libpysal/graph/_utils.py
@@ -246,7 +246,7 @@ def _resolve_islands(heads, tails, ids, weights):
     Induce self-loops for a collection of ids and links describing a
     contiguity graph. Induced self-loops will have zero weight.
     """
-    islands = np.setdiff1d(ids, heads)
+    islands = pd.Index(ids).difference(pd.Index(heads))
     if islands.shape != (0,):
         heads = np.hstack((heads, islands))
         tails = np.hstack((tails, islands))

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -957,4 +957,4 @@ class TestBase:
                 names=["focal", "neighbor"],
             ),
         )
-        pd.testing.assert_series_equal(expected, sub._adjacency)
+        pd.testing.assert_series_equal(expected, sub._adjacency, check_dtype=False)

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -941,3 +941,20 @@ class TestBase:
         pd.testing.assert_series_equal(
             expected, nybb.component_labels, check_dtype=False
         )
+
+    def test_subgraph(self):
+        knn = graph.Graph.build_knn(self.nybb.set_geometry(self.nybb.centroid), k=2)
+        sub = knn.subgraph(["Staten Island", "Bronx", "Brooklyn"])
+        assert sub < knn
+        expected = pd.Series(
+            [1, 0, 0],
+            name="weight",
+            index=pd.MultiIndex.from_arrays(
+                [
+                    ["Staten Island", "Bronx", "Brooklyn"],
+                    ["Brooklyn", "Bronx", "Brooklyn"],
+                ],
+                names=["focal", "neighbor"],
+            ),
+        )
+        pd.testing.assert_series_equal(expected, sub._adjacency)


### PR DESCRIPTION
I have found myself in a need to create subsets of a large graph covering only specific portions of my geometries. Hence I have developed a method to create a subgraph since making a subset of adjacency and passing that to a constructor discards isolates.