### PR TITLE
REGR: fix regression in Graph.build_kernel

### DIFF
--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1130,7 +1130,7 @@ class Graph(SetOpsMixin):
             taper=taper,
         )
 
-        return cls.from_arrays(head, tail, weight, is_sorted=True)
+        return cls.from_arrays(head, tail, weight)
 
     @classmethod
     def build_knn(

--- a/libpysal/graph/tests/test_builders.py
+++ b/libpysal/graph/tests/test_builders.py
@@ -291,6 +291,12 @@ class TestKernel:
         assert pd.api.types.is_string_dtype(g._adjacency.index.dtypes["neighbor"])
         assert pd.api.types.is_numeric_dtype(g._adjacency.dtype)
 
+    def test_code_consistency(self):
+        gdf = gpd.read_file(geodatasets.get_path("geoda guerry"))
+        g = graph.Graph.build_kernel(gdf.centroid, k=2)
+
+        assert g.sparse.shape == (85, 85)
+
 
 @pytest.mark.network
 class TestDistanceBand:


### PR DESCRIPTION
Closes #821 

What needs to happen is not sorting per-se, the arrays are already properly sorted. But we need to do the reindexing, to ensure that the codes used to represent values inside MultiIndex are consistent across both levels of MultiIndex. Otherwise pandas does not return a square sparse matrix if one of the observations is no one's neighbour as it can happen in KNN.

This warrants a patch release.