### PR TITLE
BUG: RNG pruning condition and loop bound

### DIFF
--- a/libpysal/weights/gabriel.py
+++ b/libpysal/weights/gabriel.py
@@ -334,7 +334,7 @@ def _filter_relativehood(edges, coordinates, return_dkmax=False):
     3. for each edge of the delaunay (i,j), prune
        if any dkmax is smaller than d(i,j)
     """
-    n = edges.max()
+    n = len(coordinates)
     out = []
     r = []
     for edge in edges:

--- a/libpysal/weights/gabriel.py
+++ b/libpysal/weights/gabriel.py
@@ -332,7 +332,7 @@ def _filter_relativehood(edges, coordinates, return_dkmax=False):
     2. for each edge of the delaunay (i,j), compute
        dkmax = max(d(k,i), d(k,j)) for k in 1..n, k != i, j
     3. for each edge of the delaunay (i,j), prune
-       if any dkmax is greater than d(i,j)
+       if any dkmax is smaller than d(i,j)
     """
     n = edges.max()
     out = []
@@ -345,11 +345,12 @@ def _filter_relativehood(edges, coordinates, return_dkmax=False):
         dij = ((pi - pj) ** 2).sum() ** 0.5
         prune = False
         for k in range(n):
+            if k == i or k == j:
+                continue
             pk = coordinates[k]
             dik = ((pi - pk) ** 2).sum() ** 0.5
             djk = ((pj - pk) ** 2).sum() ** 0.5
-            distances = numpy.array([dik, djk, dkmax])
-            dkmax = distances.max()
+            dkmax = max(dik, djk)
             prune = dkmax < dij
             if (not return_dkmax) & prune:
                 break

--- a/libpysal/weights/gabriel.py
+++ b/libpysal/weights/gabriel.py
@@ -345,7 +345,7 @@ def _filter_relativehood(edges, coordinates, return_dkmax=False):
         dij = ((pi - pj) ** 2).sum() ** 0.5
         prune = False
         for k in range(n):
-            if k == i or k == j:
+            if k in (i, j):
                 continue
             pk = coordinates[k]
             dik = ((pi - pk) ** 2).sum() ** 0.5

--- a/libpysal/weights/tests/test_gabriel.py
+++ b/libpysal/weights/tests/test_gabriel.py
@@ -39,8 +39,12 @@ def test_rng():
 
     assert e.neighbors == f.neighbors
 
+    # RNG should be a subgraph of Delaunay
+    for k, neighbors in e.neighbors.items():
+        assert set(neighbors) <= set(dty[k])
+
     assert e[1] != dty[1]
-    assert list(e[1].keys()) == [0, 3, 6, 30, 38]
+    assert list(e[1].keys()) == [0, 3]
     for focal, neighbors in e.neighbors.items():
         dneighbors = dty[focal]
         assert set(neighbors) <= set(dneighbors)


### PR DESCRIPTION
This PR fixes #801:

* Fix the Toussaint RNG-2 condition: prune $(i,j)$ if ∃ $k$: $\max(d_{ik}, d_{jk}) < d_{ij}$
* include last node: `n = len(coordinates)` and skip `k == i or k == j`
* Updated the test (the resulted graph in shown below)

<img width="960" height="720" alt="image" src="https://github.com/user-attachments/assets/8e1edb59-bf1e-48e7-8372-b6b1059b1ef0" />

