### PR TITLE
CI: do not xfail momepy in reverse checks

### DIFF
--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -53,7 +53,6 @@ jobs:
               pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()';
             fail_on_failure: true
             xfail: >-
-              momepy
               mgwr
               tobler
               geosnap


### PR DESCRIPTION
with 0.7.2 released earlier today, momepy should not fail any longer. Will need a merge to trigger.