### PR TITLE
COMPAT: pandas 3 compat in kernel

### DIFF
--- a/libpysal/kernels.py
+++ b/libpysal/kernels.py
@@ -297,8 +297,12 @@ def kernel(distances, bandwidth, kernel="gaussian", taper=True, decay=False):
 
     k = func(distances, bandwidth)
     if taper is True:
+        # pandas 3.0 Copy-on-Write consequence
+        k = k.copy()
         k[distances > bandwidth] = 0.0
     elif isinstance(taper, (float, int)) and not isinstance(taper, bool):
+        # pandas 3.0 Copy-on-Write consequence
+        k = k.copy()
         k[distances > taper] = 0.0
 
     if decay:


### PR DESCRIPTION
Fixing an issue that bubbled through pandana, passing an array coming from a dataframe to a kernel function with tapering. We either need to copy or enable writing. Given we likely don't want to risk changing the original df, making a copy.