### PR TITLE
make asymmetry computation in Graph summary optional

### DIFF
--- a/libpysal/graph/_summary.py
+++ b/libpysal/graph/_summary.py
@@ -118,7 +118,7 @@ class GraphSummary:
     <Graph of 5 nodes and 10 nonzero edges indexed by
         ['Staten Island', 'Queens', 'Brooklyn', 'Manhattan', 'Bronx']>
 
-    >>> summary = contiguity.summary()
+    >>> summary = contiguity.summary(asymmetries=True)
     >>> summary
     Graph Summary Statistics
     ========================
@@ -163,14 +163,18 @@ class GraphSummary:
     20
     """
 
-    def __init__(self, graph):
+    def __init__(self, graph, asymmetries=False):
         """Create GraphSummary
 
         Parameters
         ----------
         graph : Graph
+        asymmetries : bool
+            whether to compute ``n_asymmetries``, which is considerably more expensive
+            than the other attributes. By default False.
         """
         self._graph = graph
+        self.asymmetries = asymmetries
 
         self.n_nodes = self._graph.n_nodes  # number of nodes / observations
         self.n_edges = self._graph.n_edges  # number of edges excluding isolates
@@ -182,7 +186,8 @@ class GraphSummary:
         self.pct_nonzero = self._graph.pct_nonzero
 
         # intrinsic assymetries
-        self.n_asymmetries = len(self._graph.asymmetry())
+        if asymmetries:
+            self.n_asymmetries = len(self._graph.asymmetry())
 
         # statistics of cardinalities
         card_stats = self._graph.cardinalities.describe()
@@ -220,6 +225,7 @@ class GraphSummary:
         self.trace_gtg_gg = self.diag_gtg_gg.sum()
 
     def __repr__(self):
+        n_asymmetries = f"{self.n_asymmetries:>12.0f}" if self.asymmetries else "NA"
         return f"""Graph Summary Statistics
 {'='*24}
 Graph indexed by:
@@ -231,7 +237,7 @@ Graph indexed by:
 {"Number of isolates:":<50}{self.n_isolates:12.0f}
 {"Number of non-zero edges:":<50}{self.nonzero:>12.0f}
 {"Percentage of non-zero edges:":<50}{self.pct_nonzero:>11.2f}%
-{"Number of asymmetries:":<50}{self.n_asymmetries:>12.0f}
+{"Number of asymmetries:":<50}{n_asymmetries}
 {'-'*62}
 Cardinalities
 {'='*62}
@@ -261,6 +267,7 @@ Traces
 """  # noqa: E501
 
     def _repr_html_(self):
+        n_asymmetries = f"{self.n_asymmetries:12.0f}" if self.asymmetries else "NA"
         return f"""
             <table>
                 <caption>Graph Summary Statistics</caption>
@@ -290,7 +297,7 @@ Traces
                 </tr>
                 <tr>
                     <td>Number of asymmetries:</td>
-                    <td>{self.n_asymmetries:12.0f}</td>
+                    <td>{n_asymmetries}</td>
                 </tr>
             </table>
             <table>

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1703,7 +1703,7 @@ class Graph(SetOpsMixin):
     def summary(self, asymmetries=False):
         """Summary of the Graph properties
 
-        Returs a :class:`GraphSummary` object with the statistical attributes
+        Returns a :class:`GraphSummary` object with the statistical attributes
         summarising the Graph and its basic properties. See the docstring of the
         :class:`GraphSummary` for details and all the available attributes.
 

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1707,6 +1707,12 @@ class Graph(SetOpsMixin):
         summarising the Graph and its basic properties. See the docstring of the
         :class:`GraphSummary` for details and all the available attributes.
 
+        Parameters
+        ----------
+        asymmetries : bool
+            whether to compute ``n_asymmetries``, which is considerably more expensive
+            than the other attributes. By default False.
+
         Returns
         -------
         GraphSummary

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1700,7 +1700,7 @@ class Graph(SetOpsMixin):
             ).sort_index()
             return ijs
 
-    def summary(self):
+    def summary(self, asymmetries=False):
         """Summary of the Graph properties
 
         Returs a :class:`GraphSummary` object with the statistical attributes
@@ -1732,7 +1732,7 @@ class Graph(SetOpsMixin):
         <Graph of 5 nodes and 10 nonzero edges indexed by
          ['Staten Island', 'Queens', 'Brooklyn', 'Manhattan', 'Bronx']>
 
-        >>> summary = contiguity.summary()
+        >>> summary = contiguity.summary(asymmetries=True)
         >>> summary
         Graph Summary Statistics
         ========================
@@ -1776,7 +1776,7 @@ class Graph(SetOpsMixin):
         >>> summary.s1
         20
         """
-        return GraphSummary(self)
+        return GraphSummary(self, asymmetries=asymmetries)
 
     def higher_order(self, k=2, shortest_path=True, diagonal=False, lower_order=False):
         """Contiguity weights object of order :math:`k`.

--- a/libpysal/graph/tests/test_summary.py
+++ b/libpysal/graph/tests/test_summary.py
@@ -11,7 +11,8 @@ class TestSummary:
     def setup_method(self):
         self.nybb = geopandas.read_file(geodatasets.get_path("nybb"))
         self.G = graph.Graph.build_contiguity(self.nybb)
-        self.summary = self.G.summary()
+        self.summary = self.G.summary(True)
+        self.no_asymmetries = self.G.summary()
 
     def test_exactness(self):
         assert self.summary.n_nodes == 5
@@ -199,3 +200,8 @@ G'G + GG:                                                   20
             """
 
         assert self.summary._repr_html_() == expected
+
+    def test_no_asymmetries(self):
+        assert not hasattr(self.no_asymmetries, "n_asymmetries")
+        _ = self.no_asymmetries.__repr__()
+        _ = self.no_asymmetries._repr_html_()


### PR DESCRIPTION
For non-binary weights, asymmetry check can be pretty costly. If we compute that by default in `summary`, it comes with a massive overhead when we need just s0, s1, s2 in esda. Adding a keyword that disables it by default. That way the overhead of computing stuff we don't need in esda is relatively negligible (still some but that is probably okay).