### PR TITLE
Fix/657 raster w2da missing vals

### DIFF
--- a/libpysal/weights/raster.py
+++ b/libpysal/weights/raster.py
@@ -650,7 +650,7 @@ def _index2da(data, index, attrs, coords):
             f"data length ({data.size}) must equal the number of observations "
             f"in the weights object ({len(idx)}). When the raster has missing "
             "values, pass only the values at valid (non-missing) cells in the "
-            "same order as w.index, e.g. da.to_series()[da.to_series() != nodata].values"
+            "same order as w.index, e.g. da.to_series()[da.to_series() != nodata]"
         )
     dims = idx.names
     indexer = tuple(idx.codes)

--- a/libpysal/weights/raster.py
+++ b/libpysal/weights/raster.py
@@ -645,6 +645,13 @@ def _index2da(data, index, attrs, coords):
 
     data = np.array(data).flatten()
     idx = index
+    if data.size != len(idx):
+        raise ValueError(
+            f"data length ({data.size}) must equal the number of observations "
+            f"in the weights object ({len(idx)}). When the raster has missing "
+            "values, pass only the values at valid (non-missing) cells in the "
+            "same order as w.index, e.g. da.to_series()[da.to_series() != nodata].values"
+        )
     dims = idx.names
     indexer = tuple(idx.codes)
     shape = tuple(lev.size for lev in idx.levels)

--- a/libpysal/weights/tests/test_raster.py
+++ b/libpysal/weights/tests/test_raster.py
@@ -86,6 +86,31 @@ class Testraster:
         da_compare = xarray.DataArray.equals(da2, self.da2)
         assert da_compare is True
 
+    def test_w2da_missing_vals(self):
+        """Test w2da with raster that has missing values (covers _index2da missing path)."""
+        pytest.importorskip("xarray")
+        da = raster.testDataArray((1, 4, 4), missing_vals=True)
+        w = raster.da2W(da, "rook", n_jobs=1)
+        nodata = raster.get_nodata(da)
+        ser = da.to_series()
+        valid_data = ser[ser != nodata].values
+        assert len(valid_data) == len(w.index)
+        out = raster.w2da(valid_data, w, da.attrs, None)
+        assert out.shape == da.shape
+        assert out.dims == da.dims
+        out_ser = out.to_series()
+        valid_mask = ser != nodata
+        np.testing.assert_array_equal(out_ser[valid_mask].values, valid_data)
+        assert (out_ser[~valid_mask] == nodata).all()
+
+    def test_w2da_data_length_mismatch_raises(self):
+        """Passing full flattened data when w has missing values raises clear ValueError."""
+        pytest.importorskip("xarray")
+        da = raster.testDataArray((1, 4, 4), missing_vals=True)
+        w = raster.da2W(da, "rook", n_jobs=1)
+        with pytest.raises(ValueError, match="data length.*must equal the number of observations"):
+            raster.w2da(da.data.flatten(), w, da.attrs, None)
+
     def test_wsp2da(self):
         wsp1 = raster.da2WSP(self.da1, "queen")
         da1 = raster.wsp2da(self.data1, wsp1)

--- a/libpysal/weights/tests/test_raster.py
+++ b/libpysal/weights/tests/test_raster.py
@@ -87,7 +87,7 @@ class Testraster:
         assert da_compare is True
 
     def test_w2da_missing_vals(self):
-        """Test w2da with raster that has missing values (covers _index2da missing path)."""
+        """Test w2da with raster that has missing values (_index2da missing path)."""
         pytest.importorskip("xarray")
         da = raster.testDataArray((1, 4, 4), missing_vals=True)
         w = raster.da2W(da, "rook", n_jobs=1)
@@ -104,11 +104,13 @@ class Testraster:
         assert (out_ser[~valid_mask] == nodata).all()
 
     def test_w2da_data_length_mismatch_raises(self):
-        """Passing full flattened data when w has missing values raises clear ValueError."""
+        """Full flattened data when w has missing values raises clear ValueError."""
         pytest.importorskip("xarray")
         da = raster.testDataArray((1, 4, 4), missing_vals=True)
         w = raster.da2W(da, "rook", n_jobs=1)
-        with pytest.raises(ValueError, match="data length.*must equal the number of observations"):
+        with pytest.raises(
+            ValueError, match="data length.*must equal the number of observations"
+        ):
             raster.w2da(da.data.flatten(), w, da.attrs, None)
 
     def test_wsp2da(self):


### PR DESCRIPTION
1. [x] You have run tests on this submission locally using `pytest` on your changes. Continuous integration will be run on all PRs with [GitHub Actions](https://github.com/pysal/libpysal/blob/master/.github/workflows/unittests.yml), but it is good practice to test changes locally prior to a making a PR.
2. [x] This pull request is directed to the `pysal/master` branch.
3. [x] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [ ] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [x] The justification for this PR is: 
The issue turned out to be that when a raster has missing values, w2da() was being given data with the wrong length, usually the full flattened grid instead of just the valid cells. That caused a pretty confusing shape mismatch error. I added a guard to make sure the data length matches len(w.index) with a clearer error message that points out you need to pass only valid cell values. I also added two tests: one that actually hits the missing-values code path in _index2da and another that confirms we now raise a proper error when flattened data is passed in.

Fixes #657