### PR TITLE
fix higher_order contiguity including lower order

### DIFF
--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1605,7 +1605,7 @@ class Graph(SetOpsMixin):
         sp = binary.sparse
 
         if lower_order:
-            wk = sum(sparse.linalg.matrix_power(sp, x) for x in range(2, k + 1))
+            wk = sum(sparse.linalg.matrix_power(sp, x) for x in range(1, k + 1))
             shortest_path = False
         else:
             wk = sparse.linalg.matrix_power(sp, k)

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -983,7 +983,11 @@ class TestBase:
         lower = cont.higher_order(2, lower_order=True)
         assert lower == expected
 
-    def test_higher_order_inclusive(self): #GH738
+    @pytest.mark.skipif(
+        Version(scipy_version) < Version("1.12.0"),
+        reason="sparse matrix power requires scipy>=1.12.0",
+    )
+    def test_higher_order_inclusive(self):  # GH738
         contig = graph.Graph.from_arrays(
             [0, 1, 2, 3, 3, 4, 4], [0, 3, 4, 1, 4, 2, 3], [0, 1, 1, 1, 1, 1, 1]
         )

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -983,6 +983,15 @@ class TestBase:
         lower = cont.higher_order(2, lower_order=True)
         assert lower == expected
 
+    def test_higher_order_inclusive(self): #GH738
+        contig = graph.Graph.from_arrays(
+            [0, 1, 2, 3, 3, 4, 4], [0, 3, 4, 1, 4, 2, 3], [0, 1, 1, 1, 1, 1, 1]
+        )
+        assert len(contig) == 6
+        higher = contig.higher_order(2, lower_order=True)
+        assert len(higher) == 10
+        assert contig < higher
+
     def test_n_components(self):
         nybb = graph.Graph.build_contiguity(self.nybb)
         assert nybb.n_components == 2

--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -523,7 +523,7 @@ def higher_order_sp(
         )
 
     if lower_order:
-        wk = sum(w**x for x in range(2, k + 1))
+        wk = sum(w**x for x in range(1, k + 1))
         shortest_path = False
     else:
         wk = w**k


### PR DESCRIPTION
Fixes #738 

Funnily enough, we have the same line of code in `weights/raster.py`, where it is correct.

