### PR TITLE
ENH: pass kwargs to buffer in fuzzy_contiguity

### DIFF
--- a/libpysal/graph/_contiguity.py
+++ b/libpysal/graph/_contiguity.py
@@ -267,7 +267,7 @@ def _fuzzy_contiguity(
         bounding boxes. See the documentation of ``geopandas.GeoSeries.sindex.query``
         for allowed predicates.
     **kwargs
-        Keyword arguments passed to ``geopandas.GeoSeries.buffer``
+        Keyword arguments passed to ``geopandas.GeoSeries.buffer``.
 
     Returns
     -------

--- a/libpysal/graph/_contiguity.py
+++ b/libpysal/graph/_contiguity.py
@@ -241,11 +241,7 @@ def _block_contiguity(regimes, ids=None):
 
 
 def _fuzzy_contiguity(
-    geoms,
-    ids,
-    tolerance=None,
-    buffer=None,
-    predicate="intersects",
+    geoms, ids, tolerance=None, buffer=None, predicate="intersects", **kwargs
 ):
     """Fuzzy contiguity builder
 
@@ -270,6 +266,8 @@ def _fuzzy_contiguity(
         If None is passed, neighbours are determined based on the intersection of
         bounding boxes. See the documentation of ``geopandas.GeoSeries.sindex.query``
         for allowed predicates.
+    **kwargs
+        Keyword arguments passed to ``geopandas.GeoSeries.buffer``
 
     Returns
     -------
@@ -289,7 +287,7 @@ def _fuzzy_contiguity(
         buffer = tolerance * 0.5 * abs(min(maxx - minx, maxy - miny))
 
     if buffer is not None:
-        geoms = geoms.buffer(buffer)
+        geoms = geoms.buffer(buffer, **kwargs)
 
     # query tree based on set predicate
     if GPD_013:

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -803,11 +803,7 @@ class Graph(SetOpsMixin):
 
     @classmethod
     def build_fuzzy_contiguity(
-        cls,
-        geometry,
-        tolerance=None,
-        buffer=None,
-        predicate="intersects",
+        cls, geometry, tolerance=None, buffer=None, predicate="intersects", **kwargs
     ):
         """Generate Graph from fuzzy contiguity
 
@@ -851,6 +847,8 @@ class Graph(SetOpsMixin):
             'intersects'. If None is passed, neighbours are determined based
             on the intersection of bounding boxes. See the documentation of
             ``geopandas.GeoSeries.sindex.query`` for allowed predicates.
+        **kwargs
+            Keyword arguments passed to ``geopandas.GeoSeries.buffer``
 
         Returns
         -------
@@ -860,7 +858,12 @@ class Graph(SetOpsMixin):
         ids = _evaluate_index(geometry)
 
         heads, tails, weights = _fuzzy_contiguity(
-            geometry, ids, tolerance=tolerance, buffer=buffer, predicate=predicate
+            geometry,
+            ids,
+            tolerance=tolerance,
+            buffer=buffer,
+            predicate=predicate,
+            **kwargs,
         )
 
         return cls.from_arrays(heads, tails, weights)

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -848,7 +848,7 @@ class Graph(SetOpsMixin):
             on the intersection of bounding boxes. See the documentation of
             ``geopandas.GeoSeries.sindex.query`` for allowed predicates.
         **kwargs
-            Keyword arguments passed to ``geopandas.GeoSeries.buffer``
+            Keyword arguments passed to ``geopandas.GeoSeries.buffer``.
 
         Returns
         -------

--- a/libpysal/graph/tests/test_builders.py
+++ b/libpysal/graph/tests/test_builders.py
@@ -140,6 +140,13 @@ class TestContiguity:
         assert pd.api.types.is_string_dtype(g._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(g._adjacency.dtype)
 
+    def test_fuzzy_contiguity_kwargs(self):
+        g = graph.Graph.build_fuzzy_contiguity(self.gdf_str, resolution=2)
+
+        assert pd.api.types.is_string_dtype(g._adjacency.index.dtypes["focal"])
+        assert pd.api.types.is_string_dtype(g._adjacency.index.dtypes["neighbor"])
+        assert pd.api.types.is_numeric_dtype(g._adjacency.dtype)
+
 
 class TestTriangulation:
     def setup_method(self):

--- a/libpysal/graph/tests/test_contiguity.py
+++ b/libpysal/graph/tests/test_contiguity.py
@@ -363,3 +363,17 @@ def test_fuzzy_contiguity():
         _fuzzy_contiguity(
             nybb.set_index("intID"), nybb["intID"], tolerance=0.05, buffer=5000
         )
+
+    # kwargs
+    head, tail, weight = _fuzzy_contiguity(
+        nybb.set_index("intID"), nybb["intID"], buffer=5000, resolution=2
+    )
+    numpy.testing.assert_array_equal(
+        head,
+        [5, 4, 4, 4, 3, 3, 3, 1, 1, 1, 2, 2],
+    )
+    numpy.testing.assert_array_equal(
+        tail,
+        [3, 3, 1, 2, 5, 4, 1, 4, 3, 2, 4, 1],
+    )
+    numpy.testing.assert_array_equal(weight, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])


### PR DESCRIPTION
When using `fuzzy_contiguity` with a buffer, it may be worth using a lower resolution to speed up the computation. This enables passing kwargs to buffer to allow this type of control.