### PR TITLE
DOC: Remove unused mkdocs-jupyter dependency

### DIFF
--- a/ci/312.yaml
+++ b/ci/312.yaml
@@ -32,7 +32,6 @@ dependencies:
   - zstd
   - xarray
   # for docs build action (this env only)
-  - mkdocs-jupyter
   - myst-parser
   - nbsphinx
   - numpydoc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dev = [
     "watermark",
 ]
 docs = [
-    "mkdocs-jupyter",
     "myst-parser",
     "nbsphinx",
     "numpydoc",


### PR DESCRIPTION
1. [x] You have run tests on this submission locally using `pytest` on your changes. Continuous integration will be run on all PRs with [GitHub Actions](https://github.com/pysal/libpysal/blob/master/.github/workflows/unittests.yml), but it is good practice to test changes locally prior to a making a PR.
2. [x] This pull request is directed to the `pysal/master` branch.
3. [n/a] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [n/a] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [x] The justification for this PR is: 

The docs are built with Sphinx, and I see no use of mkdocs anywhere.