### PR TITLE
Work around GEOS issue in voronoi_frames

### DIFF
--- a/libpysal/cg/voronoi.py
+++ b/libpysal/cg/voronoi.py
@@ -425,7 +425,7 @@ def voronoi_frames(
         shapely.GeometryCollection(objects.values), extend_to=limit
     )
     # Get individual polygons out of the collection
-    polygons = gpd.GeoSeries(shapely.get_parts(voronoi), crs=geometry.crs)
+    polygons = gpd.GeoSeries(shapely.get_parts(voronoi), crs=geometry.crs).make_valid()
 
     # temporary fix for libgeos/geos#1062
     if not (polygons.geom_type == "Polygon").all():

--- a/libpysal/cg/voronoi.py
+++ b/libpysal/cg/voronoi.py
@@ -430,7 +430,9 @@ def voronoi_frames(
         shapely.GeometryCollection(objects.values), extend_to=limit
     )
     # Get individual polygons out of the collection
-    polygons = gpd.GeoSeries(shapely.get_parts(voronoi), crs=geometry.crs).make_valid()
+    polygons = gpd.GeoSeries(
+        shapely.make_valid(shapely.get_parts(voronoi)), crs=geometry.crs
+    )
 
     # temporary fix for libgeos/geos#1062
     if not (polygons.geom_type == "Polygon").all():

--- a/libpysal/cg/voronoi.py
+++ b/libpysal/cg/voronoi.py
@@ -313,6 +313,7 @@ def voronoi_frames(
     clip: str | shapely.Geometry | None = "bounding_box",
     shrink: float = 0,
     segment: float = 0,
+    grid_size: float = 1e-5,
     return_input: bool | None = None,
     as_gdf: bool | None = None,
 ) -> gpd.GeoSeries:
@@ -351,6 +352,9 @@ def voronoi_frames(
     segment : float, optional
         Distance for the segmentation of lines used to add coordinates to lines or
         polygons prior Voronoi tessellation, by default 0
+    grid_size : float, optional
+        Grid size precision under which the voronoi algorithm is generated,
+        by default 1e-5
     return_input : bool, optional
         Whether to return the input geometry, defaults to True
     as_gdf : bool, optional
@@ -379,7 +383,8 @@ def voronoi_frames(
                 "projected CRS before using voronoi_polygons.",
             )
 
-        objects = geometry.geometry.copy()
+        # Set precision of the input geometry (avoids GEOS precision issues)
+        objects = shapely.set_precision(geometry.geometry.copy(), grid_size)
 
         geom_types = objects.geom_type
         mask_poly = geom_types.isin(["Polygon", "MultiPolygon"])

--- a/libpysal/cg/voronoi.py
+++ b/libpysal/cg/voronoi.py
@@ -378,8 +378,9 @@ def voronoi_frames(
                 "Use 'GeoSeries.to_crs()' to re-project geometries to a "
                 "projected CRS before using voronoi_polygons.",
             )
-        # Set precision of the input geometry (avoids GEOS precision issues)
-        objects = geometry.copy()
+
+        objects = geometry.geometry.copy()
+
         geom_types = objects.geom_type
         mask_poly = geom_types.isin(["Polygon", "MultiPolygon"])
         mask_line = objects.geom_type.isin(["LineString", "MultiLineString"])


### PR DESCRIPTION
While using the new `voronoi_frames` on a fairly large dataset, I noticed this issue libgeos/geos#1062 plus another where some polygons coming from GEOS were not actually valid, likely due to the same reason. This is a workaround that solves all I faced. 

