### PR TITLE
ENH: add index_pairs to Graph

### DIFF
--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1597,6 +1597,20 @@ class Graph(SetOpsMixin):
         """Number of nonzero weights."""
         return (self._adjacency.drop(self.isolates) > 0).sum()
 
+    @cached_property
+    def index_pairs(self):
+        """Return focal-neighbor index pairs
+
+        Returns
+        -------
+        tuple(Index, Index)
+            tuple of two aligned pandas.Index objects encoding all edges of the Graph
+            by their nodes
+        """
+        focal = self._adjacency.index.get_level_values("focal")
+        neighbor = self._adjacency.index.get_level_values("neighbor")
+        return (focal, neighbor)
+
     def asymmetry(self, intrinsic=True):
         r"""Asymmetry check.
 

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -652,6 +652,73 @@ class TestBase:
         assert self.g_int.nonzero == 25
         assert graph.Graph(self.adjacency_int_binary).nonzero == 9
 
+    def test_index_pairs(self):
+        focal, neighbor = self.g_str.index_pairs
+        exp_focal = pd.Index(
+            [
+                "a",
+                "a",
+                "a",
+                "b",
+                "b",
+                "b",
+                "c",
+                "c",
+                "d",
+                "d",
+                "d",
+                "e",
+                "e",
+                "e",
+                "e",
+                "f",
+                "f",
+                "f",
+                "g",
+                "g",
+                "h",
+                "h",
+                "h",
+                "i",
+                "i",
+                "j",
+            ],
+            name="focal",
+        )
+        exp_neighbor = pd.Index(
+            [
+                "a",
+                "b",
+                "d",
+                "a",
+                "c",
+                "e",
+                "b",
+                "f",
+                "a",
+                "e",
+                "g",
+                "b",
+                "d",
+                "f",
+                "h",
+                "c",
+                "e",
+                "i",
+                "d",
+                "h",
+                "e",
+                "g",
+                "i",
+                "f",
+                "h",
+                "j",
+            ],
+            name="neighbor",
+        )
+        pd.testing.assert_index_equal(exp_focal, focal)
+        pd.testing.assert_index_equal(exp_neighbor, neighbor)
+
     def test_transform_r(self):
         expected_w = [
             0.5,


### PR DESCRIPTION
This adds convenience property to extract two aligned indices of focal-neighbour pairs as suggested by @sjsrey in https://github.com/pysal/esda/pull/326#discussion_r1674214831. 