### PR TITLE
DOC : Radius and distance_metric Document updates in Kernel

### DIFF
--- a/libpysal/weights/distance.py
+++ b/libpysal/weights/distance.py
@@ -385,6 +385,14 @@ class Kernel(W):
                   If true, set diagonal weights = 1.0, if false (default),
                   diagonals weights are set to value according to kernel
                   function.
+    distance_metric : str
+                      Defines how distance is calculated between two observations.
+                      Options : ['euclidean','manhattan','chebyshev','minkowski','arc'].
+                      If a `radius` is specified, `distance_metric` is automatically set to 'arc'.
+    radius      : float
+                  It sets a maximum distance cutoff for neighbors to be considered,
+                  Observations with distance <= radius are considered ,else their weights are set to 0.
+
     function    : {'triangular','uniform','quadratic','quartic','gaussian'}
                   kernel function defined as follows with
 


### PR DESCRIPTION
## Issue Number : #467

Added Documentation for radius and distance_metric parameters on page : 
"https://pysal.org/libpysal/generated/libpysal.weights.Kernel.html#libpysal.weights.Kernel"

Changes Made 

- added docs for radius
- added docs for distance_metric 

5. [x ] The justification for this PR is: 

This PR documents the `radius` and `distance_metric` parameters of
`libpysal.weights.Kernel`, which were previously exposed in the API but
undocumented in the generated documentation. No functional changes are
introduced.

Before :  
<img width="1065" height="831" alt="image" src="https://github.com/user-attachments/assets/f4f692e6-c91c-42c5-8ae9-83568356a20e" />

After : 
<img width="1079" height="702" alt="image" src="https://github.com/user-attachments/assets/2c933574-64f8-45f2-9b9b-70d8ba6086d2" />



Closes #467

