### PR TITLE
PERF: eliminate redundant sorting

### DIFF
--- a/libpysal/graph/_utils.py
+++ b/libpysal/graph/_utils.py
@@ -32,7 +32,6 @@ def _sparse_to_arrays(sparray, ids=None, resolve_isolates=True, return_adjacency
     When we know we are dealing with cliques, we don't want to resolve
     isolates here but will do that later once cliques are induced.
     """
-    argsort_kwds = {"stable": True} if NUMPY_GE_2 else {}
     sparray = sparray.tocoo(copy=False)
     if ids is not None:
         ids = np.asarray(ids)
@@ -42,15 +41,13 @@ def _sparse_to_arrays(sparray, ids=None, resolve_isolates=True, return_adjacency
                 f"the shape of sparse {sparray.shape}."
             )
 
-        sorter = sparray.row.argsort(**argsort_kwds)
-        head = ids[sparray.row][sorter]
-        tail = ids[sparray.col][sorter]
-        data = sparray.data[sorter]
+        head = ids[sparray.row]
+        tail = ids[sparray.col]
+        data = sparray.data
     else:
-        sorter = sparray.row.argsort(**argsort_kwds)
-        head = sparray.row[sorter]
-        tail = sparray.col[sorter]
-        data = sparray.data[sorter]
+        head = sparray.row
+        tail = sparray.col
+        data = sparray.data
         ids = np.arange(sparray.shape[0], dtype=int)
 
     if resolve_isolates:

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1085,7 +1085,7 @@ class Graph(SetOpsMixin):
             coplanar=coplanar,
         )
 
-        return cls.from_arrays(head, tail, weight)
+        return cls.from_arrays(head, tail, weight, is_sorted=True)
 
     @classmethod
     def build_knn(cls, data, k, metric="euclidean", p=2, coplanar="raise"):


### PR DESCRIPTION
Within `gwlearn` bandwidth search, we generate quite large graphs and it turned out that the bottleneck is not model fitting but graph creation. Especially sorting and reindex we do, and which we do at multiple spots even though one shall be enough. Removing some obvious redundancies here but there's a likelihood that some other performance-focused PRs will follow.