### PR TITLE
Add tests for KDTree arc-distance queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ __pycache__
 
 # virtual environment
 venv/
+.venv/
+
+# Editor settings
+.vscode/
 
 # Installer logs
 pip-log.txt

--- a/libpysal/cg/tests/test_kdtree.py
+++ b/libpysal/cg/tests/test_kdtree.py
@@ -1,0 +1,39 @@
+# Tests derived from Arc_KDTree docstring examples to get the expected behavior
+
+
+import math
+
+import pytest
+
+from libpysal.cg import sphere
+from libpysal.cg.kdtree import KDTree
+
+
+def test_arc_kdtree_basic_query():
+    pts = [(0, 90), (0, 0), (180, 0), (0, -90)]
+    kd = KDTree(pts, distance_metric="Arc", radius=sphere.RADIUS_EARTH_KM)
+
+    d, i = kd.query((90, 0), k=4)
+
+    assert len(d) == 4
+    assert len(i) == 4
+
+
+def test_arc_distance_quarter_circumference():
+    pts = [(0, 90), (0, 0), (180, 0), (0, -90)]
+    kd = KDTree(pts, distance_metric="Arc", radius=sphere.RADIUS_EARTH_KM)
+
+    d, _ = kd.query((90, 0), k=4)
+
+    expected = 2 * math.pi * sphere.RADIUS_EARTH_KM / 4
+    assert abs(d[0] - expected) < 1e-5
+
+
+def test_arc_query_ball_point_raises_for_large_radius():
+    pts = [(0, 0), (90, 0)]
+    kd = KDTree(pts, distance_metric="Arc", radius=sphere.RADIUS_EARTH_KM)
+
+    too_large_radius = kd.circumference
+
+    with pytest.raises(ValueError):
+        kd.query_ball_point((0, 0), r=too_large_radius)


### PR DESCRIPTION
1. [ x] You have run tests on this submission locally using `pytest` on your changes. Continuous integration will be run on all PRs with [GitHub Actions](https://github.com/pysal/libpysal/blob/master/.github/workflows/unittests.yml), but it is good practice to test changes locally prior to a making a PR.
2. [x ] This pull request is directed to the `pysal/master` branch.
3. [x ] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [ ] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. The justification for this PR is: 
I added a few basic tests for KDTree arc-distance queries.

The goal is just to check that arc-distance querying works as expected
including a simple case where the distance should be close to a quarter
of the Earth's circumference

This only adds tests and does not change any existing functionality.
All tests are passing locally.
