### PR TITLE
DOC: correct User Guide link in documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,7 @@ Introduction
 
 
 Examples demonstrating some of **libpysal** functionality are available in the
-`User Guide <user-guide.html>`_.
+`User Guide <user-guide/intro.html>`_.
 
 Details are available in the `libpysal api <api.html>`_.
 


### PR DESCRIPTION
The justification for this PR is: Fix broken 'User Guide' link in the documentation by updating the Sphinx internal doc target.
Fixes #831 

