### PR TITLE
ENH: include assign_self_weight (formerly fill_diagonal) in Graph

### DIFF
--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1429,10 +1429,11 @@ class Graph(SetOpsMixin):
         Parameters
         ----------
         weight : float | array-like
-            Defines the value(s) to which the weight of self-loops should be set. If a
-            constant is passed then each self-loop will get this value (default is 1).
-            An array of length ``Graph.n`` can be passed to set explicit values to each
-            self-loop (assumed to be in the same order as original data).
+            Defines the value(s) to which the weight representing the relationship with
+            itself should be set. If a constant is passed then each self-weight will get
+            this value (default is 1). An array of length ``Graph.n`` can be passed to
+            set explicit values to each self-weight (assumed to be in the same order as
+            original data).
 
         Returns
         -------

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1421,26 +1421,26 @@ class Graph(SetOpsMixin):
         zeros = (self._adjacency == 0) != isolates
         return Graph(self._adjacency[~zeros], is_sorted=True)
 
-    def set_self_weights(self, val=1):
-        """Set self-weights in the Graph to a value.
+    def add_self_loops(self, weight=1):
+        """Set add self-loopswith a set weight to the Graph.
 
-        Value for each ``focal == neighbor`` location in the graph is set to ``val``.
+        Value for each ``focal == neighbor`` location in the graph is set to ``weight``.
 
         Parameters
         ----------
-        val : float | array-like
-            Defines the value(s) to which the self-weights should be set. If a constant
-            is passed then each self-weight will get this value (default is 1). An array
-            of length ``Graph.n``can be passed to set explicit values to each
-            self-weight (assumed to be in the same order as original data).
+        weight : float | array-like
+            Defines the value(s) to which the weiight of self-loops should be set. If a
+            constant is passed then each self-loop will get this value (default is 1).
+            An array of length ``Graph.n``can be passed to set explicit values to each
+            self-lopp (assumed to be in the same order as original data).
 
         Returns
         -------
         Graph
-            A new Graph with self-weights set
+            A new Graph with added self-loops
         """
         addition = pd.Series(
-            val,
+            weight,
             index=pd.MultiIndex.from_arrays(
                 [self.unique_ids, self.unique_ids], names=["focal", "neighbor"]
             ),

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1421,23 +1421,23 @@ class Graph(SetOpsMixin):
         zeros = (self._adjacency == 0) != isolates
         return Graph(self._adjacency[~zeros], is_sorted=True)
 
-    def add_self_loops(self, weight=1):
-        """Set add self-loopswith a set weight to the Graph.
+    def assign_self_weight(self, weight=1):
+        """Assign values to edges represeting self-weight.
 
         Value for each ``focal == neighbor`` location in the graph is set to ``weight``.
 
         Parameters
         ----------
         weight : float | array-like
-            Defines the value(s) to which the weiight of self-loops should be set. If a
+            Defines the value(s) to which the weight of self-loops should be set. If a
             constant is passed then each self-loop will get this value (default is 1).
-            An array of length ``Graph.n``can be passed to set explicit values to each
+            An array of length ``Graph.n`` can be passed to set explicit values to each
             self-lopp (assumed to be in the same order as original data).
 
         Returns
         -------
         Graph
-            A new Graph with added self-loops
+            A new Graph with added self-weights
         """
         addition = pd.Series(
             weight,

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -162,7 +162,7 @@ class Graph(SetOpsMixin):
         pandas.Series
             Underlying adjacency list
         """
-        return self._adjacency.copy(deep=True)
+        return self._adjacency.copy()
 
     @classmethod
     def from_W(cls, w):  # noqa: N802

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1422,9 +1422,9 @@ class Graph(SetOpsMixin):
         return Graph(self._adjacency[~zeros], is_sorted=True)
 
     def assign_self_weight(self, weight=1):
-        """Assign values to edges represeting self-weight.
+        """Assign values to edges representing self-weight.
 
-        Value for each ``focal == neighbor`` location in the graph is set to ``weight``.
+        The value for each ``focal == neighbor`` location in the graph is set to ``weight``.
 
         Parameters
         ----------
@@ -1432,12 +1432,12 @@ class Graph(SetOpsMixin):
             Defines the value(s) to which the weight of self-loops should be set. If a
             constant is passed then each self-loop will get this value (default is 1).
             An array of length ``Graph.n`` can be passed to set explicit values to each
-            self-lopp (assumed to be in the same order as original data).
+            self-loop (assumed to be in the same order as original data).
 
         Returns
         -------
         Graph
-            A new Graph with added self-weights
+            A new ``Graph`` with added self-weights.
         """
         addition = pd.Series(
             weight,

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1421,24 +1421,23 @@ class Graph(SetOpsMixin):
         zeros = (self._adjacency == 0) != isolates
         return Graph(self._adjacency[~zeros], is_sorted=True)
 
-    def fill_diagonal(self, val=1):
-        """Fill Graph with values inserted along the main diagonal.
+    def set_self_weights(self, val=1):
+        """Set self-weights in the Graph to a value.
 
         Value for each ``focal == neighbor`` location in the graph is set to ``val``.
 
         Parameters
         ----------
         val : float | array-like
-            Defines the value(s) to which the weights matrix diagonal should
-            be set. If a constant is passed then each element along the
-            diagonal will get this value (default is 1). An array of length
-            Graph.n can be passed to set explicit values to each element along
-            the diagonal (assumed to be in the same order as original data).
+            Defines the value(s) to which the self-weights should be set. If a constant
+            is passed then each self-weight will get this value (default is 1). An array
+            of length ``Graph.n``can be passed to set explicit values to each
+            self-weight (assumed to be in the same order as original data).
 
         Returns
         -------
         Graph
-            A new Graph with new values along the diagonal
+            A new Graph with self-weights set
         """
         addition = pd.Series(
             val,
@@ -1453,12 +1452,6 @@ class Graph(SetOpsMixin):
             .reindex(self.unique_ids, level=1)
         )
         return Graph(adj, is_sorted=True)
-
-    def fill_diagonal_sparse(self):
-        sp = self.sparse
-        sp = sp.tolil()
-        sp.setdiag(1)
-        return Graph.from_sparse(sp, ids=self.unique_ids)
 
 
 def _arrange_arrays(heads, tails, weights, ids=None):

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1424,7 +1424,8 @@ class Graph(SetOpsMixin):
     def assign_self_weight(self, weight=1):
         """Assign values to edges representing self-weight.
 
-        The value for each ``focal == neighbor`` location in the graph is set to ``weight``.
+        The value for each ``focal == neighbor`` location in
+        the graph is set to ``weight``.
 
         Parameters
         ----------

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1405,9 +1405,11 @@ class Graph(SetOpsMixin):
 
     def eliminate_zeros(self):
         """Remove graph edges with zero weight
+
         Eliminates edges with weight == 0 that do not encode an
         isolate. This is useful to clean-up edges that will make
         no effect in operations like :meth:`lag`.
+
         Returns
         -------
         Graph
@@ -1419,17 +1421,26 @@ class Graph(SetOpsMixin):
         zeros = (self._adjacency == 0) != isolates
         return Graph(self._adjacency[~zeros], is_sorted=True)
 
-    def fill_diagonal(self):
+    def fill_diagonal(self, val=1):
+        """Fill Graph with values inserted along the main diagonal.
+
+        Value for each ``focal == neighbor`` location in the graph is set to ``val``.
+
+        Returns
+        -------
+        Graph
+            A new Graph with new values along the diagonal
+        """
         no_isolates = self.unique_ids.difference(self.isolates)
         addition = pd.Series(
-            1,
+            val,
             index=pd.MultiIndex.from_arrays(
                 [no_isolates, no_isolates], names=["focal", "neighbor"]
             ),
             name="weight",
         )
         adj = pd.concat([self._adjacency, addition])
-        adj.loc[self.isolates] = 1
+        adj.loc[self.isolates] = val
         return Graph(adj, is_sorted=False)
 
     def fill_diagonal_sparse(self):

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -966,3 +966,19 @@ class TestBase:
             ),
         )
         pd.testing.assert_series_equal(expected, sub._adjacency, check_dtype=False)
+
+    def test_fill_diagonal(self):
+        contig = graph.Graph.build_contiguity(self.nybb)
+        diag = contig.fill_diagonal()
+        assert len(diag._adjacency) == 15
+        assert diag._adjacency.sum() == 15
+
+        diag_array = contig.fill_diagonal([2, 3, 4, 5, 6])
+        assert len(diag_array._adjacency) == 15
+        assert diag_array._adjacency.sum() == 30
+
+        for i, val in enumerate(range(2, 7)):
+            assert (
+                diag_array._adjacency[(contig.unique_ids[i], contig.unique_ids[i])]
+                == val
+            )

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -967,13 +967,13 @@ class TestBase:
         )
         pd.testing.assert_series_equal(expected, sub._adjacency, check_dtype=False)
 
-    def test_add_self_loops(self):
+    def test_assign_self_weight(self):
         contig = graph.Graph.build_contiguity(self.nybb)
-        diag = contig.add_self_loops()
+        diag = contig.assign_self_weight()
         assert len(diag._adjacency) == 15
         assert diag._adjacency.sum() == 15
 
-        diag_array = contig.add_self_loops([2, 3, 4, 5, 6])
+        diag_array = contig.assign_self_weight([2, 3, 4, 5, 6])
         assert len(diag_array._adjacency) == 15
         assert diag_array._adjacency.sum() == 30
 

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -967,13 +967,13 @@ class TestBase:
         )
         pd.testing.assert_series_equal(expected, sub._adjacency, check_dtype=False)
 
-    def test_fill_diagonal(self):
+    def test_add_self_loops(self):
         contig = graph.Graph.build_contiguity(self.nybb)
-        diag = contig.fill_diagonal()
+        diag = contig.add_self_loops()
         assert len(diag._adjacency) == 15
         assert diag._adjacency.sum() == 15
 
-        diag_array = contig.fill_diagonal([2, 3, 4, 5, 6])
+        diag_array = contig.add_self_loops([2, 3, 4, 5, 6])
         assert len(diag_array._adjacency) == 15
         assert diag_array._adjacency.sum() == 30
 


### PR DESCRIPTION
Closes #668

@knaaptime this includes pandas-fu version as well as roundtrip via sparse for now. Timing below. 

```py
import geopandas as gpd
from geodatasets import get_path
from libpysal import graph

df = gpd.read_file(get_path("geoda.ncovr"))
contig  = graph.Graph.build_contiguity(df)

%%timeit
contig.fill_diagonal()
5.31 ms ± 108 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

%%timeit
contig.fill_diagonal_sparse()
16.3 ms ± 92.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Here, the sparse version is about 3x slower. This ratio seems to be more or less consistent with any size of the graph.