### PR TITLE
lint & format `io/iohandlers/tests/*.py`

### DIFF
--- a/libpysal/io/iohandlers/tests/test_arcgis_dbf.py
+++ b/libpysal/io/iohandlers/tests/test_arcgis_dbf.py
@@ -5,11 +5,11 @@ import warnings
 import pytest
 
 from .... import examples as pysal_examples
-from ...fileio import FileIO as psopen
+from ...fileio import FileIO
 from ..arcgis_dbf import ArcGISDbfIO
 
 
-class Testtest_ArcGISDbfIO:
+class TesttestArcGISDbfIO:
     def setup_method(self):
         self.test_file = test_file = pysal_examples.get_path("arcgis_ohio.dbf")
         self.obj = ArcGISDbfIO(test_file, "r")
@@ -52,10 +52,10 @@ class Testtest_ArcGISDbfIO:
         f = tempfile.NamedTemporaryFile(suffix=".dbf")
         fname = f.name
         f.close()
-        o = psopen(fname, "w", "arcgis_dbf")
+        o = FileIO(fname, "w", "arcgis_dbf")
         o.write(w)
         o.close()
-        f = psopen(fname, "r", "arcgis_dbf")
+        f = FileIO(fname, "r", "arcgis_dbf")
         wnew = f.read()
         f.close()
         assert wnew.pct_nonzero == w.pct_nonzero

--- a/libpysal/io/iohandlers/tests/test_arcgis_swm.py
+++ b/libpysal/io/iohandlers/tests/test_arcgis_swm.py
@@ -4,11 +4,11 @@ import tempfile
 import pytest
 
 from .... import examples as pysal_examples
-from ...fileio import FileIO as psopen
+from ...fileio import FileIO
 from ..arcgis_swm import ArcGISSwmIO
 
 
-class Testtest_ArcGISSwmIO:
+class TesttestArcGISSwmIO:
     def setup_method(self):
         self.test_file = test_file = pysal_examples.get_path("ohio.swm")
         self.obj = ArcGISSwmIO(test_file, "r")
@@ -35,9 +35,9 @@ class Testtest_ArcGISSwmIO:
         f = tempfile.NamedTemporaryFile(suffix=".swm")
         fname = f.name
         f.close()
-        o = psopen(fname, "w")
+        o = FileIO(fname, "w")
         o.write(w)
         o.close()
-        wnew = psopen(fname, "r").read()
+        wnew = FileIO(fname, "r").read()
         assert wnew.pct_nonzero == w.pct_nonzero
         os.remove(fname)

--- a/libpysal/io/iohandlers/tests/test_arcgis_txt.py
+++ b/libpysal/io/iohandlers/tests/test_arcgis_txt.py
@@ -5,11 +5,11 @@ import warnings
 import pytest
 
 from .... import examples as pysal_examples
-from ...fileio import FileIO as psopen
+from ...fileio import FileIO
 from ..arcgis_txt import ArcGISTextIO
 
 
-class Testtest_ArcGISTextIO:
+class TesttestArcGISTextIO:
     def setup_method(self):
         self.test_file = test_file = pysal_examples.get_path("arcgis_txt.txt")
         self.obj = ArcGISTextIO(test_file, "r")
@@ -26,9 +26,9 @@ class Testtest_ArcGISTextIO:
             if len(warn) > 0:
                 assert issubclass(warn[0].category, RuntimeWarning)
                 assert (
-                    "DBF relating to ArcGIS TEXT was not found, proceeding with unordered string IDs."
-                    in str(warn[0].message)
-                )
+                    "DBF relating to ArcGIS TEXT was not found, "
+                    "proceeding with unordered string IDs."
+                ) in str(warn[0].message)
         assert w.n == 3
         assert w.mean_neighbors == 2.0
         assert [0.1, 0.05] == list(w[2].values())
@@ -46,23 +46,23 @@ class Testtest_ArcGISTextIO:
             if len(warn) > 0:
                 assert issubclass(warn[0].category, RuntimeWarning)
                 assert (
-                    "DBF relating to ArcGIS TEXT was not found, proceeding with unordered string IDs."
-                    in str(warn[0].message)
-                )
+                    "DBF relating to ArcGIS TEXT was not found, "
+                    "proceeding with unordered string IDs."
+                ) in str(warn[0].message)
         f = tempfile.NamedTemporaryFile(suffix=".txt")
         fname = f.name
         f.close()
-        o = psopen(fname, "w", "arcgis_text")
+        o = FileIO(fname, "w", "arcgis_text")
         o.write(w)
         o.close()
         with warnings.catch_warnings(record=True) as warn:
             warnings.simplefilter("always")
-            wnew = psopen(fname, "r", "arcgis_text").read()
+            wnew = FileIO(fname, "r", "arcgis_text").read()
             if len(warn) > 0:
                 assert issubclass(warn[0].category, RuntimeWarning)
                 assert (
-                    "DBF relating to ArcGIS TEXT was not found, proceeding with unordered string IDs."
-                    in str(warn[0].message)
-                )
+                    "DBF relating to ArcGIS TEXT was not found, "
+                    "proceeding with unordered string IDs."
+                ) in str(warn[0].message)
         assert wnew.pct_nonzero == w.pct_nonzero
         os.remove(fname)

--- a/libpysal/io/iohandlers/tests/test_csvWrapper.py
+++ b/libpysal/io/iohandlers/tests/test_csvWrapper.py
@@ -1,10 +1,8 @@
-from sys import version as V
+# ruff: noqa: N999
 
 from .... import examples as pysal_examples
 from ...util import WKTParser
 from .. import csvWrapper
-
-PY3 = int(V[0]) > 2
 
 
 class TesttestCsvWrapper:
@@ -38,10 +36,10 @@ class TesttestCsvWrapper:
         objs = self.obj.read()
         assert len(objs) == 78
         self.obj.seek(0)
-        objsB = list(self.obj)
-        assert len(objsB) == 78
-        for rowA, rowB in zip(objs, objsB):
-            assert rowA == rowB
+        objs_b = list(self.obj)
+        assert len(objs_b) == 78
+        for row_a, row_b in zip(objs, objs_b, strict=True):
+            assert row_a == row_b
 
     def test_casting(self):
         self.obj.cast("WKT", WKTParser())
@@ -63,12 +61,8 @@ class TesttestCsvWrapper:
             (-89.4927978515625, 39.980186462402344),
             (-89.585220336914062, 39.978794097900391),
         ]
-        if PY3:
-            for i, pt in enumerate(self.obj.__next__()[0].vertices):
-                assert pt[:] == verts[i]
-        else:
-            for i, pt in enumerate(self.obj.next()[0].vertices):
-                assert pt[:] == verts[i]
+        for i, pt in enumerate(self.obj.__next__()[0].vertices):
+            assert pt[:] == verts[i]
 
     def test_by_col(self):
         for field in self.obj.header:

--- a/libpysal/io/iohandlers/tests/test_dat.py
+++ b/libpysal/io/iohandlers/tests/test_dat.py
@@ -4,11 +4,11 @@ import tempfile
 import pytest
 
 from .... import examples as pysal_examples
-from ...fileio import FileIO as psopen
+from ...fileio import FileIO
 from ..dat import DatIO
 
 
-class Testtest_DatIO:
+class TesttestDatIO:
     def setup_method(self):
         self.test_file = test_file = pysal_examples.get_path("wmat.dat")
         self.obj = DatIO(test_file, "r")
@@ -35,9 +35,9 @@ class Testtest_DatIO:
         f = tempfile.NamedTemporaryFile(suffix=".dat")
         fname = f.name
         f.close()
-        o = psopen(fname, "w")
+        o = FileIO(fname, "w")
         o.write(w)
         o.close()
-        wnew = psopen(fname, "r").read()
+        wnew = FileIO(fname, "r").read()
         assert wnew.pct_nonzero == w.pct_nonzero
         os.remove(fname)

--- a/libpysal/io/iohandlers/tests/test_db.py
+++ b/libpysal/io/iohandlers/tests/test_db.py
@@ -6,7 +6,7 @@ import shapely
 
 from .... import examples as pysal_examples
 from ... import geotable as pdio
-from ...fileio import FileIO as psopen
+from ...fileio import FileIO
 
 try:
     import sqlalchemy
@@ -39,7 +39,8 @@ class TestSqliteReader:
             self.conn,
             index=True,
             dtype={
-                "date": sqlalchemy.types.UnicodeText,  # Should convert the df date into a true date object, just a hack again
+                # Should convert the df date into a true date object, just a hack again
+                "date": sqlalchemy.types.UnicodeText,
                 "dataset": sqlalchemy.types.UnicodeText,
                 "street": sqlalchemy.types.UnicodeText,
                 "intersection": sqlalchemy.types.UnicodeText,
@@ -49,7 +50,7 @@ class TestSqliteReader:
         )  # This is converted to TEXT as lowest type common sqlite
 
     def test_deserialize(self):
-        db = psopen(f"sqlite:///{self.dbf}")
+        db = FileIO(f"sqlite:///{self.dbf}")
         assert db.tables == ["newhaven"]
 
         gj = db._get_gjson("newhaven")

--- a/libpysal/io/iohandlers/tests/test_gal.py
+++ b/libpysal/io/iohandlers/tests/test_gal.py
@@ -4,11 +4,11 @@ import tempfile
 import pytest
 
 from .... import examples as pysal_examples
-from ...fileio import FileIO as psopen
+from ...fileio import FileIO
 from ..gal import GalIO
 
 
-class Testtest_GalIO:
+class TesttestGalIO:
     def setup_method(self):
         self.test_file = test_file = pysal_examples.get_path("sids2.gal")
         self.obj = GalIO(test_file, "r")
@@ -40,8 +40,8 @@ class Testtest_GalIO:
         f = tempfile.NamedTemporaryFile(suffix=".gal")
         fname = f.name
         f.close()
-        o = psopen(fname, "w")
+        o = FileIO(fname, "w")
         o.write(w)
         o.close()
-        wnew = psopen(fname, "r").read()
+        wnew = FileIO(fname, "r").read()
         assert wnew.pct_nonzero == w.pct_nonzero

--- a/libpysal/io/iohandlers/tests/test_geobugs_txt.py
+++ b/libpysal/io/iohandlers/tests/test_geobugs_txt.py
@@ -4,11 +4,11 @@ import tempfile
 import pytest
 
 from .... import examples as pysal_examples
-from ...fileio import FileIO as psopen
+from ...fileio import FileIO
 from ..geobugs_txt import GeoBUGSTextIO
 
 
-class Testtest_GeoBUGSTextIO:
+class TesttestGeoBUGSTextIO:
     def setup_method(self):
         self.test_file_scot = test_file_scot = pysal_examples.get_path("geobugs_scot")
         self.test_file_col = test_file_col = pysal_examples.get_path(
@@ -48,9 +48,9 @@ class Testtest_GeoBUGSTextIO:
             f = tempfile.NamedTemporaryFile(suffix="")
             fname = f.name
             f.close()
-            o = psopen(fname, "w", "geobugs_text")
+            o = FileIO(fname, "w", "geobugs_text")
             o.write(w)
             o.close()
-            wnew = psopen(fname, "r", "geobugs_text").read()
+            wnew = FileIO(fname, "r", "geobugs_text").read()
             assert wnew.pct_nonzero == w.pct_nonzero
             os.remove(fname)

--- a/libpysal/io/iohandlers/tests/test_geoda_txt.py
+++ b/libpysal/io/iohandlers/tests/test_geoda_txt.py
@@ -3,13 +3,13 @@
 import pytest
 
 from .... import examples as pysal_examples
-from ..geoda_txt import GeoDaTxtReader as GTR
+from ..geoda_txt import GeoDaTxtReader
 
 
-class Testtest_GeoDaTxtReader:
+class TesttestGeoDaTxtReader:
     def setup_method(self):
         test_file = pysal_examples.get_path("stl_hom.txt")
-        self.obj = GTR(test_file, "r")
+        self.obj = GeoDaTxtReader(test_file, "r")
 
     def test___init__(self):
         assert self.obj.header == ["FIPSNO", "HR8488", "HR8893", "HC8488"]

--- a/libpysal/io/iohandlers/tests/test_gwt.py
+++ b/libpysal/io/iohandlers/tests/test_gwt.py
@@ -4,11 +4,11 @@ import tempfile
 import pytest
 
 from .... import examples as pysal_examples
-from ...fileio import FileIO as psopen
+from ...fileio import FileIO
 from ..gwt import GwtIO
 
 
-class Testtest_GwtIO:
+class TesttestGwtIO:
     def setup_method(self):
         self.test_file = test_file = pysal_examples.get_path("juvenile.gwt")
         self.obj = GwtIO(test_file, "r")
@@ -41,13 +41,13 @@ class Testtest_GwtIO:
             f = tempfile.NamedTemporaryFile(suffix=".gwt")
             fname = f.name
             f.close()
-            o = psopen(fname, "w")
+            o = FileIO(fname, "w")
             # copy the shapefile and ID variable names from the old gwt.
             # this is only available after the read() method has been called.
             # o.shpName = self.obj.shpName
             # o.varName = self.obj.varName
             o.write(w)
             o.close()
-            wnew = psopen(fname, "r").read()
+            wnew = FileIO(fname, "r").read()
             assert wnew.pct_nonzero == w.pct_nonzero
             os.remove(fname)

--- a/libpysal/io/iohandlers/tests/test_mat.py
+++ b/libpysal/io/iohandlers/tests/test_mat.py
@@ -5,11 +5,11 @@ import warnings
 import pytest
 
 from .... import examples as pysal_examples
-from ...fileio import FileIO as psopen
+from ...fileio import FileIO
 from ..mat import MatIO
 
 
-class Testtest_MatIO:
+class TesttestMatIO:
     def setup_method(self):
         self.test_file = test_file = pysal_examples.get_path("spat-sym-us.mat")
         self.obj = MatIO(test_file, "r")
@@ -36,13 +36,13 @@ class Testtest_MatIO:
         f = tempfile.NamedTemporaryFile(suffix=".mat")
         fname = f.name
         f.close()
-        o = psopen(fname, "w")
+        o = FileIO(fname, "w")
         with warnings.catch_warnings(record=True) as warn:
             warnings.simplefilter("always")
             o.write(w)
             if len(warn) > 0:
                 assert issubclass(warn[0].category, FutureWarning)
         o.close()
-        wnew = psopen(fname, "r").read()
+        wnew = FileIO(fname, "r").read()
         assert wnew.pct_nonzero == w.pct_nonzero
         os.remove(fname)

--- a/libpysal/io/iohandlers/tests/test_mtx.py
+++ b/libpysal/io/iohandlers/tests/test_mtx.py
@@ -4,7 +4,7 @@ import tempfile
 import pytest
 
 from .... import examples as pysal_examples
-from ...fileio import FileIO as psopen
+from ...fileio import FileIO
 from ..mtx import MtxIO
 
 
@@ -22,8 +22,9 @@ class TesttestMtxIO:
         w = self.obj.read()
         assert w.n == 49
         assert w.mean_neighbors == 4.7346938775510203
-        assert [0.33329999999999999, 0.33329999999999999, 0.33329999999999999] == \
-            list(w[1].values())
+        assert [0.33329999999999999, 0.33329999999999999, 0.33329999999999999] == list(
+            w[1].values()
+        )
         s0 = w.s0
         self.obj.seek(0)
         wsp = self.obj.read(sparse=True)
@@ -43,10 +44,10 @@ class TesttestMtxIO:
             f = tempfile.NamedTemporaryFile(suffix=".mtx")
             fname = f.name
             f.close()
-            o = psopen(fname, "w")
+            o = FileIO(fname, "w")
             o.write(w)
             o.close()
-            wnew = psopen(fname, "r").read(sparse=i)
+            wnew = FileIO(fname, "r").read(sparse=i)
             if i:
                 assert wnew.s0 == w.s0
             else:

--- a/libpysal/io/iohandlers/tests/test_pyDbfIO.py
+++ b/libpysal/io/iohandlers/tests/test_pyDbfIO.py
@@ -1,3 +1,5 @@
+# ruff: noqa: N999, SIM115
+
 import os
 import tempfile
 
@@ -5,7 +7,7 @@ from .... import examples as pysal_examples
 from ..pyDbfIO import DBF
 
 
-class Testtest_DBF:
+class TesttestDBF:
     def setup_method(self):
         self.test_file = test_file = pysal_examples.get_path("10740.dbf")
         self.dbObj = DBF(test_file, "r")
@@ -40,10 +42,10 @@ class Testtest_DBF:
         objs = self.dbObj.read()
         assert len(objs) == 195
         self.dbObj.seek(0)
-        objsB = list(self.dbObj)
-        assert len(objsB) == 195
-        for rowA, rowB in zip(objs, objsB):
-            assert rowA == rowB
+        objs_b = list(self.dbObj)
+        assert len(objs_b) == 195
+        for row_a, row_b in zip(objs, objs_b, strict=True):
+            assert row_a == row_b
 
     def test_random_access(self):
         self.dbObj.seek(0)

--- a/libpysal/io/iohandlers/tests/test_pyShpIO.py
+++ b/libpysal/io/iohandlers/tests/test_pyShpIO.py
@@ -1,3 +1,5 @@
+# ruff: noqa: N806, N999, SIM115
+
 import os
 import tempfile
 
@@ -5,11 +7,11 @@ from .... import examples as pysal_examples
 from ..pyShpIO import PurePyShpWrapper
 
 
-class Testtest_PurePyShpWrapper:
+class TesttestPurePyShpWrapper:
     def setup_method(self):
         test_file = pysal_examples.get_path("10740.shp")
         self.test_file = test_file
-        self.shpObj = PurePyShpWrapper(test_file, "r")
+        self.shp_obj = PurePyShpWrapper(test_file, "r")
         f = tempfile.NamedTemporaryFile(suffix=".shp")
         shpcopy = f.name
         f.close()
@@ -17,52 +19,52 @@ class Testtest_PurePyShpWrapper:
         self.shxcopy = shpcopy.replace(".shp", ".shx")
 
     def test_len(self):
-        assert len(self.shpObj) == 195
+        assert len(self.shp_obj) == 195
 
     def test_tell(self):
-        assert self.shpObj.tell() == 0
-        self.shpObj.read(1)
-        assert self.shpObj.tell() == 1
-        self.shpObj.read(50)
-        assert self.shpObj.tell() == 51
-        self.shpObj.read()
-        assert self.shpObj.tell() == 195
+        assert self.shp_obj.tell() == 0
+        self.shp_obj.read(1)
+        assert self.shp_obj.tell() == 1
+        self.shp_obj.read(50)
+        assert self.shp_obj.tell() == 51
+        self.shp_obj.read()
+        assert self.shp_obj.tell() == 195
 
     def test_seek(self):
-        self.shpObj.seek(0)
-        assert self.shpObj.tell() == 0
-        self.shpObj.seek(55)
-        assert self.shpObj.tell() == 55
-        self.shpObj.read(1)
-        assert self.shpObj.tell() == 56
+        self.shp_obj.seek(0)
+        assert self.shp_obj.tell() == 0
+        self.shp_obj.seek(55)
+        assert self.shp_obj.tell() == 55
+        self.shp_obj.read(1)
+        assert self.shp_obj.tell() == 56
 
     def test_read(self):
-        self.shpObj.seek(0)
-        objs = self.shpObj.read()
+        self.shp_obj.seek(0)
+        objs = self.shp_obj.read()
         assert len(objs) == 195
 
-        self.shpObj.seek(0)
-        objsB = list(self.shpObj)
-        assert len(objsB) == 195
+        self.shp_obj.seek(0)
+        objs_b = list(self.shp_obj)
+        assert len(objs_b) == 195
 
-        for shpA, shpB in zip(objs, objsB):
-            assert shpA.vertices == shpB.vertices
+        for shp_a, shp_b in zip(objs, objs_b, strict=True):
+            assert shp_a.vertices == shp_b.vertices
 
     def test_random_access(self):
-        self.shpObj.seek(57)
-        shp57 = self.shpObj.read(1)[0]
-        self.shpObj.seek(32)
-        shp32 = self.shpObj.read(1)[0]
+        self.shp_obj.seek(57)
+        shp57 = self.shp_obj.read(1)[0]
+        self.shp_obj.seek(32)
+        shp32 = self.shp_obj.read(1)[0]
 
-        self.shpObj.seek(57)
-        assert self.shpObj.read(1)[0].vertices == shp57.vertices
-        self.shpObj.seek(32)
-        assert self.shpObj.read(1)[0].vertices == shp32.vertices
+        self.shp_obj.seek(57)
+        assert self.shp_obj.read(1)[0].vertices == shp57.vertices
+        self.shp_obj.seek(32)
+        assert self.shp_obj.read(1)[0].vertices == shp32.vertices
 
     def test_write(self):
         out = PurePyShpWrapper(self.shpcopy, "w")
-        self.shpObj.seek(0)
-        for shp in self.shpObj:
+        self.shp_obj.seek(0)
+        for shp in self.shp_obj:
             out.write(shp)
         out.close()
 

--- a/libpysal/io/iohandlers/tests/test_stata_txt.py
+++ b/libpysal/io/iohandlers/tests/test_stata_txt.py
@@ -4,11 +4,11 @@ import tempfile
 import pytest
 
 from .... import examples as pysal_examples
-from ...fileio import FileIO as psopen
+from ...fileio import FileIO
 from ..stata_txt import StataTextIO
 
 
-class Testtest_StataTextIO:
+class TesttestStataTextIO:
     def setup_method(self):
         self.test_file_sparse = test_file_sparse = pysal_examples.get_path(
             "stata_sparse.txt"
@@ -48,12 +48,12 @@ class Testtest_StataTextIO:
             f = tempfile.NamedTemporaryFile(suffix=".txt")
             fname = f.name
             f.close()
-            o = psopen(fname, "w", "stata_text")
+            o = FileIO(fname, "w", "stata_text")
             if obj == self.obj_sparse:
                 o.write(w)
             else:
                 o.write(w, matrix_form=True)
             o.close()
-            wnew = psopen(fname, "r", "stata_text").read()
+            wnew = FileIO(fname, "r", "stata_text").read()
             assert wnew.pct_nonzero == w.pct_nonzero
             os.remove(fname)

--- a/libpysal/io/iohandlers/tests/test_wk1.py
+++ b/libpysal/io/iohandlers/tests/test_wk1.py
@@ -4,11 +4,11 @@ import tempfile
 import pytest
 
 from .... import examples as pysal_examples
-from ...fileio import FileIO as psopen
+from ...fileio import FileIO
 from ..wk1 import Wk1IO
 
 
-class Testtest_Wk1IO:
+class TesttestWk1IO:
     def setup_method(self):
         self.test_file = test_file = pysal_examples.get_path("spat-sym-us.wk1")
         self.obj = Wk1IO(test_file, "r")
@@ -35,10 +35,9 @@ class Testtest_Wk1IO:
         f = tempfile.NamedTemporaryFile(suffix=".wk1")
         fname = f.name
         f.close()
-        o = psopen(fname, "w")
+        o = FileIO(fname, "w")
         o.write(w)
         o.close()
-        wnew = psopen(fname, "r").read()
+        wnew = FileIO(fname, "r").read()
         assert wnew.pct_nonzero == w.pct_nonzero
         os.remove(fname)
-

--- a/libpysal/io/iohandlers/tests/test_wkt.py
+++ b/libpysal/io/iohandlers/tests/test_wkt.py
@@ -4,7 +4,7 @@ from .... import examples as pysal_examples
 from ..wkt import WKTReader
 
 
-class Testtest_WKTReader:
+class TesttestWKTReader:
     def setup_method(self):
         self.test_file = test_file = pysal_examples.get_path("stl_hom.wkt")
         self.obj = WKTReader(test_file, "r")


### PR DESCRIPTION
xref https://github.com/pysal/libpysal/issues/589

This PR:

* breaks out https://github.com/pysal/libpysal/pull/630 (part 5 of $n$)
* formats and lints `io/iohandlers/tests/*.py`
