### PR TITLE
COMPAT: fix numpy 2.0 incompatibility

### DIFF
--- a/ci/312-dev.yaml
+++ b/ci/312-dev.yaml
@@ -32,6 +32,7 @@ dependencies:
   - pip:
       # dev versions of packages
       - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
+      - numpy
       - pandas
       - scikit-learn
       - scipy

--- a/ci/312-dev.yaml
+++ b/ci/312-dev.yaml
@@ -32,7 +32,6 @@ dependencies:
   - pip:
       # dev versions of packages
       - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
-      - numpy
       - pandas
       - scikit-learn
       - scipy

--- a/libpysal/cg/voronoi.py
+++ b/libpysal/cg/voronoi.py
@@ -99,7 +99,7 @@ def voronoi_regions(vor, radius=None):
 
     center = vor.points.mean(axis=0)
     if radius is None:
-        radius = vor.points.ptp().max() * 2
+        radius = np.ptp(vor.points).max() * 2
 
     all_ridges = {}
     for (p1, p2), (v1, v2) in zip(vor.ridge_points, vor.ridge_vertices, strict=True):

--- a/libpysal/examples/remotes.py
+++ b/libpysal/examples/remotes.py
@@ -742,7 +742,9 @@ def _build_remotes():
     n = 791
     k = 65
     download_url = "https://github.com/lanselin/spreg_sample_data/archive/master.zip"
-    explain_url = "https://raw.githubusercontent.com/lanselin/spreg_sample_data/master/README.md"
+    explain_url = (
+        "https://raw.githubusercontent.com/lanselin/spreg_sample_data/master/README.md"
+    )
     datasets[name] = Example(name, description, n, k, download_url, explain_url)
 
     # remove Cars dataset as it is broken


### PR DESCRIPTION
Closes #722 

The issue probably won't pop-up for users given it is in the legacy implementation you would need to import directly.

Also adding numpy nightly to dev env.