### PR TITLE
BUG: ensure validity of polygons in voronoi_frames

### DIFF
--- a/libpysal/cg/voronoi.py
+++ b/libpysal/cg/voronoi.py
@@ -463,6 +463,11 @@ def voronoi_frames(
     else:
         polygons = polygons.iloc[ids_polygons].reset_index(drop=True)
 
+    # ensure validity as union can occasionally produce invalid polygons that may
+    # break the intersection below
+    if not polygons.is_valid.all():
+        polygons = polygons.make_valid()
+
     # Clip polygons if limit is provided
     if limit is not None:
         to_be_clipped = polygons.sindex.query(limit.boundary, "intersects")


### PR DESCRIPTION
On some of the locations where `coverage_union` failed, unary union does not fail but produces invalid polygons. If that happens, the subsequent intersection has a tendency to fail. This seems to fix it but I wasn't able to extract a sample small enough to be included in CI. So my proposal is not merge as is.