### PR TITLE
PERF: don't build coincident lookup if not needed

### DIFF
--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -211,8 +211,7 @@ def _knn(coordinates, metric="euclidean", k=1, p=2, coincident="raise"):
     coordinates, ids, geoms = _validate_geometry_input(
         coordinates, ids=None, valid_geometry_types=_VALID_GEOMETRY_TYPES
     )
-    n_coincident, coincident_lut = _build_coincidence_lookup(geoms)
-    max_at_one_site = coincident_lut.input_index.str.len().max()
+    n_coincident = geoms.geometry.duplicated().sum()
     n_samples, _ = coordinates.shape
 
     if n_coincident == 0:
@@ -234,6 +233,8 @@ def _knn(coordinates, metric="euclidean", k=1, p=2, coincident="raise"):
         )
         return d
     else:
+        coincident_lut = _build_coincidence_lookup(geoms)
+        max_at_one_site = coincident_lut.input_index.str.len().max()
         if coincident == "raise":
             raise ValueError(
                 f"There are {len(coincident_lut)} unique locations in the dataset, "

--- a/libpysal/graph/_triangulation.py
+++ b/libpysal/graph/_triangulation.py
@@ -58,10 +58,11 @@ def _validate_coincident(triangulator):
         )
 
         # check for coincident points
-        n_coincident, coincident_lut = _build_coincidence_lookup(geoms)
+        n_coincident = geoms.geometry.duplicated().sum()
 
         # resolve coincident points prior triangulation
         if n_coincident > 0:
+            coincident_lut = _build_coincidence_lookup(geoms)
             if coincident == "raise":
                 raise ValueError(
                     f"There are {len(coincident_lut)} unique locations in "
@@ -129,7 +130,7 @@ def _validate_coincident(triangulator):
             coordinates, ids, geoms = input_coordinates, input_ids, input_geoms
             heads, tails, weights = adjtable.values.T
 
-        adjtable = _reorder_adjtable_by_ids(adjtable, ids)
+            adjtable = _reorder_adjtable_by_ids(adjtable, ids)
 
         # return data for Graph.from_arrays
         return adjtable.focal.values, adjtable.neighbor.values, adjtable.weight.values

--- a/libpysal/graph/_utils.py
+++ b/libpysal/graph/_utils.py
@@ -144,7 +144,6 @@ def _build_coincidence_lookup(geoms):
             "coindicence checks are only well-defined for "
             f"geom_types: {valid_coincident_geom_types}"
         )
-    max_coincident = geoms.geometry.duplicated().sum()
     if GPD_013:
         lut = (
             geoms.to_frame("geometry")
@@ -165,7 +164,7 @@ def _build_coincidence_lookup(geoms):
         lut["geometry"] = geopandas.GeoSeries.from_wkb(lut["geometry"])
 
     lut = geopandas.GeoDataFrame(lut)
-    return max_coincident, lut.rename(columns={"index": "input_index"})
+    return lut.rename(columns={"index": "input_index"})
 
 
 def _validate_geometry_input(geoms, ids=None, valid_geometry_types=None):


### PR DESCRIPTION
I was building some triangulation graphs on a fairly large data (150k points)  and it took 25 minutes. I figured that vast majority of time was consumed by the handing of coincident points, even though there were no coincident points in the whole dataset. With this PR, the same Gabriel graph took 7s.

See the timings on a repr:

```py
coords = np.random.rand(10000, 2)

g = Graph.build_triangulation(coords, kernel="identity")
# main: 10 s ± 58.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# this PR: 193 ms ± 1.81 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

The tests on this will fail until #709 is merged.