### PR TITLE
Refactor handling of coincident points in triangulation

### DIFF
--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -3,6 +3,7 @@ import pandas
 from scipy import optimize, sparse, spatial, stats
 
 from ._utils import (
+    CoplanarError,
     _build_coplanarity_lookup,
     _induce_cliques,
     _jitter_geoms,
@@ -239,7 +240,7 @@ def _knn(coordinates, metric="euclidean", k=1, p=2, coplanar="raise"):
         coplanar_lut = _build_coplanarity_lookup(geoms)
         max_at_one_site = coplanar_lut.input_index.str.len().max()
         if coplanar == "raise":
-            raise ValueError(
+            raise CoplanarError(
                 f"There are {len(coplanar_lut)} unique locations in the dataset, "
                 f"but {len(coordinates)} observations. At least one of these sites "
                 f"has {max_at_one_site} points, more than the {k} nearest neighbors "

--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -7,7 +7,6 @@ from ._utils import (
     _induce_cliques,
     _jitter_geoms,
     _reorder_adjtable_by_ids,
-    # _resolve_islands,
     _sparse_to_arrays,
     _validate_geometry_input,
 )
@@ -125,6 +124,8 @@ def _kernel(
         parameter for minkowski metric, ignored if metric != "minkowski".
     taper : bool (default: True)
         remove links with a weight equal to zero
+    resolve_isolates : bool
+        Try to resolve isolates. Can be disabled if we are dealing with cliques later.
     """
     if metric != "precomputed":
         coordinates, ids, _ = _validate_geometry_input(
@@ -202,11 +203,7 @@ def _kernel(
     if taper:
         d.eliminate_zeros()
 
-    heads, tails, weights = _sparse_to_arrays(
-        d, ids=ids, resolve_isolates=resolve_isolates
-    )
-
-    return heads, tails, weights
+    return _sparse_to_arrays(d, ids=ids, resolve_isolates=resolve_isolates)
 
 
 def _knn(coordinates, metric="euclidean", k=1, p=2, coincident="raise"):

--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -7,7 +7,7 @@ from ._utils import (
     _induce_cliques,
     _jitter_geoms,
     _reorder_adjtable_by_ids,
-    _resolve_islands,
+    # _resolve_islands,
     _sparse_to_arrays,
     _validate_geometry_input,
 )
@@ -79,6 +79,7 @@ def _kernel(
     p=2,
     taper=True,
     coincident="raise",
+    resolve_isolates=True,
 ):
     """
     Compute a kernel function over a distance matrix.
@@ -201,9 +202,11 @@ def _kernel(
     if taper:
         d.eliminate_zeros()
 
-    heads, tails, weights = _sparse_to_arrays(d, ids=ids)
+    heads, tails, weights = _sparse_to_arrays(
+        d, ids=ids, resolve_isolates=resolve_isolates
+    )
 
-    return _resolve_islands(heads, tails, ids, weights)
+    return heads, tails, weights
 
 
 def _knn(coordinates, metric="euclidean", k=1, p=2, coincident="raise"):

--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -211,6 +211,9 @@ def _knn(coordinates, metric="euclidean", k=1, p=2, coincident="raise"):
     coordinates, ids, geoms = _validate_geometry_input(
         coordinates, ids=None, valid_geometry_types=_VALID_GEOMETRY_TYPES
     )
+    if coincident == "jitter":
+        coordinates, geoms = _jitter_geoms(coordinates, geoms=geoms)
+
     n_coincident = geoms.geometry.duplicated().sum()
     n_samples, _ = coordinates.shape
 

--- a/libpysal/graph/_triangulation.py
+++ b/libpysal/graph/_triangulation.py
@@ -110,29 +110,6 @@ def _validate_coplanar(triangulator):
             adjtable["neighbor"] = ids[adjtable.neighbor]
 
             adjtable = _reorder_adjtable_by_ids(adjtable, ids)
-            # coplanar_addition = []
-            # coplanar, _, nearest = coplanar.T
-            # for c, n in zip(coplanar, nearest, strict=True):
-            #     neighbors = edges[:, 1][edges[:, 0] == n]
-            #     for n_ in neighbors:
-            #         fill = weights[(heads_ix == n) & (tails_ix == n_)].item()
-            #         coplanar_addition.append([c, n_, fill])
-            #         coplanar_addition.append([n_, c, fill])
-            #     coplanar_addition.append([c, n, fill_value])
-            #     coplanar_addition.append([n, c, fill_value])
-            # adjtable_filled = pandas.concat(
-            #     [
-            #         adjtable,
-            #         pandas.DataFrame(
-            #             coplanar_addition, columns=["focal", "neighbor", "weight"]
-            #         ),
-            #     ],
-            #     ignore_index=True,
-            # )
-            # adjtable_filled["focal"] = ids[adjtable_filled.focal]
-            # adjtable_filled["neighbor"] = ids[adjtable_filled.neighbor]
-
-            # adjtable = _reorder_adjtable_by_ids(adjtable_filled, ids)
         else:
             adjtable["focal"] = ids[adjtable.focal]
             adjtable["neighbor"] = ids[adjtable.neighbor]

--- a/libpysal/graph/_triangulation.py
+++ b/libpysal/graph/_triangulation.py
@@ -10,8 +10,6 @@ from libpysal.cg import voronoi_frames
 from ._contiguity import _vertex_set_intersection
 from ._kernel import _kernel, _kernel_functions, _optimize_bandwidth
 from ._utils import (
-    # _build_coincidence_lookup,
-    # _induce_cliques,
     _jitter_geoms,
     _reorder_adjtable_by_ids,
     _validate_geometry_input,

--- a/libpysal/graph/_triangulation.py
+++ b/libpysal/graph/_triangulation.py
@@ -66,7 +66,7 @@ def _validate_coplanar(triangulator):
             coordinates = _jitter_geoms(coordinates, seed=seed)
 
         # generate triangulation (triangulator is the wrapped function)
-        heads_ix, tails_ix, coplanar, edges = triangulator(
+        heads_ix, tails_ix, coplanar_loopkup, edges = triangulator(
             coordinates, coplanar, **kwargs
         )
 
@@ -94,7 +94,7 @@ def _validate_coplanar(triangulator):
         )
 
         # reinsert points resolved via clique
-        if (coplanar.shape[0] > 0) & (coplanar == "clique"):
+        if (coplanar_loopkup.shape[0] > 0) & (coplanar == "clique"):
             # Note that the kernel is only used to compute a fill value for the clique.
             # In the case of the voronoi weights. Using boxcar with an infinite
             # bandwidth also gives us the correct fill value for the voronoi weight: 1.
@@ -104,7 +104,7 @@ def _validate_coplanar(triangulator):
                 fill_value = _kernel_functions[kernel](
                     numpy.array([0]), bandwidth
                 ).item()
-            coplanar, _, nearest = coplanar.T
+            coplanar, _, nearest = coplanar_loopkup.T
             adjtable = _induce_cliques2(adjtable, coplanar, nearest, edges, fill_value)
             adjtable["focal"] = ids[adjtable.focal]
             adjtable["neighbor"] = ids[adjtable.neighbor]

--- a/libpysal/graph/_triangulation.py
+++ b/libpysal/graph/_triangulation.py
@@ -11,7 +11,7 @@ from ._contiguity import _vertex_set_intersection
 from ._kernel import _kernel, _kernel_functions, _optimize_bandwidth
 from ._utils import (
     CoplanarError,
-    _induce_cliques2,
+    _induce_cliques,
     _jitter_geoms,
     _reorder_adjtable_by_ids,
     _validate_geometry_input,
@@ -66,7 +66,7 @@ def _validate_coplanar(triangulator):
             coordinates = _jitter_geoms(coordinates, seed=seed)
 
         # generate triangulation (triangulator is the wrapped function)
-        heads_ix, tails_ix, coplanar_loopkup, edges = triangulator(
+        heads_ix, tails_ix, coplanar_loopkup = triangulator(
             coordinates, coplanar, **kwargs
         )
 
@@ -105,7 +105,7 @@ def _validate_coplanar(triangulator):
                     numpy.array([0]), bandwidth
                 ).item()
             coplanar, _, nearest = coplanar_loopkup.T
-            adjtable = _induce_cliques2(adjtable, coplanar, nearest, edges, fill_value)
+            adjtable = _induce_cliques(adjtable, coplanar, nearest, fill_value)
             adjtable["focal"] = ids[adjtable.focal]
             adjtable["neighbor"] = ids[adjtable.neighbor]
 
@@ -193,7 +193,7 @@ def _delaunay(coordinates, coplanar):
     edges, _, coplanar = _voronoi_edges(coordinates, coplanar)
     heads_ix, tails_ix = edges.T
 
-    return heads_ix, tails_ix, coplanar, edges
+    return heads_ix, tails_ix, coplanar
 
 
 @_validate_coplanar
@@ -268,7 +268,7 @@ def _gabriel(coordinates, coplanar):
     sorted_heads_ix = heads_ix[order]
     sorted_tails_ix = tails_ix[order]
 
-    return sorted_heads_ix, sorted_tails_ix, coplanar, edges
+    return sorted_heads_ix, sorted_tails_ix, coplanar
 
 
 @_validate_coplanar
@@ -336,7 +336,7 @@ def _relative_neighborhood(coordinates, coplanar):
     heads_ix, tails_ix, distance = zip(*output, strict=True)
     heads_ix, tails_ix = numpy.asarray(heads_ix), numpy.asarray(tails_ix)
 
-    return heads_ix, tails_ix, coplanar, numpy.row_stack([heads_ix, tails_ix]).T
+    return heads_ix, tails_ix, coplanar
 
 
 @_validate_coplanar
@@ -422,7 +422,7 @@ def _voronoi(coordinates, coplanar, clip="bounding_box", rook=True):
     cells = voronoi_frames(coordinates, clip=clip, return_input=False, as_gdf=False)
     heads_ix, tails_ix, weights = _vertex_set_intersection(cells, rook=rook)
 
-    return heads_ix, tails_ix, numpy.array([]), numpy.array([])
+    return heads_ix, tails_ix, numpy.array([])
 
 
 #### utilities

--- a/libpysal/graph/_triangulation.py
+++ b/libpysal/graph/_triangulation.py
@@ -518,6 +518,8 @@ def _filter_relativehood(edges, coordinates, return_dkmax=False):
             if (i == k) or (j == k):
                 continue
             pk = coordinates[k]
+            if (pi == pk).all() or (pj == pk).all():  # coincident
+                continue
             dik = ((pi - pk) ** 2).sum() ** 0.5
             djk = ((pj - pk) ** 2).sum() ** 0.5
             dkmax = numpy.array([dik, djk]).max()

--- a/libpysal/graph/_utils.py
+++ b/libpysal/graph/_utils.py
@@ -144,7 +144,7 @@ def _build_coplanarity_lookup(geoms):
     geoms = geoms.reset_index(drop=True)
     coplanar = []
     nearest = []
-    r = geoms.groupby(geoms).groups
+    r = geoms.groupby(geoms).groups if GPD_013 else geoms.groupby(geoms.to_wkb()).groups
     for g in r.values():
         if len(g) == 2:
             coplanar.append(g[0])

--- a/libpysal/graph/_utils.py
+++ b/libpysal/graph/_utils.py
@@ -39,7 +39,7 @@ def _sparse_to_arrays(sparray, ids=None, resolve_isolates=True):
     return head, tail, data
 
 
-def _jitter_geoms(coordinates, geoms, seed=None):
+def _jitter_geoms(coordinates, geoms=None, seed=None):
     """
     Jitter geometries based on the smallest required movements to induce
     uniqueness. For each point, this samples a radius and angle uniformly
@@ -65,8 +65,13 @@ def _jitter_geoms(coordinates, geoms, seed=None):
     dy = r + np.cos(theta)
     # then adding the displacements
     coordinates = coordinates + np.column_stack((dx, dy))
-    geoms = geopandas.GeoSeries(geopandas.points_from_xy(*coordinates.T, crs=geoms.crs))
-    return coordinates, geoms
+    if geoms is not None:
+        geoms = geopandas.GeoSeries(
+            geopandas.points_from_xy(*coordinates.T, crs=geoms.crs)
+        )
+        return coordinates, geoms
+
+    return coordinates
 
 
 def _induce_cliques(adjtable, clique_to_members, fill_value=1):

--- a/libpysal/graph/_utils.py
+++ b/libpysal/graph/_utils.py
@@ -11,6 +11,8 @@ PANDAS_GE_21 = Version(pd.__version__) >= Version("2.1.0")
 
 
 class CoplanarError(ValueError):
+    """Custom ValueError raised when coplanar points are detected."""
+
     pass
 
 

--- a/libpysal/graph/_utils.py
+++ b/libpysal/graph/_utils.py
@@ -121,7 +121,7 @@ def _induce_cliques2(adjtable, coplanar, nearest, edges, fill_value=1):
     for c, n in zip(coplanar, nearest, strict=True):
         neighbors = edges[:, 1][edges[:, 0] == n]
         for n_ in neighbors:
-            fill = adjtable.weights[
+            fill = adjtable.weight[
                 (adjtable.focal == n) & (adjtable.neighbor == n_)
             ].item()
             coplanar_addition.append([c, n_, fill])

--- a/libpysal/graph/_utils.py
+++ b/libpysal/graph/_utils.py
@@ -11,7 +11,7 @@ GPD_013 = Version(geopandas.__version__) >= Version("0.13")
 PANDAS_GE_21 = Version(pd.__version__) >= Version("2.1.0")
 
 
-def _sparse_to_arrays(sparray, ids=None):
+def _sparse_to_arrays(sparray, ids=None, resolve_isolates=True):
     """Convert sparse array to arrays of adjacency"""
     sparray = sparray.tocoo(copy=False)
     if ids is not None:
@@ -32,7 +32,11 @@ def _sparse_to_arrays(sparray, ids=None):
         tail = sparray.col[sorter]
         data = sparray.data[sorter]
         ids = np.arange(sparray.shape[0], dtype=int)
-    return _resolve_islands(head, tail, ids, data)
+
+    if resolve_isolates:
+        return _resolve_islands(head, tail, ids, data)
+
+    return head, tail, data
 
 
 def _jitter_geoms(coordinates, geoms, seed=None):

--- a/libpysal/graph/_utils.py
+++ b/libpysal/graph/_utils.py
@@ -143,15 +143,15 @@ def _neighbor_dict_to_edges(neighbors, weights=None):
     return heads, tails, data_array
 
 
-def _build_coincidence_lookup(geoms):
+def _build_coplanarity_lookup(geoms):
     """
-    Identify coincident points and create a look-up table for the coincident geometries.
+    Identify coplanar points and create a look-up table for the coplanar geometries.
     """
-    valid_coincident_geom_types = set(("Point",))  # noqa: C405
-    if not set(geoms.geom_type) <= valid_coincident_geom_types:
+    valid_coplanar_geom_types = set(("Point",))  # noqa: C405
+    if not set(geoms.geom_type) <= valid_coplanar_geom_types:
         raise ValueError(
-            "coindicence checks are only well-defined for "
-            f"geom_types: {valid_coincident_geom_types}"
+            "Coplanarity checks are only well-defined for "
+            f"geom_types: {valid_coplanar_geom_types}"
         )
     if GPD_013:
         lut = (

--- a/libpysal/graph/_utils.py
+++ b/libpysal/graph/_utils.py
@@ -17,7 +17,11 @@ class CoplanarError(ValueError):
 
 
 def _sparse_to_arrays(sparray, ids=None, resolve_isolates=True):
-    """Convert sparse array to arrays of adjacency"""
+    """Convert sparse array to arrays of adjacency
+
+    When we know we are dealing with cliques, we don't want to resolve
+    isolates here but will do that later once cliques are induced.
+    """
     sparray = sparray.tocoo(copy=False)
     if ids is not None:
         ids = np.asarray(ids)

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -851,7 +851,7 @@ class Graph(SetOpsMixin):
         bandwidth=None,
         metric="euclidean",
         p=2,
-        coincident="raise",
+        coplanar="raise",
     ):
         """Generate Graph from geometry data based on a kernel function
 
@@ -892,11 +892,11 @@ class Graph(SetOpsMixin):
             only euclidean, minkowski, and manhattan/cityblock distances are admitted.
         p : int (default: 2)
             parameter for minkowski metric, ignored if metric != "minkowski".
-        coincident: str, optional (default "raise")
-            Method for handling coincident points when ``k`` is not None. Options are
-            ``'raise'`` (raising an exception when coincident points are present),
-            ``'jitter'`` (randomly displace coincident points to produce uniqueness), &
-            ``'clique'`` (induce fully-connected sub cliques for coincident points).
+        coplanar: str, optional (default "raise")
+            Method for handling coplanar points when ``k`` is not None. Options are
+            ``'raise'`` (raising an exception when coplanar points are present),
+            ``'jitter'`` (randomly displace coplanar points to produce uniqueness), &
+            ``'clique'`` (induce fully-connected sub cliques for coplanar points).
 
         Returns
         -------
@@ -913,13 +913,13 @@ class Graph(SetOpsMixin):
             k=k,
             p=p,
             ids=ids,
-            coincident=coincident,
+            coplanar=coplanar,
         )
 
         return cls.from_arrays(head, tail, weight)
 
     @classmethod
-    def build_knn(cls, data, k, metric="euclidean", p=2, coincident="raise"):
+    def build_knn(cls, data, k, metric="euclidean", p=2, coplanar="raise"):
         """Generate Graph from geometry data based on k-nearest neighbors search
 
         Parameters
@@ -939,11 +939,11 @@ class Graph(SetOpsMixin):
             only euclidean, minkowski, and manhattan/cityblock distances are admitted.
         p : int (default: 2)
             parameter for minkowski metric, ignored if metric != "minkowski".
-        coincident: str, optional (default "raise")
-            Method for handling coincident points. Options include
-            ``'raise'`` (raising an exception when coincident points are present),
-            ``'jitter'`` (randomly displace coincident points to produce uniqueness), &
-            ``'clique'`` (induce fully-connected sub cliques for coincident points).
+        coplanar: str, optional (default "raise")
+            Method for handling coplanar points. Options include
+            ``'raise'`` (raising an exception when coplanar points are present),
+            ``'jitter'`` (randomly displace coplanar points to produce uniqueness), &
+            ``'clique'`` (induce fully-connected sub cliques for coplanar points).
 
 
         Returns
@@ -1008,7 +1008,7 @@ class Graph(SetOpsMixin):
             k=k,
             p=p,
             ids=ids,
-            coincident=coincident,
+            coplanar=coplanar,
         )
 
         return cls.from_arrays(head, tail, weight)
@@ -1094,7 +1094,7 @@ class Graph(SetOpsMixin):
         kernel="boxcar",
         clip="bounding_box",
         rook=True,
-        coincident="raise",
+        coplanar="raise",
     ):
         """Generate Graph from geometry based on triangulation
 
@@ -1142,11 +1142,11 @@ class Graph(SetOpsMixin):
             If True, two geometries are considered neighbours if they
             share at least one edge. If False, two geometries are considered neighbours
             if they share at least one vertex. By default True
-        coincident: str, optional (default "raise")
-            Method for handling coincident points. Options include
-            ``'raise'`` (raising an exception when coincident points are present),
-            ``'jitter'`` (randomly displace coincident points to produce uniqueness), &
-            ``'clique'`` (induce fully-connected sub cliques for coincident points).
+        coplanar: str, optional (default "raise")
+            Method for handling coplanar points. Options include
+            ``'raise'`` (raising an exception when coplanar points are present),
+            ``'jitter'`` (randomly displace coplanar points to produce uniqueness), &
+            ``'clique'`` (induce fully-connected sub cliques for coplanar points).
 
         Returns
         -------
@@ -1195,19 +1195,19 @@ class Graph(SetOpsMixin):
 
         if method == "delaunay":
             head, tail, weights = _delaunay(
-                data, ids=ids, bandwidth=bandwidth, kernel=kernel, coincident=coincident
+                data, ids=ids, bandwidth=bandwidth, kernel=kernel, coplanar=coplanar
             )
         elif method == "gabriel":
             head, tail, weights = _gabriel(
-                data, ids=ids, bandwidth=bandwidth, kernel=kernel, coincident=coincident
+                data, ids=ids, bandwidth=bandwidth, kernel=kernel, coplanar=coplanar
             )
         elif method == "relative_neighborhood":
             head, tail, weights = _relative_neighborhood(
-                data, ids=ids, bandwidth=bandwidth, kernel=kernel, coincident=coincident
+                data, ids=ids, bandwidth=bandwidth, kernel=kernel, coplanar=coplanar
             )
         elif method == "voronoi":
             head, tail, weights = _voronoi(
-                data, ids=ids, clip=clip, rook=rook, coincident=coincident
+                data, ids=ids, clip=clip, rook=rook, coplanar=coplanar
             )
         else:
             raise ValueError(

--- a/libpysal/graph/tests/test_builders.py
+++ b/libpysal/graph/tests/test_builders.py
@@ -265,14 +265,14 @@ class TestKernel:
         assert pd.api.types.is_numeric_dtype(g._adjacency.dtype)
 
     def test_knn_intids(self):
-        g = graph.Graph.build_knn(self.gdf, k=3, coincident="jitter")
+        g = graph.Graph.build_knn(self.gdf, k=3, coplanar="jitter")
 
         assert pd.api.types.is_numeric_dtype(g._adjacency.index.dtypes["focal"])
         assert pd.api.types.is_numeric_dtype(g._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(g._adjacency.dtype)
 
     def test_knn_strids(self):
-        g = graph.Graph.build_kernel(self.gdf_str, k=3, coincident="jitter")
+        g = graph.Graph.build_kernel(self.gdf_str, k=3, coplanar="jitter")
 
         assert pd.api.types.is_string_dtype(g._adjacency.index.dtypes["focal"])
         assert pd.api.types.is_string_dtype(g._adjacency.index.dtypes["neighbor"])

--- a/libpysal/graph/tests/test_kernel.py
+++ b/libpysal/graph/tests/test_kernel.py
@@ -299,7 +299,7 @@ def test_metric_k(metric):
 #     raise NotImplementedError()
 
 
-def test_coincident():
+def test_coplanar():
     grocs_duplicated = pd.concat(
         [grocs, grocs.iloc[:10], grocs.iloc[:3]], ignore_index=True
     )
@@ -315,16 +315,14 @@ def test_coincident():
         _kernel(grocs_duplicated, k=2)
 
     # k, jitter
-    head, tail, weight = _kernel(
-        grocs_duplicated, taper=False, k=2, coincident="jitter"
-    )
+    head, tail, weight = _kernel(grocs_duplicated, taper=False, k=2, coplanar="jitter")
     assert head.shape[0] == len(grocs_duplicated) * 2
     assert tail.shape == head.shape
     assert weight.shape == head.shape
     np.testing.assert_array_equal(pd.unique(head), grocs_duplicated.index)
 
     # k, clique
-    head, tail, weight = _kernel(grocs_duplicated, k=2, coincident="clique")
+    head, tail, weight = _kernel(grocs_duplicated, k=2, coplanar="clique")
     assert head.shape[0] >= len(grocs_duplicated) * 2
     assert tail.shape == head.shape
     assert weight.shape == head.shape

--- a/libpysal/graph/tests/test_kernel.py
+++ b/libpysal/graph/tests/test_kernel.py
@@ -22,6 +22,7 @@ from libpysal.graph._kernel import (
     _kernel,
     _kernel_functions,
 )
+from libpysal.graph._utils import CoplanarError
 
 grocs = geopandas.read_file(geodatasets.get_path("geoda groceries"))[
     ["OBJECTID", "geometry"]
@@ -311,7 +312,7 @@ def test_coplanar():
     np.testing.assert_array_equal(pd.unique(head), grocs_duplicated.index)
 
     # k, raise
-    with pytest.raises(ValueError, match="There are"):
+    with pytest.raises(CoplanarError, match="There are"):
         _kernel(grocs_duplicated, k=2)
 
     # k, jitter

--- a/libpysal/graph/tests/test_triangulation.py
+++ b/libpysal/graph/tests/test_triangulation.py
@@ -23,6 +23,7 @@ from libpysal.graph._triangulation import (
     _relative_neighborhood,
     _voronoi,
 )
+from libpysal.graph._utils import CoplanarError
 from libpysal.graph.base import Graph
 
 stores = geopandas.read_file(geodatasets.get_path("geoda liquor_stores")).explode(
@@ -305,7 +306,7 @@ class Testcoplanar:
 
     def test_delaunay_error(self):
         with pytest.raises(
-            ValueError,
+            CoplanarError,
             match="There are 5 unique locations in the dataset, but 6 observations",
         ):
             _delaunay(self.df_int)
@@ -353,7 +354,7 @@ class Testcoplanar:
 
     def test_gabriel_error(self):
         with pytest.raises(
-            ValueError,
+            CoplanarError,
             match="There are 5 unique locations in the dataset, but 6 observations",
         ):
             _gabriel(self.df_int)
@@ -393,7 +394,7 @@ class Testcoplanar:
 
     def test_relative_neighborhood_error(self):
         with pytest.raises(
-            ValueError,
+            CoplanarError,
             match="There are 5 unique locations in the dataset, but 6 observations",
         ):
             _relative_neighborhood(self.df_int)
@@ -439,7 +440,7 @@ class Testcoplanar:
 
     def test_voronoi_error(self):
         with pytest.raises(
-            ValueError,
+            CoplanarError,
             match="There are 5 unique locations in the dataset, but 6 observations",
         ):
             _voronoi(self.df_int)

--- a/libpysal/graph/tests/test_triangulation.py
+++ b/libpysal/graph/tests/test_triangulation.py
@@ -332,7 +332,7 @@ class TestCoincident:
 
     def test_delaunay_clique(self):
         # TODO: fix the implemntation to make this pass
-        heads, tails, weights = _delaunay(self.df_int, coincident="clique", seed=0)
+        heads, tails, weights = _delaunay(self.df_int, coincident="clique")
 
         exp_heads = np.array(
             [0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5]
@@ -345,7 +345,7 @@ class TestCoincident:
         np.testing.assert_array_equal(heads, exp_heads)
         np.testing.assert_array_equal(tails, exp_tails)
 
-        heads, tails, weights = _delaunay(self.df_string, coincident="clique", seed=0)
+        heads, tails, weights = _delaunay(self.df_string, coincident="clique")
 
         np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
         np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
@@ -376,7 +376,7 @@ class TestCoincident:
 
     def test_gabriel_clique(self):
         # TODO: fix the implemntation to make this pass
-        heads, tails, weights = _gabriel(self.df_int, coincident="clique", seed=0)
+        heads, tails, weights = _gabriel(self.df_int, coincident="clique")
 
         exp_heads = np.array([0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 4, 5])
         exp_tails = np.array([1, 2, 4, 0, 2, 3, 4, 5, 0, 1, 3, 4, 1, 2, 0, 1, 2, 1])
@@ -385,7 +385,7 @@ class TestCoincident:
         np.testing.assert_array_equal(heads, exp_heads)
         np.testing.assert_array_equal(tails, exp_tails)
 
-        heads, tails, weights = _gabriel(self.df_string, coincident="clique", seed=0)
+        heads, tails, weights = _gabriel(self.df_string, coincident="clique")
 
         np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
         np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
@@ -420,9 +420,7 @@ class TestCoincident:
 
     def test_relative_neighborhood_clique(self):
         # TODO: fix the implemntation to make this pass
-        heads, tails, weights = _relative_neighborhood(
-            self.df_int, coincident="clique", seed=0
-        )
+        heads, tails, weights = _relative_neighborhood(self.df_int, coincident="clique")
 
         exp_heads = np.array([0, 0, 1, 1, 1, 1, 2, 2, 3, 4, 4, 5])
         exp_tails = np.array([1, 4, 0, 2, 4, 5, 1, 3, 2, 0, 1, 1])
@@ -432,7 +430,7 @@ class TestCoincident:
         np.testing.assert_array_equal(tails, exp_tails)
 
         heads, tails, weights = _relative_neighborhood(
-            self.df_string, coincident="clique", seed=0
+            self.df_string, coincident="clique"
         )
 
         np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))

--- a/libpysal/graph/tests/test_triangulation.py
+++ b/libpysal/graph/tests/test_triangulation.py
@@ -98,9 +98,9 @@ parametrize_constructors = pytest.mark.parametrize(
 
 
 def test_correctness_voronoi_clipping():
-    noclip = _voronoi(lap_coords, clip=None, rook=True)
-    extent = _voronoi(lap_coords, clip="bounding_box", rook=True)
-    alpha = _voronoi(lap_coords, clip="alpha_shape", rook=True)
+    noclip = _voronoi(lap_coords, coincident="raise", clip=None, rook=True)
+    extent = _voronoi(lap_coords, coincident="raise", clip="bounding_box", rook=True)
+    alpha = _voronoi(lap_coords, coincident="raise", clip="alpha_shape", rook=True)
 
     g_noclip = Graph.from_arrays(*noclip)
     g_extent = Graph.from_arrays(*extent)

--- a/libpysal/graph/tests/test_triangulation.py
+++ b/libpysal/graph/tests/test_triangulation.py
@@ -286,7 +286,7 @@ def test_coplanar_jitter_voronoi():
     assert unique_heads.shape[0] == 3360
 
 
-class Testcoplanar:
+class TestCoplanar:
     def setup_method(self):
         self.geom = [
             shapely.Point(0, 0),

--- a/libpysal/graph/tests/test_triangulation.py
+++ b/libpysal/graph/tests/test_triangulation.py
@@ -98,9 +98,9 @@ parametrize_constructors = pytest.mark.parametrize(
 
 
 def test_correctness_voronoi_clipping():
-    noclip = _voronoi(lap_coords, coincident="raise", clip=None, rook=True)
-    extent = _voronoi(lap_coords, coincident="raise", clip="bounding_box", rook=True)
-    alpha = _voronoi(lap_coords, coincident="raise", clip="alpha_shape", rook=True)
+    noclip = _voronoi(lap_coords, coplanar="raise", clip=None, rook=True)
+    extent = _voronoi(lap_coords, coplanar="raise", clip="bounding_box", rook=True)
+    alpha = _voronoi(lap_coords, coplanar="raise", clip="alpha_shape", rook=True)
 
     g_noclip = Graph.from_arrays(*noclip)
     g_extent = Graph.from_arrays(*extent)
@@ -269,13 +269,13 @@ def test_kernel():
     np.testing.assert_array_almost_equal(expected, weight)
 
 
-def test_coincident_raise_voronoi():
+def test_coplanar_raise_voronoi():
     with pytest.raises(ValueError, match="There are"):
         _voronoi(stores, clip=False)
 
 
-def test_coincident_jitter_voronoi():
-    cp_heads, cp_tails, cp_w = _voronoi(stores, clip=False, coincident="jitter")
+def test_coplanar_jitter_voronoi():
+    cp_heads, cp_tails, cp_w = _voronoi(stores, clip=False, coplanar="jitter")
     unique_heads, unique_tails, unique_w = _voronoi(stores_unique, clip=False)
     assert not np.array_equal(cp_heads, unique_heads)
     assert not np.array_equal(cp_tails, unique_tails)
@@ -285,14 +285,14 @@ def test_coincident_jitter_voronoi():
     assert unique_heads.shape[0] == 3360
 
 
-class TestCoincident:
+class Testcoplanar:
     def setup_method(self):
         self.geom = [
             shapely.Point(0, 0),
             shapely.Point(1, 1),
             shapely.Point(2, 0),
             shapely.Point(3, 1),
-            shapely.Point(0, 0),  # coincident point
+            shapely.Point(0, 0),  # coplanar point
             shapely.Point(0, 5),
         ]
         self.df_int = geopandas.GeoDataFrame(
@@ -311,7 +311,7 @@ class TestCoincident:
             _delaunay(self.df_int)
 
     def test_delaunay_jitter(self):
-        heads, tails, weights = _delaunay(self.df_int, coincident="jitter", seed=0)
+        heads, tails, weights = _delaunay(self.df_int, coplanar="jitter", seed=0)
 
         exp_heads = np.array(
             [0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5]
@@ -324,7 +324,7 @@ class TestCoincident:
         np.testing.assert_array_equal(heads, exp_heads)
         np.testing.assert_array_equal(tails, exp_tails)
 
-        heads, tails, weights = _delaunay(self.df_string, coincident="jitter", seed=0)
+        heads, tails, weights = _delaunay(self.df_string, coplanar="jitter", seed=0)
 
         np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
         np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
@@ -332,7 +332,7 @@ class TestCoincident:
 
     def test_delaunay_clique(self):
         # TODO: fix the implemntation to make this pass
-        heads, tails, weights = _delaunay(self.df_int, coincident="clique")
+        heads, tails, weights = _delaunay(self.df_int, coplanar="clique")
 
         exp_heads = np.array(
             [0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5]
@@ -345,7 +345,7 @@ class TestCoincident:
         np.testing.assert_array_equal(heads, exp_heads)
         np.testing.assert_array_equal(tails, exp_tails)
 
-        heads, tails, weights = _delaunay(self.df_string, coincident="clique")
+        heads, tails, weights = _delaunay(self.df_string, coplanar="clique")
 
         np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
         np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
@@ -359,7 +359,7 @@ class TestCoincident:
             _gabriel(self.df_int)
 
     def test_gabriel_jitter(self):
-        heads, tails, weights = _gabriel(self.df_int, coincident="jitter", seed=0)
+        heads, tails, weights = _gabriel(self.df_int, coplanar="jitter", seed=0)
 
         exp_heads = np.array([0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5])
         exp_tails = np.array([2, 4, 2, 3, 4, 5, 0, 1, 3, 1, 2, 5, 0, 1, 1, 3])
@@ -368,7 +368,7 @@ class TestCoincident:
         np.testing.assert_array_equal(heads, exp_heads)
         np.testing.assert_array_equal(tails, exp_tails)
 
-        heads, tails, weights = _gabriel(self.df_string, coincident="jitter", seed=0)
+        heads, tails, weights = _gabriel(self.df_string, coplanar="jitter", seed=0)
 
         np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
         np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
@@ -376,7 +376,7 @@ class TestCoincident:
 
     def test_gabriel_clique(self):
         # TODO: fix the implemntation to make this pass
-        heads, tails, weights = _gabriel(self.df_int, coincident="clique")
+        heads, tails, weights = _gabriel(self.df_int, coplanar="clique")
 
         exp_heads = np.array([0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 4, 5])
         exp_tails = np.array([1, 2, 4, 0, 2, 3, 4, 5, 0, 1, 3, 4, 1, 2, 0, 1, 2, 1])
@@ -385,7 +385,7 @@ class TestCoincident:
         np.testing.assert_array_equal(heads, exp_heads)
         np.testing.assert_array_equal(tails, exp_tails)
 
-        heads, tails, weights = _gabriel(self.df_string, coincident="clique")
+        heads, tails, weights = _gabriel(self.df_string, coplanar="clique")
 
         np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
         np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
@@ -400,7 +400,7 @@ class TestCoincident:
 
     def test_relative_neighborhood_jitter(self):
         heads, tails, weights = _relative_neighborhood(
-            self.df_int, coincident="jitter", seed=0
+            self.df_int, coplanar="jitter", seed=0
         )
 
         exp_heads = np.array([0, 0, 1, 1, 2, 3, 3, 4, 4, 5])
@@ -411,7 +411,7 @@ class TestCoincident:
         np.testing.assert_array_equal(tails, exp_tails)
 
         heads, tails, weights = _relative_neighborhood(
-            self.df_string, coincident="jitter", seed=0
+            self.df_string, coplanar="jitter", seed=0
         )
 
         np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
@@ -420,7 +420,7 @@ class TestCoincident:
 
     def test_relative_neighborhood_clique(self):
         # TODO: fix the implemntation to make this pass
-        heads, tails, weights = _relative_neighborhood(self.df_int, coincident="clique")
+        heads, tails, weights = _relative_neighborhood(self.df_int, coplanar="clique")
 
         exp_heads = np.array([0, 0, 1, 1, 1, 1, 2, 2, 3, 4, 4, 5])
         exp_tails = np.array([1, 4, 0, 2, 4, 5, 1, 3, 2, 0, 1, 1])
@@ -430,7 +430,7 @@ class TestCoincident:
         np.testing.assert_array_equal(tails, exp_tails)
 
         heads, tails, weights = _relative_neighborhood(
-            self.df_string, coincident="clique"
+            self.df_string, coplanar="clique"
         )
 
         np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
@@ -445,7 +445,7 @@ class TestCoincident:
             _voronoi(self.df_int)
 
     def test_voronoi_jitter(self):
-        heads, tails, weights = _voronoi(self.df_int, coincident="jitter", seed=0)
+        heads, tails, weights = _voronoi(self.df_int, coplanar="jitter", seed=0)
 
         exp_heads = np.array([0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5])
         exp_tails = np.array([1, 2, 4, 0, 2, 3, 4, 5, 0, 1, 3, 1, 2, 5, 0, 1, 1, 3])
@@ -454,7 +454,7 @@ class TestCoincident:
         np.testing.assert_array_equal(heads, exp_heads)
         np.testing.assert_array_equal(tails, exp_tails)
 
-        heads, tails, weights = _voronoi(self.df_string, coincident="jitter", seed=0)
+        heads, tails, weights = _voronoi(self.df_string, coplanar="jitter", seed=0)
 
         np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
         np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
@@ -462,7 +462,7 @@ class TestCoincident:
 
     def test_voronoi_clique(self):
         # TODO: fix the implemntation to make this pass
-        heads, tails, weights = _voronoi(self.df_int, coincident="clique", seed=0)
+        heads, tails, weights = _voronoi(self.df_int, coplanar="clique", seed=0)
 
         exp_heads = np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 5, 5])
         exp_tails = np.array([1, 4, 0, 2, 3, 4, 5, 1, 3, 1, 2, 5, 0, 1, 1, 3])
@@ -471,7 +471,7 @@ class TestCoincident:
         np.testing.assert_array_equal(heads, exp_heads)
         np.testing.assert_array_equal(tails, exp_tails)
 
-        heads, tails, weights = _voronoi(self.df_string, coincident="clique", seed=0)
+        heads, tails, weights = _voronoi(self.df_string, coplanar="clique", seed=0)
 
         np.testing.assert_array_equal(heads, np.vectorize(self.mapping.get)(exp_heads))
         np.testing.assert_array_equal(tails, np.vectorize(self.mapping.get)(exp_tails))
@@ -480,6 +480,6 @@ class TestCoincident:
     def test_wrong_resolver(self):
         with pytest.raises(
             ValueError,
-            match="Recieved option coincident='nonsense'",
+            match="Recieved option coplanar='nonsense'",
         ):
-            _delaunay(self.df_int, coincident="nonsense")
+            _delaunay(self.df_int, coplanar="nonsense")


### PR DESCRIPTION
Closes #713 

Had to touch more stuff than intended but we now rely on QHull to identify coincident points and provide a lookup from which we can build cliques. This should ensure that we won't hit the precision issues. 

Some minor cleanup happened alongside, i.e. to avoid solving isolates twice in a row.