### PR TITLE
Robust nodata detection in raster builders

### DIFF
--- a/libpysal/weights/raster.py
+++ b/libpysal/weights/raster.py
@@ -358,9 +358,17 @@ def _da2wsp(
     mask = None
 
     # Handle NaN masking for float rasters (explicit or implicit nodata)
-    if np.issubdtype(values.dtype, np.floating) and (
-        nodata is None or (isinstance(nodata, float) and np.isnan(nodata))
-    ):
+    # We check if nodata is None (implicit) or a nan (explicit)
+    # This handles both python float('nan') and numpy scalar np.nan
+    is_nan_nodata = False
+    if nodata is None:
+        is_nan_nodata = True
+    elif isinstance(nodata, (float, np.floating)) and np.isnan(nodata):
+        is_nan_nodata = True
+
+    if np.issubdtype(values.dtype, np.floating) and is_nan_nodata:
+        # We cannot use `values != nodata` when nodata is np.nan because
+        # np.nan != np.nan is True, which fails to mask the nodata values.
         mask = ~np.isnan(values)
     else:
         mask = values != nodata

--- a/libpysal/weights/raster.py
+++ b/libpysal/weights/raster.py
@@ -353,11 +353,22 @@ def _da2wsp(
     ser = da.to_series()
     dtype = np.int32 if (shape[0] * shape[1]) < 46340**2 else np.int64
     nodata = get_nodata(da)
-    if nodata is not None:
-        mask = (ser != nodata).to_numpy()
+
+    values = ser.to_numpy()
+    mask = None
+
+    # Handle NaN masking for float rasters (explicit or implicit nodata)
+    if np.issubdtype(values.dtype, np.floating) and (
+        nodata is None or (isinstance(nodata, float) and np.isnan(nodata))
+    ):
+        mask = ~np.isnan(values)
+    else:
+        mask = values != nodata
+
+    if mask is not None:
         ids = np.where(mask)[0]
         id_map = _idmap(ids, mask, dtype)
-        ser = ser[ser != nodata]
+        ser = ser[mask]
     else:
         ids = np.arange(len(ser), dtype=dtype)
         id_map = ids.copy()
@@ -393,7 +404,7 @@ def _da2wsp(
     else:
         # Fallback method to build sparse matrix
         sw = lat2SW(*shape, criterion)
-        if "nodatavals" in da.attrs and da.attrs["nodatavals"]:
+        if mask is not None:
             sw = sw[mask]
             sw = sw[:, mask]
         return sw, ser

--- a/libpysal/weights/raster.py
+++ b/libpysal/weights/raster.py
@@ -361,9 +361,9 @@ def _da2wsp(
     # We check if nodata is None (implicit) or a nan (explicit)
     # This handles both python float('nan') and numpy scalar np.nan
     is_nan_nodata = False
-    if nodata is None:
-        is_nan_nodata = True
-    elif isinstance(nodata, (float, np.floating)) and np.isnan(nodata):
+    if nodata is None or (
+        isinstance(nodata, (float, np.floating)) and np.isnan(nodata)
+    ):
         is_nan_nodata = True
 
     if np.issubdtype(values.dtype, np.floating) and is_nan_nodata:

--- a/libpysal/weights/raster.py
+++ b/libpysal/weights/raster.py
@@ -176,7 +176,7 @@ def nodata_from_attrs(attrs):
     candidates = ["_FillValue", "missing_value", "fill_value", "nodata", "nodatavals"]
     for i in candidates:
         if i in attrs:
-            if isinstance(i, tuple):
+            if isinstance(attrs[i], tuple):
                 return attrs[i][0]
             else:
                 return attrs[i]

--- a/libpysal/weights/tests/test_raster.py
+++ b/libpysal/weights/tests/test_raster.py
@@ -162,3 +162,42 @@ class TestNodata:
 
         wsp = raster.da2WSP(da)
         assert wsp.n == 9
+
+    def test_nan_nodata_numpy_scalar(self):
+        """
+        Verify that using a numpy scalar nan (e.g. np.float32(np.nan))
+        also triggers the correct masking.
+        """
+        data = np.array([[1.0, 1.0, 1.0], [1.0, np.nan, 1.0], [1.0, 1.0, 1.0]])
+        da = self.xr.DataArray(data, dims=("y", "x"))
+        # Set nodata to a numpy scalar nan
+        da.attrs["nodatavals"] = (np.float32(np.nan),)
+        
+        wsp = raster.da2WSP(da)
+        assert wsp.n == 8
+
+    def test_all_nan_raster(self):
+        """
+        Verify that an all-NaN raster results in an empty weights object
+        With n=0.
+        """
+        data = np.full((3, 3), np.nan)
+        da = self.xr.DataArray(data, dims=("y", "x"))
+        da.attrs["nodatavals"] = (np.nan,)
+        
+        wsp = raster.da2WSP(da)
+        assert wsp.n == 0
+        assert wsp.sparse.nnz == 0
+
+    def test_infinite_values(self):
+        """
+        Verify that infinite values are treated as valid data (not masked out)
+        as long as nodata is NaN.
+        """
+        data = np.array([[1.0, np.inf, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])
+        da = self.xr.DataArray(data, dims=("y", "x"))
+        da.attrs["nodatavals"] = (np.nan,)
+        
+        wsp = raster.da2WSP(da)
+        # All 9 cells are valid (infinity is valid data)
+        assert wsp.n == 9

--- a/libpysal/weights/tests/test_raster.py
+++ b/libpysal/weights/tests/test_raster.py
@@ -120,7 +120,7 @@ class TestNodata:
         da = self.xr.DataArray(data, dims=("y", "x"))
 
         # Expected: center NaN pixel excluded -> 8 valid cells
-        # Actual (current bug): NaN is not masked -> 9 cells
+        # Actual (current bug): NaN is not masked ->
         wsp = raster.da2WSP(da)
         assert wsp.n == 8
 
@@ -172,7 +172,7 @@ class TestNodata:
         da = self.xr.DataArray(data, dims=("y", "x"))
         # Set nodata to a numpy scalar nan
         da.attrs["nodatavals"] = (np.float32(np.nan),)
-        
+
         wsp = raster.da2WSP(da)
         assert wsp.n == 8
 
@@ -184,7 +184,7 @@ class TestNodata:
         data = np.full((3, 3), np.nan)
         da = self.xr.DataArray(data, dims=("y", "x"))
         da.attrs["nodatavals"] = (np.nan,)
-        
+
         wsp = raster.da2WSP(da)
         assert wsp.n == 0
         assert wsp.sparse.nnz == 0
@@ -197,7 +197,7 @@ class TestNodata:
         data = np.array([[1.0, np.inf, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])
         da = self.xr.DataArray(data, dims=("y", "x"))
         da.attrs["nodatavals"] = (np.nan,)
-        
+
         wsp = raster.da2WSP(da)
         # All 9 cells are valid (infinity is valid data)
         assert wsp.n == 9

--- a/libpysal/weights/tests/test_raster.py
+++ b/libpysal/weights/tests/test_raster.py
@@ -105,3 +105,60 @@ class Testraster:
         )
         w = Queen.from_xarray(da)
         assert w.n == 97232
+
+
+class TestNodata:
+    def setup_method(self):
+        self.xr = pytest.importorskip("xarray")
+
+    def test_nan_nodata_float_raster_not_masked(self):
+        """
+        Float rasters with NaN nodata should exclude NaN cells from contiguity,
+        but current logic does not mask them since `ser != np.nan` is always True.
+        """
+        data = np.array([[1.0, 1.0, 1.0], [1.0, np.nan, 1.0], [1.0, 1.0, 1.0]])
+        da = self.xr.DataArray(data, dims=("y", "x"))
+
+        # Expected: center NaN pixel excluded -> 8 valid cells
+        # Actual (current bug): NaN is not masked -> 9 cells
+        wsp = raster.da2WSP(da)
+        assert wsp.n == 8
+
+    def test_rio_nodata(self):
+        """
+        Raster with da.rio.nodata should be correctly masked.
+        This guards existing behavior for rioxarray.
+        """
+        pytest.importorskip("rioxarray")
+        import rioxarray  # noqa: F401
+
+        data = np.array([[1, 1, 1], [1, -9999, 1], [1, 1, 1]])
+        # xarray with rioxarray needs coords to be valid usually
+        # for some ops, but write_nodata might be fine
+        da = self.xr.DataArray(data, dims=("y", "x"))
+        da = da.rio.write_nodata(-9999)
+
+        wsp = raster.da2WSP(da)
+        assert wsp.n == 8
+
+    def test_attrs_nodata(self):
+        """
+        Raster with da.attrs['nodatavals'] should be correctly masked.
+        This guards backward compatibility.
+        """
+        data = np.array([[1, 1, 1], [1, -1, 1], [1, 1, 1]], dtype=int)
+        da = self.xr.DataArray(data, dims=("y", "x"))
+        da.attrs["nodatavals"] = (-1,)
+
+        wsp = raster.da2WSP(da)
+        assert wsp.n == 8
+
+    def test_no_nodata(self):
+        """
+        Raster without nodata should include all pixels.
+        """
+        data = np.array([[1.0, 1.0, 1.0], [1.0, 2.0, 1.0], [1.0, 1.0, 1.0]])
+        da = self.xr.DataArray(data, dims=("y", "x"))
+
+        wsp = raster.da2WSP(da)
+        assert wsp.n == 9


### PR DESCRIPTION
The justification for this PR is: 

- Handle NaNs explicitly in masking logic for float rasters
- Fix fallback path to respect generated masks (e.g. from NaN or rio.nodata)
- Add regression tests for NaN handling and rioxarray compatibility


