### PR TITLE
COMPAT: ensure argsort output has a stable order in numpy 2

### DIFF
--- a/libpysal/graph/_utils.py
+++ b/libpysal/graph/_utils.py
@@ -8,6 +8,7 @@ from packaging.version import Version
 
 GPD_013 = Version(geopandas.__version__) >= Version("0.13")
 PANDAS_GE_21 = Version(pd.__version__) >= Version("2.1.0")
+NUMPY_GE_2 = Version(np.__version__) >= Version("2.0.0")
 
 try:
     from numba import njit  # noqa: E401
@@ -31,6 +32,7 @@ def _sparse_to_arrays(sparray, ids=None, resolve_isolates=True, return_adjacency
     When we know we are dealing with cliques, we don't want to resolve
     isolates here but will do that later once cliques are induced.
     """
+    argsort_kwds = {"stable": True} if NUMPY_GE_2 else {}
     sparray = sparray.tocoo(copy=False)
     if ids is not None:
         ids = np.asarray(ids)
@@ -40,12 +42,12 @@ def _sparse_to_arrays(sparray, ids=None, resolve_isolates=True, return_adjacency
                 f"the shape of sparse {sparray.shape}."
             )
 
-        sorter = sparray.row.argsort()
+        sorter = sparray.row.argsort(**argsort_kwds)
         head = ids[sparray.row][sorter]
         tail = ids[sparray.col][sorter]
         data = sparray.data[sorter]
     else:
-        sorter = sparray.row.argsort()
+        sorter = sparray.row.argsort(**argsort_kwds)
         head = sparray.row[sorter]
         tail = sparray.col[sorter]
         data = sparray.data[sorter]

--- a/libpysal/graph/tests/test_triangulation.py
+++ b/libpysal/graph/tests/test_triangulation.py
@@ -245,7 +245,7 @@ def test_ids(ids):
 
 
 def test_kernel():
-    _, _, weight = _delaunay(cau_coords, kernel="gaussian")
+    heads_ix, tails_ix, weight = _delaunay(cau_coords, kernel="gaussian")
     expected = np.array(
         [
             0.1305618,
@@ -266,8 +266,9 @@ def test_kernel():
             0.02004257,
         ]
     )
+    order = np.lexsort((tails_ix, heads_ix))
 
-    np.testing.assert_array_almost_equal(expected, weight)
+    np.testing.assert_array_almost_equal(expected, weight[order])
 
 
 def test_coplanar_raise_voronoi():

--- a/libpysal/graph/tests/test_triangulation.py
+++ b/libpysal/graph/tests/test_triangulation.py
@@ -245,7 +245,7 @@ def test_ids(ids):
 
 
 def test_kernel():
-    heads_ix, tails_ix, weight = _delaunay(cau_coords, kernel="gaussian")
+    _, _, weight = _delaunay(cau_coords, kernel="gaussian")
     expected = np.array(
         [
             0.1305618,
@@ -266,9 +266,8 @@ def test_kernel():
             0.02004257,
         ]
     )
-    order = np.lexsort((tails_ix, heads_ix))
 
-    np.testing.assert_array_almost_equal(expected, weight[order])
+    np.testing.assert_array_almost_equal(expected, weight)
 
 
 def test_coplanar_raise_voronoi():


### PR DESCRIPTION
Fixes #724

In the end, the results were just in a slightly different order but (head, tail, weight) tuple was always correct. Given we do sorting ourselves in the constructor anyway, this has no impact on creation of graph. Just an intermediate arrays are in different order. Canonically sorting the output before assertion solves the issue.

If you build the full Graph using `build_triangulation`, they are identical.