### PR TITLE
Enable MyST Markdown support for libpysal documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,9 +37,16 @@ extensions = [  #'sphinx_gallery.gen_gallery',
     "numpydoc",
     #'sphinx.ext.napoleon',
     "matplotlib.sphinxext.plot_directive",
+    "myst_parser",
     "nbsphinx",
 ]
 bibtex_bibfiles = ["_static/references.bib"]
+
+# Enable MyST extensions for enhanced Markdown support
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+]
 
 # sphinx_gallery_conf = {
 #      # path to your examples scripts
@@ -57,7 +64,10 @@ templates_path = ["_templates"]
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = ".rst"
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
 
 # The master toctree document.
 master_doc = "index"


### PR DESCRIPTION
This PR enables MyST Markdown support in the libpysal documentation by adding the MyST parser and allowing .md files. 
No existing content is modified & the current reStructuredText and nbsphinx workflow is unchanged. This is for preparing the documentation infrastructure for future modernization, in line with the approach used in gwlearn.

**AI Disclosure:**
AI tool was used just to find the **myst_enable_extensions** for the betterment. 