### PR TITLE
PERF: sorting-related improvements in Graph

### DIFF
--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -314,7 +314,9 @@ class Graph(SetOpsMixin):
             libpysal.graph.Graph based on sparse
         """
 
-        return cls.from_arrays(*_sparse_to_arrays(sparse, ids))
+        return cls(
+            _sparse_to_arrays(sparse, ids, return_adjacency=True), is_sorted=True
+        )
 
     @classmethod
     def from_arrays(cls, focal_ids, neighbor_ids, weight, **kwargs):


### PR DESCRIPTION
I've done some profiling which led to these changes.

- avoiding re-creation of adjacency and re-sorting already sorting arrays in `_sparse_to_arrays` - cuts time to about half
- faster `_reorder_adjtable_by_ids` (no apply) (10x faster than original)
- `_validate_sparse_input` is removed as it is not used anywhere

We still do sorting multiple times in many places but if I short-circuit that, we hit #687 and issues with sparse round tripping. The final sorting either needs to happen in `__init__` as now or would need to happen in `.sparse`. Keeping it in the constructor is probably better idea as we know that a Graph is always correct as is.