### PR TITLE
BUG: misaligned weights in the gabriel graph

### DIFF
--- a/libpysal/graph/_triangulation.py
+++ b/libpysal/graph/_triangulation.py
@@ -283,8 +283,11 @@ def _gabriel(coordinates):
     heads_ix, tails_ix = numpy.row_stack(
         list(set(map(tuple, edges)).difference(set(droplist)))
     ).T
+    order = numpy.lexsort((tails_ix, heads_ix))
+    sorted_heads_ix = heads_ix[order]
+    sorted_tails_ix = tails_ix[order]
 
-    return heads_ix, tails_ix
+    return sorted_heads_ix, sorted_tails_ix
 
 
 @_validate_coincident

--- a/libpysal/graph/tests/test_builders.py
+++ b/libpysal/graph/tests/test_builders.py
@@ -190,6 +190,23 @@ class TestTriangulation:
                 self.gdf, method="invalid", kernel="parabolic", bandwidth=7500
             )
 
+    def test_delunay_subsets(self):
+        delaunay = graph.Graph.build_triangulation(
+            self.gdf_str, "delaunay", kernel="identity"
+        )
+        gabriel = graph.Graph.build_triangulation(
+            self.gdf_str, "gabriel", kernel="identity"
+        )
+        rn = graph.Graph.build_triangulation(
+            self.gdf_str, "relative_neighborhood", kernel="identity"
+        )
+        pd.testing.assert_series_equal(
+            gabriel.adjacency, delaunay.adjacency.loc[gabriel.adjacency.index]
+        )
+        pd.testing.assert_series_equal(
+            rn.adjacency, delaunay.adjacency.loc[rn.adjacency.index]
+        )
+
 
 class TestKernel:
     def setup_method(self):


### PR DESCRIPTION
Found a bug in Gabriel graph. heads and tails come unsorted from filtering, resulting in misaligned weights. See repr:

```py
import geopandas
from libpysal.graph import Graph
import momepy

blgs = geopandas.read_file(momepy.datasets.get_path('bubenec'), layer='buildings')

delaunay = Graph.build_triangulation(blgs.centroid, "delaunay", kernel="identity")
gabriel = Graph.build_triangulation(blgs.centroid, "gabriel", kernel="identity")
relative = Graph.build_triangulation(blgs.centroid, "relative_neighborhood", kernel="identity")

>>> delaunay[48]
neighbor
46      24.357863
47      32.418353
49      49.764015
74     155.698588
75      99.914953
141     93.302955
Name: weight, dtype: float64

>>> gabriel[48]
neighbor
46    128.634198
47     24.117386
Name: weight, dtype: float64

>>> relative[48]
neighbor
46    24.357863
47    32.418353
Name: weight, dtype: float64
```

It should be a subset of Delaunay, not alter the value.