### PR TITLE
REF: minor performance improvements in Graph

### DIFF
--- a/libpysal/graph/_spatial_lag.py
+++ b/libpysal/graph/_spatial_lag.py
@@ -22,4 +22,4 @@ def _lag_spatial(graph, y):
             "The length of `y` needs to match the number of observations "
             f"in Graph. Expected {sp.shape[0]}, got {len(y)}."
         )
-    return graph.sparse @ y
+    return sp @ y

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -191,7 +191,7 @@ class Graph(SetOpsMixin):
         libpysal.weights.W
             representation of graph as a weights.W object
         """
-        grouper = self._adjacency.groupby(level=0)
+        grouper = self._adjacency.groupby(level=0, sort=False)
         neighbors = {}
         weights = {}
         for ix, chunk in grouper:
@@ -883,7 +883,7 @@ class Graph(SetOpsMixin):
         dict
             dict of tuples representing neighbors
         """
-        grouper = self._adjacency.groupby(level=0)
+        grouper = self._adjacency.groupby(level=0, sort=False)
         neighbors = {}
         for ix, chunk in grouper:
             if ix in self.isolates:
@@ -906,7 +906,7 @@ class Graph(SetOpsMixin):
         dict
             dict of tuples representing weights
         """
-        grouper = self._adjacency.groupby(level=0)
+        grouper = self._adjacency.groupby(level=0, sort=False)
         weights = {}
         for ix, chunk in grouper:
             if ix in self.isolates:

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -3,6 +3,8 @@ from functools import cached_property
 
 import numpy as np
 import pandas as pd
+from packaging.version import Version
+from scipy import __version__ as scipy_version
 from scipy import sparse
 
 from libpysal.weights import W
@@ -881,18 +883,14 @@ class Graph(SetOpsMixin):
         dict
             dict of tuples representing neighbors
         """
-        return (
-            self._adjacency.reset_index(level=1)
-            .groupby(level=0)
-            .apply(
-                lambda group: tuple(
-                    group[
-                        ~((group.index == group.neighbor) & (group.weight == 0))
-                    ].neighbor
-                )
-            )
-            .to_dict()
-        )
+        grouper = self._adjacency.groupby(level=0)
+        neighbors = {}
+        for ix, chunk in grouper:
+            if ix in self.isolates:
+                neighbors[ix] = ()
+            else:
+                neighbors[ix] = tuple(chunk.index.get_level_values("neighbor"))
+        return neighbors
 
     @cached_property
     def weights(self):
@@ -908,30 +906,26 @@ class Graph(SetOpsMixin):
         dict
             dict of tuples representing weights
         """
-        return (
-            self._adjacency.reset_index(level=1)
-            .groupby(level=0)
-            .apply(
-                lambda group: tuple(
-                    group[
-                        ~((group.index == group.neighbor) & (group.weight == 0))
-                    ].weight
-                )
-            )
-            .to_dict()
-        )
+        grouper = self._adjacency.groupby(level=0)
+        weights = {}
+        for ix, chunk in grouper:
+            if ix in self.isolates:
+                weights[ix] = ()
+            else:
+                weights[ix] = tuple(chunk)
+        return weights
 
     @cached_property
     def sparse(self):
-        """Return a scipy.sparse array (COO)
+        """Return a scipy.sparse array (CSR)
 
         Returns
         -------
-        scipy.sparse.COO
+        scipy.sparse.CSR
             sparse representation of the adjacency
         """
-        # pivot to COO sparse matrix and cast to array
-        return sparse.coo_array(
+        # pivot to COO sparse matrix and cast to sparse CRS array
+        return sparse.csr_array(
             self._adjacency.astype("Sparse[float]").sparse.to_coo(sort_labels=True)[0]
         )
 
@@ -1006,8 +1000,7 @@ class Graph(SetOpsMixin):
     @cached_property
     def _components(self):
         """helper for n_components and component_labels"""
-        # TODO: remove casting to matrix once scipy supports arrays here
-        return sparse.csgraph.connected_components(sparse.coo_matrix(self.sparse))
+        return sparse.csgraph.connected_components(self.sparse)
 
     @cached_property
     def n_components(self):
@@ -1185,23 +1178,24 @@ class Graph(SetOpsMixin):
         Graph
             higher order weights
         """
-        # TODO: remove casting to matrix once scipy implements matrix_power on array.
-        # [https://github.com/scipy/scipy/pull/18544]
+        if not Version(scipy_version) >= Version("1.12.0"):
+            raise ImportError("Graph.higher_order() requires scipy>=1.12.0.")
+
         binary = self.transform("B")
-        sp = sparse.csr_matrix(binary.sparse)
+        sp = binary.sparse
 
         if lower_order:
-            wk = sum(sp**x for x in range(2, k + 1))
+            wk = sum(sparse.linalg.matrix_power(sp, x) for x in range(2, k + 1))
             shortest_path = False
         else:
-            wk = sp**k
+            wk = sparse.linalg.matrix_power(sp, k)
 
         rk, ck = wk.nonzero()
         sk = set(zip(rk, ck, strict=True))
 
         if shortest_path:
             for j in range(1, k):
-                wj = sp**j
+                wj = sparse.linalg.matrix_power(sp, j)
                 rj, cj = wj.nonzero()
                 sj = set(zip(rj, cj, strict=True))
                 sk.difference_update(sj)

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -7,6 +7,8 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pytest
+from packaging.version import Version
+from scipy import __version__ as scipy_version
 from scipy import sparse
 
 from libpysal import graph, weights
@@ -856,6 +858,10 @@ class TestBase:
         with pytest.raises(ValueError, match="The length of `y`"):
             self.g_str.lag(list(range(1, 15)))
 
+    @pytest.mark.skipif(
+        Version(scipy_version) < Version("1.12.0"),
+        reason="sparse matrix power requires scipy>=1.12.0",
+    )
     def test_higher_order(self):
         cont = graph.Graph.build_contiguity(self.nybb)
         k2 = cont.higher_order(2)


### PR DESCRIPTION
Follow up on #691 and conversion to `neighbors` and `weights` dicts as discussed there.

I am also changing the sparse format to CSR which is what we need for lag and generally anything else and what weights is using. That also allows cleaner implementation of `_components`.

Plus using `matrix_power` implementation for scipy sparse array (courtesy of @ljwolf) which allows us to skip conversion to sparse matrix.

Note that the change of the sparse representation is technically a hard-breaking change but given we're in experimental phase we can afford it.