### PR TITLE
feat: add weight based coloring to static plots

### DIFF
--- a/libpysal/graph/_plotting.py
+++ b/libpysal/graph/_plotting.py
@@ -104,7 +104,7 @@ def _plot(
     # get array of coordinates in the order reflecting graph_obj._adjacency.index.codes
     # we need to work on int position to allow fast filtering of duplicated edges and
     # cannot rely on gdf remaining in the same order between Graph creation and
-    # plotting  
+    # plotting
     coords = shapely.get_coordinates(
         gdf.reindex(graph_obj.unique_ids).representative_point()
     )
@@ -113,7 +113,7 @@ def _plot(
         if not pd.api.types.is_list_like(focal):
             focal = [focal]
         subset = graph_obj._adjacency[focal]
-        codes = subset.index.codes 
+        codes = subset.index.codes
 
     else:
         codes = graph_obj._adjacency.index.codes
@@ -287,7 +287,7 @@ def _explore_graph(
             # focals
             geoms.iloc[np.unique(subset.index.codes[0])].explore(
                 m=m, **dict(node_kws, **focal_kws)
-            ) 
+            )
         else:
             geoms.explore(m=m, **node_kws)
     return m

--- a/libpysal/graph/_plotting.py
+++ b/libpysal/graph/_plotting.py
@@ -16,6 +16,8 @@ def _plot(
     ax=None,
     figsize=None,
     limit_extent=False,
+    color_by_weight=False,
+    cmap="viridis",
 ):
     """Plot edges and nodes of the Graph
 
@@ -61,6 +63,12 @@ def _plot(
     limit_extent : bool, optional
         limit the extent of the axis to the extent of the plotted graph, by default
         False
+    color_by_weight : bool, optional
+        If True, edges are colored by their weights using the specified colormap.
+        If False, all edges use the same color. By default False
+    cmap : str, optional
+        Colormap to use when ``color_by_weight=True``. Can be any valid matplotlib
+        colormap name (e.g., "viridis", "plasma", "coolwarm"). By default "viridis"
 
     Returns
     -------
@@ -70,6 +78,7 @@ def _plot(
     try:
         import matplotlib.pyplot as plt
         from matplotlib import collections
+        import matplotlib.colors as mcolors
 
     except (ImportError, ModuleNotFoundError) as err:
         raise ImportError("matplotlib is required for `plot`.") from err
@@ -84,15 +93,18 @@ def _plot(
         node_kws = {"color": color}
 
     if edge_kws is not None:
-        if "color" not in edge_kws:
+        if "color" not in edge_kws and not color_by_weight:
             edge_kws["color"] = color
     else:
-        edge_kws = {"color": color}
+        if not color_by_weight:
+            edge_kws = {"color": color}
+        else:
+            edge_kws = {}
 
     # get array of coordinates in the order reflecting graph_obj._adjacency.index.codes
     # we need to work on int position to allow fast filtering of duplicated edges and
     # cannot rely on gdf remaining in the same order between Graph creation and
-    # plotting
+    # plotting  
     coords = shapely.get_coordinates(
         gdf.reindex(graph_obj.unique_ids).representative_point()
     )
@@ -101,14 +113,37 @@ def _plot(
         if not pd.api.types.is_list_like(focal):
             focal = [focal]
         subset = graph_obj._adjacency[focal]
-        codes = subset.index.codes
+        codes = subset.index.codes 
 
     else:
         codes = graph_obj._adjacency.index.codes
 
     # avoid plotting both ij and ji
-    edges = np.unique(np.sort(np.column_stack([codes]).T, axis=1), axis=0)
+    edges, indices = np.unique(
+        np.sort(np.column_stack([codes]).T, axis=1), return_index=True, axis=0
+    )
     lines = coords[edges]
+
+    if color_by_weight:
+        if focal is not None:
+            weights = subset.iloc[indices].values
+        else:
+            weights = graph_obj._adjacency.iloc[indices].values
+
+        if len(weights) > 0 and weights.max() != weights.min():
+            norm = mcolors.Normalize(vmin=weights.min(), vmax=weights.max())
+        else:
+            norm = mcolors.Normalize(vmin=0, vmax=1)
+
+        colormap = plt.get_cmap(cmap)
+        colors = colormap(norm(weights))
+
+        edge_kws["colors"] = colors
+        edge_kws.pop("color", None)
+
+        sm = plt.cm.ScalarMappable(cmap=colormap, norm=norm)
+        sm.set_array([])
+        plt.colorbar(sm, ax=ax, label="Weight")
 
     ax.add_collection(collections.LineCollection(lines, **edge_kws))
 
@@ -252,7 +287,7 @@ def _explore_graph(
             # focals
             geoms.iloc[np.unique(subset.index.codes[0])].explore(
                 m=m, **dict(node_kws, **focal_kws)
-            )
+            ) 
         else:
             geoms.explore(m=m, **node_kws)
     return m

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -2421,6 +2421,8 @@ class Graph(SetOpsMixin):
         ax=None,
         figsize=None,
         limit_extent=False,
+        color_by_weight=False,
+        cmap="viridis",
     ):
         """Plot edges and nodes of the Graph
 
@@ -2463,6 +2465,12 @@ class Graph(SetOpsMixin):
         limit_extent : bool, optional
             limit the extent of the axis to the extent of the plotted graph, by default
             False
+        color_by_weight : bool, optional
+            If True, edges are colored by their weights using the specified colormap.
+            If False, all edges use the same color. By default False
+        cmap : str, optional
+            Colormap to use when ``color_by_weight=True``. Can be any valid matplotlib
+            colormap name (e.g., "viridis", "plasma", "coolwarm"). By default "viridis"
 
         Returns
         -------
@@ -2491,6 +2499,8 @@ class Graph(SetOpsMixin):
             ax=ax,
             figsize=figsize,
             limit_extent=limit_extent,
+            color_by_weight=color_by_weight,
+            cmap=cmap,
         )
 
     def explore(

--- a/libpysal/graph/tests/test_plotting.py
+++ b/libpysal/graph/tests/test_plotting.py
@@ -12,6 +12,8 @@ from libpysal.graph.tests.test_utils import fetch_map_string
 class TestPlotting:
     def setup_method(self):
         _ = pytest.importorskip("matplotlib")
+        import matplotlib
+        matplotlib.use("Agg")  # Use non-interactive backend for CI
 
         self.nybb = geopandas.read_file(geodatasets.get_path("nybb"))
         self.G = graph.Graph.build_contiguity(self.nybb)

--- a/libpysal/graph/tests/test_plotting.py
+++ b/libpysal/graph/tests/test_plotting.py
@@ -256,6 +256,114 @@ class TestPlotting:
             pathcollection_focal.get_facecolor(), np.array([[0.0, 0.0, 1.0, 1.0]])
         )
 
+    def test_color_by_weight(self):
+        """Test weight-based coloring feature"""
+        import pandas as pd
+
+        # Create a graph with varying weights for testing
+        focal_ids = ["Staten Island", "Queens", "Brooklyn", "Manhattan", "Bronx"]
+        neighbor_ids = ["Queens", "Brooklyn", "Manhattan", "Bronx", "Staten Island"]
+        weights = [0.2, 0.4, 0.6, 0.8, 1.0]
+
+        adjacency = pd.Series(
+            weights,
+            index=pd.MultiIndex.from_arrays(
+                [focal_ids, neighbor_ids], names=["focal", "neighbor"]
+            ),
+            name="weight",
+        )
+        G_test = graph.Graph(adjacency)
+
+        # Test that color_by_weight=True produces colors array
+        ax = G_test.plot(self.nybb_str, color_by_weight=True)
+        linecollection = ax.collections[0]
+
+        # When color_by_weight=True, should use colors array
+        edgecolors = linecollection.get_edgecolors()
+        assert edgecolors is not None
+        assert len(edgecolors) == len(weights)
+        assert edgecolors.shape[1] == 4  # RGBA
+
+        # Different weights should produce different colors
+        # Check that colors are not all the same
+        assert not np.allclose(edgecolors[0], edgecolors[1])
+
+    def test_color_by_weight_false(self):
+        """Test that color_by_weight=False maintains backward compatibility"""
+        ax = self.G.plot(self.nybb, color_by_weight=False, color="red")
+
+        linecollection = ax.collections[0]
+        # Should use single color, not colors array
+        color = linecollection.get_color()
+        np.testing.assert_array_equal(color, np.array([[1.0, 0.0, 0.0, 1.0]]))
+
+    def test_color_by_weight_cmap(self):
+        """Test that cmap parameter works"""
+        import pandas as pd
+        import matplotlib.pyplot as plt
+
+        # Use existing graph but test with different colormap
+        # This tests that cmap parameter is accepted and produces different colors
+        ax1 = self.G_str.plot(self.nybb_str, color_by_weight=True, cmap="viridis")
+        ax2 = self.G_str.plot(self.nybb_str, color_by_weight=True, cmap="plasma")
+
+        linecollection1 = ax1.collections[0]
+        linecollection2 = ax2.collections[0]
+
+        edgecolors1 = linecollection1.get_edgecolors()
+        edgecolors2 = linecollection2.get_edgecolors()
+
+        assert edgecolors1 is not None
+        assert edgecolors2 is not None
+        # Different colormaps should produce different colors
+        # (at least for some edges, unless all weights are identical)
+        assert len(edgecolors1) == len(edgecolors2)
+
+    def test_color_by_weight_focal(self):
+        """Test weight-based coloring with focal parameter"""
+        import pandas as pd
+
+        # Create a graph with varying weights - use existing contiguity graph
+        # but modify weights for testing
+        G_test = self.G_str.copy()
+
+        # Test with focal parameter - should work with existing graph
+        ax = G_test.plot(self.nybb_str, focal="Queens", color_by_weight=True)
+        linecollection = ax.collections[0]
+        edgecolors = linecollection.get_edgecolors()
+
+        # Should have colors for edges from Queens
+        assert edgecolors is not None
+        assert len(edgecolors) > 0
+
+    def test_color_by_weight_same_weights(self):
+        """Test weight-based coloring when all weights are the same"""
+        import pandas as pd
+
+        # Create a graph with ALL identical weights using all boroughs
+        focal_ids = ["Staten Island", "Queens", "Brooklyn", "Manhattan", "Bronx"]
+        neighbor_ids = ["Queens", "Brooklyn", "Manhattan", "Bronx", "Staten Island"]
+        weights = [1.0, 1.0, 1.0, 1.0, 1.0]  # All weights identical
+
+        adjacency = pd.Series(
+            weights,
+            index=pd.MultiIndex.from_arrays(
+                [focal_ids, neighbor_ids], names=["focal", "neighbor"]
+            ),
+            name="weight",
+        )
+        G_test = graph.Graph(adjacency)
+
+        # Should not crash when all weights are identical
+        ax = G_test.plot(self.nybb_str, color_by_weight=True)
+        linecollection = ax.collections[0]
+        edgecolors = linecollection.get_edgecolors()
+
+        assert edgecolors is not None
+        assert len(edgecolors) == len(weights)
+        # All colors should be identical when weights are identical
+        np.testing.assert_array_equal(edgecolors[0], edgecolors[1])
+
 
 class TestExplore:
     def setup_method(self):


### PR DESCRIPTION
The justification for this PR is: 
It adds the feature of coloring edges by their weights in static plots which was initiated in #628 
The method discussed in the issue is what is indeed being used in this PR. We get weights of the edges, normalize them to [0, 1] and then pass them to a matplotlib colormap and use the colormap to plot the different colors for different edges. I have used a color_by_weight boolean parameter, thus enabling backward compatibility and have also added a colorbar for weight to color mapping.
AI assistance was used for code development; all communication and explanations are written by me.