### PR TITLE
COMPAT: compatibility with pandas 3

### DIFF
--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -84,7 +84,7 @@ class Graph(SetOpsMixin):
             raise TypeError(
                 f"The adjacency table needs to be a pandas.Series. {type(adjacency)}"
             )
-        if not adjacency.index.names == ["focal", "neighbor"]:
+        if not tuple(adjacency.index.names) == ("focal", "neighbor"):
             raise ValueError(
                 "The index of the adjacency table needs to be a MultiIndex named "
                 "['focal', 'neighbor']."


### PR DESCRIPTION
pandas no longer returns names of MultiIndex as a list but as a tuple. Making our check compatible.


This will need to be released before pandas 3 which is scheduled for April. Otherwise, graph module will be unusable with pandas 3.