### PR TITLE
BUG: fix handling of non-isolate self-weights of 0 and order preservation

### DIFF
--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1473,13 +1473,7 @@ class Graph(SetOpsMixin):
         pandas.Index
             Index with a subset of observations that do not have any neighbor
         """
-        nulls = self._adjacency[self._adjacency == 0]
-        # since not all zeros are necessarily isolates, do the focal == neighbor check
-        return (
-            nulls[nulls.index.codes[0] == nulls.index.codes[1]]
-            .index.get_level_values(0)
-            .unique()
-        )
+        return self.cardinalities.index[self.cardinalities == 0]
 
     @cached_property
     def unique_ids(self):
@@ -1972,8 +1966,12 @@ class Graph(SetOpsMixin):
             ),
             name="weight",
         )
+        # drop existing self weights and replace them with a new value
+        existing_self_weights = self._adjacency.index[
+            self._adjacency.index.codes[0] == self._adjacency.index.codes[1]
+        ]
         adj = (
-            pd.concat([self.adjacency.drop(self.isolates), addition])
+            pd.concat([self._adjacency.drop(existing_self_weights), addition])
             .reindex(self.unique_ids, level=0)
             .reindex(self.unique_ids, level=1)
         )

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1933,10 +1933,10 @@ class Graph(SetOpsMixin):
         Graph
             subset of Graph with zero-weight edges eliminated
         """
-        # get a mask for isolates
-        isolates = self._adjacency.index.codes[0] == self._adjacency.index.codes[1]
         # substract isolates from mask of zeros
-        zeros = (self._adjacency == 0) != isolates
+        zeros = (self._adjacency == 0) != np.isin(
+            self._adjacency.index.get_level_values(0), self.isolates
+        )
         return Graph(self._adjacency[~zeros], is_sorted=True)
 
     def assign_self_weight(self, weight=1):

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -264,7 +264,9 @@ class Graph(SetOpsMixin):
                 neighbors[ix] = chunk.index.get_level_values("neighbor").tolist()
                 weights[ix] = chunk.tolist()
 
-        return W(neighbors=neighbors, weights=weights, id_order=self.unique_ids)
+        return W(
+            neighbors=neighbors, weights=weights, id_order=self.unique_ids.tolist()
+        )
 
     @classmethod
     def from_adjacency(

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -265,7 +265,10 @@ class Graph(SetOpsMixin):
                 weights[ix] = chunk.tolist()
 
         return W(
-            neighbors=neighbors, weights=weights, id_order=self.unique_ids.tolist()
+            neighbors=neighbors,
+            weights=weights,
+            id_order=self.unique_ids.tolist(),
+            silence_warnings=True,
         )
 
     @classmethod

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -597,6 +597,9 @@ class TestBase:
         self.g_str._adjacency.iloc[1] = 0  # zero weight, no isolate
         pd.testing.assert_index_equal(self.g_str.isolates, expected)
 
+        with_additional_zeros = self.g_str.assign_self_weight(0)
+        pd.testing.assert_index_equal(with_additional_zeros.isolates, expected)
+
     def test_n(self):
         assert self.g_int.n == 10
         assert self.g_str.n == 10

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -1148,9 +1148,9 @@ class TestBase:
     def test_aggregate(self):
         contig = graph.Graph.build_contiguity(self.nybb)
         expected = pd.Series(
-            [7.3890561, 7.3890561, 20.08553692, 20.08553692, 1.0],
+            [1.0, 20.08553692, 7.3890561, 20.08553692, 7.3890561],
             index=pd.Index(
-                ["Bronx", "Brooklyn", "Manhattan", "Queens", "Staten Island"],
+                ["Staten Island", "Queens", "Brooklyn", "Manhattan", "Bronx"],
                 name="focal",
             ),
             name="weight",

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -186,6 +186,7 @@ class TestBase:
         )
         g_roundtripped = graph.Graph.from_W(w)
         assert self.g_int == g_roundtripped
+        assert isinstance(w.id_order, list)
 
         w = self.g_str.to_W()
         pd.testing.assert_series_equal(
@@ -1003,7 +1004,8 @@ class TestBase:
         )
 
     def test_eliminate_zeros(self):
-        adj = self.adjacency_str_binary.copy()
+        nybb = graph.Graph.build_contiguity(self.nybb)
+        adj = nybb._adjacency.copy()
         adj["Bronx", "Queens"] = 0
         adj["Queens", "Manhattan"] = 0
         with_zero = graph.Graph(adj)

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -1011,8 +1011,11 @@ class TestBase:
         adj = nybb._adjacency.copy()
         adj["Bronx", "Queens"] = 0
         adj["Queens", "Manhattan"] = 0
+        adj["Queens", "Queens"] = 0
         with_zero = graph.Graph(adj)
-        expected = adj.drop([("Bronx", "Queens"), ("Queens", "Manhattan")])
+        expected = adj.drop(
+            [("Bronx", "Queens"), ("Queens", "Manhattan"), ("Queens", "Queens")]
+        )
         pd.testing.assert_series_equal(with_zero.eliminate_zeros()._adjacency, expected)
 
     def test_subgraph(self):


### PR DESCRIPTION
Work over in esda uncovered a series of bugs related to handling of self-weights with 0 weight which are **not** isolates at the same time. I hope that this fixes them all. They are all tested, either in their own or in related tests. Reverting each would cause CI to fail.

This is precisely the reason why I started doing the support of Graph in esda, in hope that it verifies that Graph works as intended.

This is required for https://github.com/pysal/esda/pull/293/ to pass, alongside #742.