### PR TITLE
DOC: move Graph from experimental to stable API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,8 +6,24 @@
 libpysal API reference
 ======================
 
+Spatial Graph
+-------------
+
+Modern implementation of spatial graphs encoding spatial weights matrices.
+
+.. autosummary::
+   :toctree: generated/
+
+   libpysal.graph.Graph
+   libpysal.graph.GraphSummary
+   libpysal.graph.read_parquet
+   libpysal.graph.read_gal
+   libpysal.graph.read_gwt
+
 Spatial Weights
 ---------------
+
+Legacy implementation of spatial weights matrices.
 
 .. autosummary::
    :toctree: generated/
@@ -251,19 +267,3 @@ examples
    libpysal.examples.get_path
 
 
-Experimental
-------------
-
-Experimental modules with unstable API.
-
-graph
------
-
-.. autosummary::
-   :toctree: generated/
-
-   libpysal.graph.Graph
-   libpysal.graph.GraphSummary
-   libpysal.graph.read_parquet
-   libpysal.graph.read_gal
-   libpysal.graph.read_gwt


### PR DESCRIPTION
I am still not sure if this is not premature given the number of bugs I've found while doing the Graph support in esda but here it is. Once this is merged, `Graph` is considered stable.