### PR TITLE
add back `numba` in Py312 tests

### DIFF
--- a/ci/312-dev.yaml
+++ b/ci/312-dev.yaml
@@ -21,7 +21,7 @@ dependencies:
   - geos
   - joblib
   - networkx
-  # - numba # follow up when numba is ready for 3.12
+  - numba
   - packaging
   - pyarrow
   - pyproj

--- a/ci/312.yaml
+++ b/ci/312.yaml
@@ -23,7 +23,7 @@ dependencies:
   - geodatasets
   - joblib
   - networkx
-  # - numba # follow up when numba is ready for 3.12
+  - numba
   - pyarrow
   - scikit-learn
   - sqlalchemy


### PR DESCRIPTION
This PR adds back `numba` into the Python 3.12 tests.

* resolves https://github.com/pysal/libpysal/issues/590
* xref
  * https://github.com/pysal/libpysal/pull/585
  *  https://github.com/numba/numba/issues/9197#issuecomment-1923489918