### PR TITLE
final lint/format run through & update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,15 @@
-repos: 
-- repo: https://github.com/psf/black
-  rev: "23.10.0"
-  hooks:
-  - id: black
-    language_version: python3
+files: "libpysal\/"
+repos:
+  - repo: https://github.com/psf/black
+    rev: "23.10.1"
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.1.6"
+    hooks:
+      - id: ruff
+
+ci:
+  autofix_prs: false
+  autoupdate_schedule: quarterly

--- a/libpysal/cg/standalone.py
+++ b/libpysal/cg/standalone.py
@@ -634,7 +634,9 @@ def get_polygon_point_dist(poly, pt):
         part_prox = []
         for vertices in poly._vertices:
             vx_range = range(-1, len(vertices) - 1)
-            seg = lambda i: LineSegment(vertices[i], vertices[i + 1])  # noqa: B023
+            seg = lambda i: LineSegment(  # noqa: E731
+                vertices[i], vertices[i + 1]  # noqa: B023
+            )
             _min_dist = min([get_segment_point_dist(seg(i), pt)[0] for i in vx_range])
             part_prox.append(_min_dist)
         dist = min(part_prox)

--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -254,14 +254,14 @@ def _knn(coordinates, metric="euclidean", k=1, p=2, coincident="raise"):
                 coincident="jitter",
             )
 
-        if (coincident == "clique"):
+        if coincident == "clique":
             heads, tails, weights = _sparse_to_arrays(
                 _knn(
                     coincident_lut.geometry, metric=metric, k=k, p=p, coincident="raise"
                 )
             )
             adjtable = pandas.DataFrame.from_dict(
-                dict(focal=heads, neighbor=tails, weight=weights)
+                {"focal": heads, "neighbor": tails, "weight": weights}
             )
             adjtable = _induce_cliques(adjtable, coincident_lut, fill_value=-1)
             adjtable = _reorder_adjtable_by_ids(adjtable, ids)

--- a/libpysal/io/fileio.py
+++ b/libpysal/io/fileio.py
@@ -146,7 +146,7 @@ class FileIO(metaclass=FileIO_MetaCls):  # should be a type?
             print(f"Ext: '.{key}', Modes: {list(val.keys())!r}")
 
     @classmethod
-    def open(cls, *args, **kwargs):  # noqa: A001
+    def open(cls, *args, **kwargs):  # noqa: A001, A003
         """Alias for ``FileIO()``."""
 
         return cls(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,18 +86,6 @@ line-length = 88
 line-length = 88
 select = ["E", "F", "W", "I", "UP", "N", "B", "A", "C4", "SIM", "ARG"]
 target-version = "py310"
-ignore = [
-    "B006",
-    "B008",
-    "B009",
-    "B010",
-    "C408",
-    "E731",
-    "N803",
-    "N806",
-    "N999",
-    "UP007"
-]
 exclude = ["libpysal/tests/*", "docs/*"]
 [tool.ruff.per-file-ignores]
 "*__init__.py" = [


### PR DESCRIPTION
This PR:
* cleans up several lingering formatting & linting spots
* updates `.pre-commit` for for `black` and `ruff`
* xref #589

To decide:
* Within `pyproject.toml`, I am more leaning towards the mindset of omitting [`[tool.ruff.ignore]`](https://github.com/pysal/libpysal/blob/9e459608ef1b34e41ef63711da8e86c5ca085f7c/pyproject.toml#L89) in `pyproject.toml` altogether and handling 99.9% of cases within files themselves (everything in the PR passes that way). However, I know others may think this is too strict. So yay or nay for keeping `[tool.ruff.ignore]`?

Once the PR is reviewed and merged the last step in #589 will be to [enable `pre-commit` on triggered GHA](https://results.pre-commit.ci)