### PR TITLE
DOC: Fix a couple Sphinx warnings

### DIFF
--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1151,17 +1151,20 @@ class Graph(SetOpsMixin):
             Clipping method when ``method="voronoi"``. Ignored otherwise.
             Default is ``'bounding_box'``. Options are as follows.
 
-            * ``None`` -- No clip is applied. Voronoi cells may be arbitrarily
-            larger that the source map. Note that this may lead to cells that are many
-            orders of magnitude larger in extent than the original map. Not recommended.
-            * ``'bounding_box'`` -- Clip the voronoi cells to the
-            bounding box of the input points.
-            * ``'convex_hull'`` -- Clip the voronoi cells to the convex hull of
-            the input points.
-            * ``'alpha_shape'`` -- Clip the voronoi cells to the tightest hull that
-            contains all points (e.g. the smallest alpha shape, using
-            :func:`libpysal.cg.alpha_shape_auto`).
-            * ``shapely.Polygon`` -- Clip to an arbitrary Polygon.
+            ``None``
+                No clip is applied. Voronoi cells may be arbitrarily larger that the
+                source map. Note that this may lead to cells that are many orders of
+                magnitude larger in extent than the original map. Not recommended.
+            ``'bounding_box'``
+                Clip the voronoi cells to the bounding box of the input points.
+            ``'convex_hull'``
+                Clip the voronoi cells to the convex hull of the input points.
+            ``'alpha_shape'``
+                Clip the voronoi cells to the tightest hull that contains all points
+                (e.g. the smallest alpha shape, using
+                :func:`libpysal.cg.alpha_shape_auto`).
+            ``shapely.Polygon``
+                Clip to an arbitrary Polygon.
 
         rook : bool, optional
             Contiguity method when ``method="voronoi"``. Ignored otherwise.

--- a/libpysal/weights/contiguity.py
+++ b/libpysal/weights/contiguity.py
@@ -404,8 +404,9 @@ class Queen(W):
     @classmethod
     def from_iterable(cls, iterable, sparse=False, **kwargs):
         """
-        Construct a weights object from a collection of arbitrary polygons. This
-        will cast the polygons to PySAL polygons, then build the W.
+        Construct a weights object from a collection of arbitrary polygons.
+
+        This will cast the polygons to PySAL polygons, then build the W.
 
         Parameters
         ----------
@@ -417,7 +418,7 @@ class Queen(W):
                       optional arguments for  :class:`pysal.weights.W`
 
         See Also
-        ---------
+        --------
         :class:`libpysal.weights.weights.W`
         :class:`libpysal.weights.contiguiyt.Queen`
         """


### PR DESCRIPTION
1. [x] You have run tests on this submission locally using `pytest` on your changes. Continuous integration will be run on all PRs with [GitHub Actions](https://github.com/pysal/libpysal/blob/master/.github/workflows/unittests.yml), but it is good practice to test changes locally prior to a making a PR.
2. [x] This pull request is directed to the `pysal/master` branch.
3. [x] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [n/a] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [x] The justification for this PR is: 

This fixes the following warnings:
```
/usr/lib/python3.12/site-packages/numpydoc/docscrape.py:455: UserWarning:
potentially wrong underline length...
See Also
--------- in
Construct a weights object from a collection of arbitrary polygons. This
will cast the polygons to PySAL polygons, then build the W....
in the docstring of from_iterable in libpysal/weights/contiguity.py.

libpysal/graph/base.py:docstring of libpysal.graph.base.Graph.build_triangulation:36: WARNING: Bullet list ends without a blank line; unexpected unindent.
```
