### PR TITLE
Add next steps guidance after installation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -54,3 +54,11 @@ contribute to libpysal development.
 .. _Python Package Index: https://pypi.org/project/libpysal/
 .. _pysal/libpysal: https://github.com/pysal/libpysal
 .. _fork: https://help.github.com/articles/fork-a-repo/
+
+Next steps
+----------
+
+After installing libpysal, new users may want to start with the User Guide
+to see example workflows and learn how the core components are used together.
+See the User Guide introduction for an overview.
+


### PR DESCRIPTION
### Description
---

Adds a short `Next steps` section to `installation.rst`. After installing `libpysal` , new users have no clear guidance on where to go next in the documentation.

The added text point users to the User Guide introduction, where they can see examples and understand the main parts of the library.

This improves the beginner experience without changing any functionallity.

### Checklist
---

- [x] You have run tests on this submission locally using pytest on your changes.  
  N/A: This is a documentation only change (does not affect code/tests).

- [x] This pull request is directed to the pysal/main branch.

- [x] This pull introduces new functionality covered by docstrings and unittests.  
  N/A: No new functionality/code changes are introduced.

- [x] You have assigned a reviewer and added relevant labels.  
  N/A: No reviewer assigned, no labels added.

- [x] The justification for this PR is:  
  After installing libpysal , new users are not given any guidance on what to read or try next. This PR adds a “Next steps” section to point them to the User Guide, making the documentation flow clean & clear for beginners.

No AI tools were used in this contribution.
