### PR TITLE
Fix for Graph.describe() when the graph has a string index (#759)

### DIFF
--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -2651,6 +2651,10 @@ class Graph(SetOpsMixin):
         if (y.index != self.unique_ids).all():
             raise ValueError("The values index is not aligned with the graph index.")
 
+        # reset numerical index to enable numba functionality
+        if isinstance(y.index.dtype, object):
+            y.index = np.arange(len(y.index))
+
         if q is None:
             grouper = y.take(self._adjacency.index.codes[1]).groupby(
                 self._adjacency.index.codes[0], sort=False

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -2652,8 +2652,8 @@ class Graph(SetOpsMixin):
             raise ValueError("The values index is not aligned with the graph index.")
 
         # reset numerical index to enable numba functionality
-        if isinstance(y.index.dtype, object):
-            y.index = np.arange(len(y.index))
+        if not isinstance(y.index.dtype, int | float):
+            y = y.reset_index(drop=True)
 
         if q is None:
             grouper = y.take(self._adjacency.index.codes[1]).groupby(

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -1352,7 +1352,7 @@ class TestBase:
         for i in nybb_contig.unique_ids:
             neigh_vals = y.loc[nybb_contig[i].index.values]
             expected = neigh_vals.mode().iloc[0] if neigh_vals.shape[0] else 0
-            res = stats.loc[i]['mode']
+            res = stats.loc[i]["mode"]
             assert res == expected
 
         ## test passing ndarray

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -1327,7 +1327,7 @@ class TestBase:
         # test with isolates and string index
         nybb_contig = graph.Graph.build_contiguity(self.nybb, rook=False)
         stats = nybb_contig.describe(
-            self.nybb.geometry.area, statistics=["count", "sum"]
+            self.nybb.geometry.area, statistics=["count", "sum", "mode"]
         )
         ## all isolate values should be nan
         assert stats.loc["Staten Island"].isna().all()
@@ -1347,6 +1347,13 @@ class TestBase:
             check_dtype=False,
             check_names=False,
         )
+
+        y = self.nybb.geometry.area
+        for i in nybb_contig.unique_ids:
+            neigh_vals = y.loc[nybb_contig[i].index.values]
+            expected = neigh_vals.mode().iloc[0] if neigh_vals.shape[0] else 0
+            res = stats.loc[i]['mode']
+            assert res == expected
 
         ## test passing ndarray
         stats1 = nybb_contig.describe(self.nybb.geometry.area, statistics=["sum"])[


### PR DESCRIPTION
This PR fixes #759 .

Pandas aggregation functions pass the original string index to numba, and thats why it fails the type check.
To fix this we can either have two new numba mode calculation functions - one for  strings, one for numbers or we can explicitly recast the index to integers, carry out the calculations using the numeric index and then reindex the results before returning them.