### PR TITLE
Formatting via `ruff`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,6 +3,8 @@ review the [contributing procedures](https://github.com/pysal/pysal/wiki/GitHub-
 
 ## Style and format
 
-1. Python 3.6, 3.7, and 3.8 are the officially supported versions.
-2. This project follows the formatting conventions of [`black`](https://black.readthedocs.io/en/stable/) and utilizes [`pre-commit`](https://pre-commit.com) to format commits prior to pull requests being made. 
-    * LJ Miranda provides an [excellent, concise guide](https://ljvmiranda921.github.io/notebook/2018/06/21/precommits-using-black-and-flake8/) on setting up and implementing a `pre-commit` hook for `black`.
+1. At the time of this writing, Python 3.10, 3.11, and 3.12 are the officially supported versions.
+2. This project implements the linting and formatting conventions of [`ruff`](https://docs.astral.sh/ruff/) on all incoming Pull Requests. To ensure a PR is properly linted and formatted prior to creating a Pull Request, [install `pre-commit`](https://pre-commit.com/#installation) in your development environment and then [set up the `libpysal` configuration of pre-commit hooks](https://pre-commit.com/#3-install-the-git-hook-scripts). 
+ 
+ 
+ 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,10 @@
 files: "libpysal\/"
 repos:
-  - repo: https://github.com/psf/black
-    rev: "23.10.1"
-    hooks:
-      - id: black
-        language_version: python3
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.1.6"
     hooks:
       - id: ruff
+      - id: ruff-format
 
 ci:
   autofix_prs: false

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-libpysal supports python >= `3.8`_ only. Please make sure that you are
+libpysal supports python >= `3.10`_ only. Please make sure that you are
 operating in a python 3 environment.
 
 Installing released version
@@ -50,7 +50,7 @@ to your local clone and submitting a pull request to `pysal/libpysal`_, you can
 contribute to libpysal development.
 
 
-.. _3.8: https://docs.python.org/3.8/
+.. _3.10: https://docs.python.org/3.10/
 .. _Python Package Index: https://pypi.org/project/libpysal/
 .. _pysal/libpysal: https://github.com/pysal/libpysal
 .. _fork: https://help.github.com/articles/fork-a-repo/

--- a/libpysal/cg/standalone.py
+++ b/libpysal/cg/standalone.py
@@ -635,7 +635,8 @@ def get_polygon_point_dist(poly, pt):
         for vertices in poly._vertices:
             vx_range = range(-1, len(vertices) - 1)
             seg = lambda i: LineSegment(  # noqa: E731
-                vertices[i], vertices[i + 1]  # noqa: B023
+                vertices[i],  # noqa: B023
+                vertices[i + 1],  # noqa: B023
             )
             _min_dist = min([get_segment_point_dist(seg(i), pt)[0] for i in vx_range])
             part_prox.append(_min_dist)

--- a/libpysal/graph/tests/test_contiguity.py
+++ b/libpysal/graph/tests/test_contiguity.py
@@ -256,16 +256,16 @@ def test_block_contiguity(regimes):
         8: [4, 5],
         9: [],
     }
-    assert {f: n.tolist() for f, n, in neighbors.items()} == wn
+    assert {f: n.tolist() for f, n in neighbors.items()} == wn
 
     ids = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
     neighbors = _block_contiguity(regimes, ids=ids)
     wn_str = {ids[f]: [ids[o] for o in n] for f, n in wn.items()}
-    assert {f: n.tolist() for f, n, in neighbors.items()} == wn_str
+    assert {f: n.tolist() for f, n in neighbors.items()} == wn_str
 
     regimes = pandas.Series(regimes, index=ids)
     neighbors = _block_contiguity(regimes)
-    assert {f: n.tolist() for f, n, in neighbors.items()} == wn_str
+    assert {f: n.tolist() for f, n in neighbors.items()} == wn_str
 
 
 def test_fuzzy_contiguity():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,6 @@ tests = [
 [tool.setuptools.packages.find]
 include = ["libpysal", "libpysal.*"]
 
-[tool.black]
-line-length = 88
-
 [tool.ruff]
 line-length = 88
 select = ["E", "F", "W", "I", "UP", "N", "B", "A", "C4", "SIM", "ARG"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,8 @@ plus = [
     "zstd",
 ]
 dev = [
-    "black",
     "pre-commit",
+    "ruff",
     "watermark",
 ]
 docs = [


### PR DESCRIPTION
This PR:
* follows the example in [`xarray-contrib/xvec`](https://github.com/xarray-contrib/xvec/pull/54/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R7) for swapping out `black` for `ruff format` in formatting
* updates `pyproject.toml` of this
* makes several minor linting and formatting corrections
* updates contributing guidelines and `docs/install` for supported Python versions 


xref #589 