### PR TITLE
Categorical spatial lag using the Graph

### DIFF
--- a/libpysal/graph/_spatial_lag.py
+++ b/libpysal/graph/_spatial_lag.py
@@ -1,8 +1,12 @@
-def _lag_spatial(graph, y):
+import numpy as np
+import pandas as pd
+
+
+def _lag_spatial(graph, y, categorical=False, ties='raise'):
     """Spatial lag operator
 
-    If w is row standardized, returns the average of each observation's neighbors;
-    if not, returns the weighted sum of each observation's neighbors.
+    Constructs spatial lag based on neighbor relations of the graph.
+
 
     Parameters
     ----------
@@ -10,11 +14,52 @@ def _lag_spatial(graph, y):
         libpysal.graph.Graph
     y : array
         numpy array with dimensionality conforming to w
+    categorical : bool
+        True if y is categorical, False if y is continuous.
+    ties : {'raise', 'random', 'tryself'}, optional
+        Policy on how to break ties when a focal unit has multiple
+        modes for a categorical lag.
+        - 'raise': This will raise an exception if ties are
+          encountered to alert the user (Default).
+        - 'random': Will break ties randomly.
+        - 'tryself': Add a self-weight to attempt to break the tie
+          with the focal label. If the self-weight does not break a
+          tie, or the self-weight induces a tie, the tie will be be
+          broken randomly.
+
 
     Returns
     -------
     numpy.array
-        array of numeric values for the spatial lag
+        array of numeric|categorical values for the spatial lag
+
+
+    Examples
+    --------
+    >>> from libpysal.graph._spatial_lag import _lag_spatial
+    >>> import numpy as np
+    >>> from libpysal.weights.util import lat2W
+    >>> from libpysal.graph import Graph
+    >>> graph = Graph.from_W(lat2W(3,3))
+    >>> y = np.arange(9)
+    >>> _lag_spatial(graph, y)
+    array([ 4.,  6.,  6., 10., 16., 14., 10., 18., 12.])
+
+    Categorical Lag (no ties)
+    >>> y = np.array([*'ababcbcbc'])
+    >>> _lag_spatial(graph, y, categorical=True)
+    array(['b', 'a', 'b', 'c', 'b', 'c', 'b', 'c', 'b'], dtype=object)
+
+    Handling ties
+    >>> y[3] = 'a'
+    >>> np.random.seed(12345)
+    >>> _lag_spatial(graph, y, categorical=True, ties='random')
+    array(['a', 'a', 'b', 'c', 'b', 'c', 'b', 'c', 'b'], dtype=object)
+    >>> _lag_spatial(graph, y, categorical=True, ties='random')
+    array(['b', 'a', 'b', 'c', 'b', 'c', 'b', 'c', 'b'], dtype=object)
+    >>> _lag_spatial(graph, y, categorical=True, ties='tryself')
+    array(['a', 'a', 'b', 'c', 'b', 'c', 'b', 'c', 'b'], dtype=object)
+
     """
     sp = graph.sparse
     if len(y) != sp.shape[0]:
@@ -22,4 +67,69 @@ def _lag_spatial(graph, y):
             "The length of `y` needs to match the number of observations "
             f"in Graph. Expected {sp.shape[0]}, got {len(y)}."
         )
+
+    if categorical:
+        if ties == 'tryself':
+            graph = graph.assign_self_weight()
+        df = pd.DataFrame(data=graph.adjacency)
+        df['neighbor_label'] = y[graph.adjacency.index.get_level_values(1)]
+        gb = df.groupby(['focal', 'neighbor_label']
+                        ).count().groupby(level='focal')
+        n_ties = gb.apply(_check_ties).sum()
+        if n_ties and ties == 'raise':
+            raise ValueError(
+                f"There are {n_ties} ties that must be broken "
+                f"to define the categorical "
+                "spatial lag for these observations. To address this "
+                "issue, consider setting `ties='tryself'` "
+                "or `ties='random'` or consult the documentation "
+                "about ties and the categorical spatial lag."
+            )
+        elif ties in ('random', 'tryself', 'raise'):
+            return gb.apply(_get_categorical_lag).values
+
+        else:
+            raise ValueError(
+                f"Recieved option ties='{ties}', but only options "
+                "'raise','random','tryself' are supported."
+            )
+
     return sp @ y
+
+
+def _check_ties(focal):
+    """Reduction to determine if a focal unit has multiple modes for neighbor labels.
+
+    Parameters
+    ----------
+    focal: row from pandas Dataframe
+          Data is a Graph with an additional column having the labels for the neighbors
+
+    Returns
+    -------
+    bool
+    """
+
+    max_count = focal.weight.max()
+    if (focal.weight == max_count).sum() > 1:
+        return True
+    return False
+
+
+def _get_categorical_lag(focal):
+    """Reduction to determine categorical spatial lag for a focal
+    unit.
+
+    Parameters
+    ----------
+    focal: row from pandas Dataframe
+          Data is a Graph with an additional column having the labels for the neighbors
+
+    Returns
+    -------
+    str
+      Label for the value of the categorical lag
+    """
+    filtered = focal[focal.weight == focal.weight.max()]
+    max_label = filtered.index.get_level_values('neighbor_label').values
+    return np.random.choice(max_label, 1)[0]

--- a/libpysal/graph/_spatial_lag.py
+++ b/libpysal/graph/_spatial_lag.py
@@ -24,8 +24,7 @@ def _lag_spatial(graph, y, categorical=False, ties="raise"):
         - 'random': Will break ties randomly.
         - 'tryself': Add a self-weight to attempt to break the tie
           with the focal label. If the self-weight does not break a
-          tie, or the self-weight induces a tie, the tie will be be
-          broken randomly.
+          tie, the tie will be be broken randomly.
 
 
     Returns
@@ -134,7 +133,7 @@ def _check_ties(focal):
     return False
 
 
-def _get_categorical_lag(focal, ties="random", own=None):
+def _get_categorical_lag(focal, ties="random"):
     """Reduction to determine categorical spatial lag for a focal
     unit.
 
@@ -143,10 +142,16 @@ def _get_categorical_lag(focal, ties="random", own=None):
     focal: row from pandas Dataframe
           Data is a Graph with an additional column having the labels for the neighbors
 
-    ties:
+    ties : {'raise', 'random', 'tryself'}, optional
+        Policy on how to break ties when a focal unit has multiple
+        modes for a categorical lag.
+        - 'raise': This will raise an exception if ties are
+          encountered to alert the user (Default).
+        - 'random': Will break ties randomly.
+        - 'tryself': Add a self-weight to attempt to break the tie
+          with the focal label. If the self-weight does not break a
+          tie, the tie will be be broken randomly.
 
-    own:
-       label of the focal unit
     Returns
     -------
     str

--- a/libpysal/graph/_spatial_lag.py
+++ b/libpysal/graph/_spatial_lag.py
@@ -77,7 +77,7 @@ def _lag_spatial(graph, y, categorical=False, ties='raise'):
             "The length of `y` needs to match the number of observations "
             f"in Graph. Expected {sp.shape[0]}, got {len(y)}."
         )
-   if ( isinstance(y.dtype, CategoricalDtype)
+    if (isinstance(y.dtype, pd.CategoricalDtype)
         or pd.api.types.is_object_dtype(y.dtype)
         or pd.api.types.is_bool_dtype(y.dtype)
         or pd.api.types.is_string_dtype(y.dtype)

--- a/libpysal/graph/_spatial_lag.py
+++ b/libpysal/graph/_spatial_lag.py
@@ -45,6 +45,16 @@ def _lag_spatial(graph, y, categorical=False, ties='raise'):
     >>> _lag_spatial(graph, y)
     array([ 4.,  6.,  6., 10., 16., 14., 10., 18., 12.])
 
+    Row standardization
+    >>> w = lat2W(3,3)
+    >>> w.transform = 'r'
+    >>> graph = Graph.from_W(w)
+    >>> y = np.arange(9)
+    >>> _lag_spatial(graph, y)
+    array([2.        , 2.        , 3.        , 3.33333333, 4.        ,
+           4.66666667, 5.        , 6.        , 6.        ])
+
+
     Categorical Lag (no ties)
     >>> y = np.array([*'ababcbcbc'])
     >>> _lag_spatial(graph, y, categorical=True)
@@ -58,7 +68,7 @@ def _lag_spatial(graph, y, categorical=False, ties='raise'):
     >>> _lag_spatial(graph, y, categorical=True, ties='random')
     array(['b', 'a', 'b', 'c', 'b', 'c', 'b', 'c', 'b'], dtype=object)
     >>> _lag_spatial(graph, y, categorical=True, ties='tryself')
-    array(['a', 'a', 'b', 'c', 'b', 'c', 'b', 'c', 'b'], dtype=object)
+    array(['a', 'a', 'b', 'a', 'b', 'c', 'b', 'c', 'b'], dtype=object)
 
     """
     sp = graph.sparse

--- a/libpysal/graph/_spatial_lag.py
+++ b/libpysal/graph/_spatial_lag.py
@@ -105,7 +105,7 @@ def _lag_spatial(graph, y, categorical=False, ties='raise'):
 
         else:
             raise ValueError(
-                f"Recieved option ties='{ties}', but only options "
+                f"Received option ties='{ties}', but only options "
                 "'raise','random','tryself' are supported."
             )
 

--- a/libpysal/graph/_spatial_lag.py
+++ b/libpysal/graph/_spatial_lag.py
@@ -77,7 +77,12 @@ def _lag_spatial(graph, y, categorical=False, ties='raise'):
             "The length of `y` needs to match the number of observations "
             f"in Graph. Expected {sp.shape[0]}, got {len(y)}."
         )
-
+   if ( isinstance(y.dtype, CategoricalDtype)
+        or pd.api.types.is_object_dtype(y.dtype)
+        or pd.api.types.is_bool_dtype(y.dtype)
+        or pd.api.types.is_string_dtype(y.dtype)
+    ):
+        categorical = True
     if categorical:
         if ties == 'tryself':
             graph = graph.assign_self_weight()

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1613,7 +1613,7 @@ class Graph(SetOpsMixin):
             ids=self.unique_ids,
         )
 
-    def lag(self, y, categorical=False, ties='raise'):
+    def lag(self, y, categorical=False, ties="raise"):
         """Spatial lag operator
 
         Constructs spatial lag based on neighbor relations of the graph.

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1645,7 +1645,7 @@ class Graph(SetOpsMixin):
         numpy.array
             array of numeric|categorical values for the spatial lag
         """
-        return _lag_spatial(self, y)
+        return _lag_spatial(self, y, categorical=categorical, ties=ties)
 
     def to_parquet(self, path, **kwargs):
         """Save Graph to a Apache Parquet

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1613,22 +1613,37 @@ class Graph(SetOpsMixin):
             ids=self.unique_ids,
         )
 
-    def lag(self, y):
+    def lag(self, y, categorical=False, ties='raise'):
         """Spatial lag operator
 
-        If weights are row standardized, returns the mean of each
-        observation's neighbors; if not, returns the weighted sum
-        of each observation's neighbors.
+        Constructs spatial lag based on neighbor relations of the graph.
+
 
         Parameters
         ----------
-        y : array-like
-            array-like (N,) shape where N is equal to number of observations in self.
+        graph : Graph
+            libpysal.graph.Graph
+        y : array
+            numpy array with dimensionality conforming to w
+        categorical : bool
+            True if y is categorical, False if y is continuous.
+        ties : {'raise', 'random', 'tryself'}, optional
+            Policy on how to break ties when a focal unit has multiple
+            modes for a categorical lag.
+            - 'raise': This will raise an exception if ties are
+            encountered to alert the user (Default).
+            - 'random': modal label ties Will be broken randomly.
+            - 'tryself': check if focal label breaks the tie between label
+            modes.  If the focal label does not break the modal tie, the
+            tie will be be broken randomly. If the focal unit has a
+            self-weight, focal label is not used to break any tie,
+            rather any tie will be broken randomly.
+
 
         Returns
         -------
-        numpy.ndarray
-            array of numeric values for the spatial lag
+        numpy.array
+            array of numeric|categorical values for the spatial lag
         """
         return _lag_spatial(self, y)
 

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1621,8 +1621,6 @@ class Graph(SetOpsMixin):
 
         Parameters
         ----------
-        graph : Graph
-            libpysal.graph.Graph
         y : array
             numpy array with dimensionality conforming to w
         categorical : bool

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1640,7 +1640,7 @@ class Graph(SetOpsMixin):
 
         Returns
         -------
-        numpy.array
+        numpy.ndarray
             array of numeric|categorical values for the spatial lag
         """
         return _lag_spatial(self, y, categorical=categorical, ties=ties)

--- a/libpysal/graph/tests/test_spatial_lag.py
+++ b/libpysal/graph/tests/test_spatial_lag.py
@@ -50,6 +50,16 @@ class TestLag:
         np.testing.assert_array_equal(yl1, yl1c)
         ylsc = np.array(["a", "a", "b", "c", "b", "c", "a", "c", "b"], dtype=object)
         np.testing.assert_array_equal(yls, ylsc)
+        # self-weight
+        neighbors = self.gc.neighbors
+        neighbors[0] = (0, 3, 1)  # add self neighbor for observation 0
+        gc = graph.Graph.from_dicts(neighbors)
+        self.yc[3] = "b"
+        yls = _lag_spatial(gc, self.yc, categorical=True, ties="tryself")
+        assert yls[0] in ["b", "a"]
+        self.yc[3] = "a"
+        yls = _lag_spatial(gc, self.yc, categorical=True, ties="tryself")
+        assert yls[0] == "a"
 
     def test_ties_raise(self):
         with pytest.raises(ValueError):

--- a/libpysal/graph/tests/test_spatial_lag.py
+++ b/libpysal/graph/tests/test_spatial_lag.py
@@ -62,6 +62,6 @@ class TestLag:
         assert yls[0] == "a"
 
     def test_ties_raise(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="There are 2 ties that must be broken"):
             self.yc[3] = "a"  # create ties
             _lag_spatial(self.gc, self.yc, categorical=True)

--- a/libpysal/graph/tests/test_spatial_lag.py
+++ b/libpysal/graph/tests/test_spatial_lag.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 
 from libpysal import graph
 from libpysal.graph._spatial_lag import _lag_spatial
@@ -17,13 +17,10 @@ class TestLag:
         self.weights = {"a": [1.0], "b": [1.0, 1.0], "c": [1.0], "d": []}
         self.g = graph.Graph.from_dicts(self.neighbors, self.weights)
         self.y = np.array([0, 1, 2, 3])
-        self.yc = np.array([*'ababcbcbc'])
-        w = lat2W(3,3)
-        w.transform = 'r'
+        self.yc = np.array([*"ababcbcbc"])
+        w = lat2W(3, 3)
+        w.transform = "r"
         self.gc = graph.Graph.from_W(w)
-
-
-
 
     def test_lag_spatial(self):
         yl = _lag_spatial(self.g, self.y)
@@ -38,25 +35,23 @@ class TestLag:
         ylc = np.array([2.0, 2.0, 3.0, 3.33333333, 4.0, 4.66666667, 5.0, 6.0, 6.0])
         np.testing.assert_array_almost_equal(yl, ylc)
 
-
     def test_lag_spatial_categorical(self):
         yl = _lag_spatial(self.gc, self.yc, categorical=True)
-        ylc = np.array(['b', 'a', 'b', 'c', 'b', 'c', 'b', 'c', 'b'],
-                       dtype=object)
+        ylc = np.array(["b", "a", "b", "c", "b", "c", "b", "c", "b"], dtype=object)
         np.testing.assert_array_equal(yl, ylc)
-        self.yc[3] = 'a'   # create ties
+        self.yc[3] = "a"  # create ties
         np.random.seed(12345)
-        yl = _lag_spatial(self.gc, self.yc, categorical=True, ties='random')
-        ylc = np.array(['a', 'a', 'b', 'c', 'b', 'c', 'b', 'c', 'b'], dtype=object)
-        yl1 = _lag_spatial(self.gc, self.yc, categorical=True, ties='random')
-        yls = _lag_spatial(self.gc, self.yc, categorical=True, ties='tryself')
+        yl = _lag_spatial(self.gc, self.yc, categorical=True, ties="random")
+        ylc = np.array(["a", "a", "b", "c", "b", "c", "b", "c", "b"], dtype=object)
+        yl1 = _lag_spatial(self.gc, self.yc, categorical=True, ties="random")
+        yls = _lag_spatial(self.gc, self.yc, categorical=True, ties="tryself")
         np.testing.assert_array_equal(yl, ylc)
-        yl1c=np.array(['b', 'a', 'b', 'c', 'b', 'c', 'b', 'c', 'b'], dtype=object)
+        yl1c = np.array(["b", "a", "b", "c", "b", "c", "b", "c", "b"], dtype=object)
         np.testing.assert_array_equal(yl1, yl1c)
-        ylsc = np.array(['a', 'a', 'b', 'a', 'b', 'c', 'b', 'c', 'b'], dtype=object)
+        ylsc = np.array(["a", "a", "b", "a", "b", "c", "b", "c", "b"], dtype=object)
         np.testing.assert_array_equal(yls, ylsc)
 
     def test_ties_raise(self):
         with pytest.raises(ValueError):
-            self.yc[3] = 'a'   # create ties
-            yl = _lag_spatial(self.gc, self.yc, categorical=True)
+            self.yc[3] = "a"  # create ties
+            _lag_spatial(self.gc, self.yc, categorical=True)

--- a/libpysal/graph/tests/test_spatial_lag.py
+++ b/libpysal/graph/tests/test_spatial_lag.py
@@ -36,7 +36,7 @@ class TestLag:
         np.testing.assert_array_almost_equal(yl, ylc)
 
     def test_lag_spatial_categorical(self):
-        yl = _lag_spatial(self.gc, self.yc, categorical=True)
+        yl = _lag_spatial(self.gc, self.yc)
         ylc = np.array(["b", "a", "b", "c", "b", "c", "b", "c", "b"], dtype=object)
         np.testing.assert_array_equal(yl, ylc)
         self.yc[3] = "a"  # create ties

--- a/libpysal/graph/tests/test_spatial_lag.py
+++ b/libpysal/graph/tests/test_spatial_lag.py
@@ -48,7 +48,7 @@ class TestLag:
         np.testing.assert_array_equal(yl, ylc)
         yl1c = np.array(["b", "a", "b", "c", "b", "c", "b", "c", "b"], dtype=object)
         np.testing.assert_array_equal(yl1, yl1c)
-        ylsc = np.array(["a", "a", "b", "a", "b", "c", "b", "c", "b"], dtype=object)
+        ylsc = np.array(["a", "a", "b", "c", "b", "c", "a", "c", "b"], dtype=object)
         np.testing.assert_array_equal(yls, ylsc)
 
     def test_ties_raise(self):


### PR DESCRIPTION
This has two changes from the creation of categorical spatial lags using W

1. `categorical` is now an option in `_lag_spatial`, to unify treatment of the lag.
2. This will raise an exception in the case where `categorical=True` , `ties=raise`, and ties are encountered.
"Explicit is better than implicit."
