### PR TITLE
DOC: link to source from pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,9 +56,6 @@ templates_path = [
 ]
 exclude_patterns = []
 
-html_copy_source = True
-html_sourcelink_suffix = ""
-
 intersphinx_mapping = {
     "geopandas": ("https://geopandas.org/en/latest", None),
     "python": ("https://docs.python.org/3", None),


### PR DESCRIPTION
This adds an icon leading to the GitHub source for each page. Especially useful for notebooks if someone wants to download them.