### PR TITLE
ENH: ensure lag_spatial is compatible with both W and Graph

### DIFF
--- a/libpysal/weights/spatial_lag.py
+++ b/libpysal/weights/spatial_lag.py
@@ -85,7 +85,7 @@ def lag_spatial(w, y):
            [6.        , 2.        ],
            [6.        , 2.        ]])
     """
-    return w.sparse * y
+    return w.sparse @ y
 
 
 def lag_categorical(w, y, ties="tryself"):


### PR DESCRIPTION
Ensures that when downstream packages (like splot https://github.com/pysal/splot/pull/184) use `lag_spatial` when a Graph is given, the actual computation produces correct lag. This will avoid silent introduction of bugs when using Graph as scipy does not raise but produces different output.