### PR TITLE
TST: ignore neatnet in reverse dependency testing

### DIFF
--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -33,6 +33,7 @@ jobs:
               pysal
               mesa-geo
               spvcm
+              neatnet
             include: >-
               mapclassify
             install: >-


### PR DESCRIPTION
neatnet does not have tests that can be executed from the distribution