### PR TITLE
ENH: support any 2-dimensional inputs in Graph.lag()

### DIFF
--- a/libpysal/graph/_spatial_lag.py
+++ b/libpysal/graph/_spatial_lag.py
@@ -13,7 +13,8 @@ def _lag_spatial(graph, y, categorical=False, ties="raise"):
     graph : Graph
         libpysal.graph.Graph
     y : array
-        numpy array with dimensionality conforming to w
+        numpy array with dimensionality conforming to w. Can be 2D if all
+        columns are numerical.
     categorical : bool
         True if y is categorical, False if y is continuous.
     ties : {'raise', 'random', 'tryself'}, optional
@@ -83,7 +84,7 @@ def _lag_spatial(graph, y, categorical=False, ties="raise"):
     if isinstance(y, list):
         y = np.array(y)
 
-    if (
+    if y.ndim == 1 and (
         categorical
         or isinstance(y.dtype, pd.CategoricalDtype)
         or pd.api.types.is_object_dtype(y.dtype)

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -2035,7 +2035,7 @@ class Graph(SetOpsMixin):
 
         return higher
 
-    def lag(self, y, categorical=False, ties="raise"):
+    def lag(self, y, categorical=None, ties="raise"):
         """Spatial lag operator
 
         Constructs spatial lag based on neighbor relations of the graph.
@@ -2043,10 +2043,12 @@ class Graph(SetOpsMixin):
 
         Parameters
         ----------
-        y : array
-            numpy array with dimensionality conforming to w
+        y : array_like
+            Array-like aligned with the graph. Can be 2-dimensional if
+            all columns are numerical.
         categorical : bool
-            True if y is categorical, False if y is continuous.
+            True if y is categorical, False if y is continuous. If None, it is
+            derived from the dtype of ``y``.
         ties : {'raise', 'random', 'tryself'}, optional
             Policy on how to break ties when a focal unit has multiple
             modes for a categorical lag.

--- a/libpysal/graph/tests/test_spatial_lag.py
+++ b/libpysal/graph/tests/test_spatial_lag.py
@@ -71,3 +71,27 @@ class TestLag:
         np.testing.assert_array_equal(
             expected, self.g.lag(["foo", "bar", "foo", "foo"])
         )
+
+    def test_2d_array(self):
+        ys = np.arange(27).reshape(9, 3)
+        lag = self.gc.lag(ys)
+
+        expected = np.array(
+            [
+                [6.0, 7.0, 8.0],
+                [6.0, 7.0, 8.0],
+                [9.0, 10.0, 11.0],
+                [10.0, 11.0, 12.0],
+                [12.0, 13.0, 14.0],
+                [14.0, 15.0, 16.0],
+                [15.0, 16.0, 17.0],
+                [18.0, 19.0, 20.0],
+                [18.0, 19.0, 20.0],
+            ]
+        )
+
+        np.testing.assert_array_almost_equal(lag, expected)
+
+        # test equality to 1d
+        for i in range(2):
+            np.testing.assert_array_equal(self.gc.lag(ys[:, i]), lag[:, i])


### PR DESCRIPTION
Resolves #813

For now, only supported case are 2-dimensional array_like objects with numerical data. If you want to do that for categorical columns, you still need to loop through. But that would theoretically be possible as well, if desired.

The code snippet reported in #813 now returns an array for both numpy.array and a DataFrame.