### PR TITLE
Added from_networkx() to Graph constructors

### DIFF
--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -523,12 +523,14 @@ class Graph(SetOpsMixin):
             raise ImportError("NetworkX is required.") from None
 
         nodes = list(graph.nodes())
-        
+
         # Check if the specified weight attribute exists on edges
         if weight is not None:
             for _u, _v, edge_data in graph.edges(data=True):
                 if weight not in edge_data:
-                    raise ValueError(f"The weight attribute '{weight}' does not exist on all edges.")
+                    raise ValueError(
+                        f"The weight attribute '{weight}' does not exist on all edges."
+                    )
 
         sparse_array = nx.to_scipy_sparse_array(graph, nodelist=nodes, weight=weight)
 

--- a/libpysal/graph/tests/test_base.py
+++ b/libpysal/graph/tests/test_base.py
@@ -486,7 +486,9 @@ class TestBase:
         nxg = nx.Graph()
         nxg.add_edge(0, 1, other_attr=0.5)
         nxg.add_edge(1, 2, other_attr=1.5)
-        with pytest.raises(ValueError, match="The weight attribute 'nonexistent_weight' does not exist"):
+        with pytest.raises(
+            ValueError, match="The weight attribute 'nonexistent_weight' does not exist"
+        ):
             graph.Graph.from_networkx(nxg, weight="nonexistent_weight")
 
     @pytest.mark.parametrize("y", [3, 5])


### PR DESCRIPTION
1. [x] You have run tests on this submission locally using `pytest` on your changes. Continuous integration will be run on all PRs with [GitHub Actions](https://github.com/pysal/libpysal/blob/master/.github/workflows/unittests.yml), but it is good practice to test changes locally prior to a making a PR.
2. [x] This pull request is directed to the `pysal/main` branch.
3. [x] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [ ] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)