### PR TITLE
BUG: fix euality check on Graph

### DIFF
--- a/libpysal/graph/_set_ops.py
+++ b/libpysal/graph/_set_ops.py
@@ -181,7 +181,7 @@ class SetOpsMixin:
             pandas.testing.assert_series_equal(
                 self._adjacency, right._adjacency, check_dtype=False
             )
-        except AssertionError:
+        except (AssertionError, AttributeError):
             return False
         return True
 

--- a/libpysal/graph/tests/test_set_ops.py
+++ b/libpysal/graph/tests/test_set_ops.py
@@ -99,10 +99,12 @@ class TestSetOps:
     def test___eq__(self):
         assert self.distance2500 == self.distance2500.copy()
         assert not self.distance2500 == self.distance2500_id  # noqa: SIM201
+        assert not self.distance2500 == None  # noqa: E711, SIM201
 
     def test___ne__(self):
         assert not self.distance2500 != self.distance2500.copy()  # noqa: SIM202
         assert self.distance2500 != self.distance2500_id
+        assert self.distance2500 != None  # noqa: E711
 
     def test___and__(self):
         result = self.distance2500 & self.knn3


### PR DESCRIPTION
When doing `Graph == not a graph`, the check currently raises an AttributeError as show in https://github.com/pysal/esda/issues/395. This fixes it and fixes https://github.com/pysal/esda/issues/395. 