### PR TITLE
fix: handle distance arrays when calculating bandwidth

### DIFF
--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -160,7 +160,10 @@ def _kernel(
         else:
             d = sparse.csc_array(coordinates)
     if bandwidth is None:
-        bandwidth = numpy.percentile(d.data, 25) if k is None else d.data.max()
+        if d.data.size > 0:
+            bandwidth = numpy.percentile(d.data, 25) if k is None else d.data.max()
+        else:
+            bandwidth = 0.0
     elif bandwidth == "auto":
         if (kernel == "identity") or (kernel is None):
             bandwidth = numpy.nan  # ignored by identity


### PR DESCRIPTION
I added a check for empty distance arrays to avoid numpy warnings and ensure stable behavior when no neighbors are found.