### PR TITLE
CI: partially resolve reverse dep testing issues

### DIFF
--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -49,6 +49,8 @@ jobs:
               pulp
               dask-geopandas
               kdepy
+              matplotlib
+              statsmodels
             installation_command: >-
               pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()'
             fail_on_failure: true

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -39,7 +39,6 @@ jobs:
               pointpats
             install: >-
               setuptools-scm
-              py-opencv
               h3-py
               hdbscan
               pandana
@@ -51,8 +50,6 @@ jobs:
               kdepy
               matplotlib
               statsmodels
-            installation_command: >-
-              pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()'; pip install opencv-contrib-python
             fail_on_failure: true
             verbose: true
             parallel: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -35,8 +35,6 @@ jobs:
               mesa-geo
             include: >-
               mapclassify
-            whitelist: >-
-              pointpats
             install: >-
               setuptools-scm
               h3-py
@@ -50,6 +48,8 @@ jobs:
               kdepy
               matplotlib
               statsmodels
+            installation_command: >-
+              pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()';
             fail_on_failure: true
             verbose: true
             parallel: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -1,8 +1,7 @@
 name: Test reverse dependencies
 on:
   push:
-    # branches: [main]
-    branches: "*"
+    branches: [main]
   schedule:
     - cron: "0 0 * * 1,4"
   workflow_dispatch:

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -35,6 +35,8 @@ jobs:
               mesa-geo
             include: >-
               mapclassify
+            whitelist: >-
+              pointpats
             install: >-
               setuptools-scm
               py-opencv
@@ -45,7 +47,7 @@ jobs:
               geodatasets
               bokeh
               pulp
-              opencv
+              py-opencv
               dask-geopandas
             install_pip: >-
               KDEpy

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -52,7 +52,7 @@ jobs:
               matplotlib
               statsmodels
             installation_command: >-
-              pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()'
+              pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()'; pip install opencv-contrib-python
             fail_on_failure: true
             verbose: true
             parallel: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -48,9 +48,7 @@ jobs:
               bokeh
               pulp
               dask-geopandas
-            install_pip: >-
-              KDEpy
-              opencv-contrib-python
+              kdepy
             installation_command: >-
               pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()'
             fail_on_failure: true

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -1,7 +1,8 @@
 name: Test reverse dependencies
 on:
   push:
-    branches: [main]
+    # branches: [main]
+    branches: "*"
   schedule:
     - cron: "0 0 * * 1,4"
   workflow_dispatch:
@@ -44,11 +45,11 @@ jobs:
               geodatasets
               bokeh
               pulp
+              opencv
             install_pip: >-
-              opencv-contrib-python
               KDEpy
             installation_command: >-
               pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()'
             fail_on_failure: true
             verbose: true
-            parallel: true
+            parallel: false

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -46,7 +46,7 @@ jobs:
               bokeh
               pulp
               opencv
-              dask_geopandas
+              dask-geopandas
             install_pip: >-
               KDEpy
             installation_command: >-

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -47,10 +47,10 @@ jobs:
               geodatasets
               bokeh
               pulp
-              py-opencv
               dask-geopandas
             install_pip: >-
               KDEpy
+              opencv-contrib-python
             installation_command: >-
               pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()'
             fail_on_failure: true

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -46,6 +46,7 @@ jobs:
               bokeh
               pulp
               opencv
+              dask_geopandas
             install_pip: >-
               KDEpy
             installation_command: >-


### PR DESCRIPTION
Remove parallel execution to resolve those `quilt3` issues, add some missing dependencies.

Couldn't make opencv work but we should resolve that in pointpats by a) skipping the test then cv2 cannot be imported, b) refactoring the minimum_bounding_rectangle on top of shapely instead.

See the log of the latest run with this config [here](https://github.com/martinfleis/libpysal/actions/runs/7703159298)

mgwr, pointpats, spvcm, tobler remain failing, all of which need to be solved in upstream.

xref #681 