### PR TITLE
Add kw arg to normalize kernel in distance weights.

### DIFF
--- a/libpysal/weights/distance.py
+++ b/libpysal/weights/distance.py
@@ -425,8 +425,9 @@ class Kernel(W):
                   adjustment to ensure knn distance range is closed on the
                   knnth observations
     normalize   : bool
-                  If True (default) gaussian kernel integrates to 1.
+                  If True (default) Gaussian kernel is normalized to integrate to 1.
                   If False K(0)=1.
+                  
 
     Attributes
     ----------

--- a/libpysal/weights/distance.py
+++ b/libpysal/weights/distance.py
@@ -424,6 +424,9 @@ class Kernel(W):
     eps         : float
                   adjustment to ensure knn distance range is closed on the
                   knnth observations
+    normalize   : bool
+                  If True (default) gaussian kernel integrates to 1.
+                  If False K(0)=1.
 
     Attributes
     ----------
@@ -530,8 +533,10 @@ class Kernel(W):
         diagonal=False,
         distance_metric="euclidean",
         radius=None,
+        normalize=True,
         **kwargs,
     ):
+        self._normalize = normalize
         if radius is not None:
             distance_metric = "arc"
         if isKDTree(data):
@@ -697,6 +702,8 @@ class Kernel(W):
         elif self.function == "gaussian":
             c = np.pi * 2
             c = c ** (-0.5)
+            if self._normalize is False:
+                c = 1
             self.kernel = [c * np.exp(-(zi**2) / 2.0) for zi in zs]
         else:
             print(("Unsupported kernel function", self.function))

--- a/libpysal/weights/distance.py
+++ b/libpysal/weights/distance.py
@@ -372,8 +372,8 @@ class Kernel(W):
     bandwidth   : float
                   or array-like (optional)
                   the bandwidth :math:`h_i` for the kernel.
-    fixed       : binary
-                  If true then :math:`h_i=h \\forall i`. If false then
+    fixed       : bool
+                  If True then :math:`h_i=h \\forall i`. If False then
                   bandwidth is adaptive across observations.
     k           : int
                   the number of nearest neighbors to use for determining

--- a/libpysal/weights/tests/test_distance.py
+++ b/libpysal/weights/tests/test_distance.py
@@ -351,6 +351,14 @@ class TestKernel(DistanceMixin):
         for k, v in list(w[self.known_wi5 - 1].items()):
             np.testing.assert_allclose(v, self.known_w5[k + 1], rtol=RTOL)
 
+    def test_w_normalize(self):
+        wg = d.Kernel.from_array(self.points, function='gaussian')
+        assert wg.weights[0] == [0.3989422804014327, 0.35206533556593145, 0.3412334260702758]
+        wgun = d.Kernel.from_array(self.points, function='gaussian', normalize=False)
+        assert wgun.weights[0] == [1.0, 0.8824969246470149, 0.8553453540369604]
+        
+
+        
     ##########################
     # Function/User tests    #
     ##########################


### PR DESCRIPTION
This is responding to the discussion in #790.


The default `normalize=True` preserves the current behavior of the Gaussian kernel weights (heavily used in `spreg`):
$$K(z) = \frac{1}{\sqrt{2\pi}} e^{-\frac{1}{2} z^2}$$

Setting `normalize=False` provides an option to use unnormalized Gaussian weights:
$$K(z) = e^{-\frac{1}{2} z^2}$$
