### PR TITLE
FIX: Fix index space mismatch in coplanar clique

### DIFF
--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -294,6 +294,10 @@ def _knn(coordinates, metric="euclidean", k=1, p=2, coplanar="raise", tree=None)
                     coplanar="raise",
                 )
             )
+            # map back head and tails to original
+            remaining_ix = numpy.delete(numpy.arange(n_samples), coplanar_lookup)
+            heads = remaining_ix[heads]
+            tails = remaining_ix[tails]
             adjtable = pandas.DataFrame.from_dict(
                 {"focal": heads, "neighbor": tails, "weight": weights}
             )

--- a/libpysal/graph/tests/test_kernel.py
+++ b/libpysal/graph/tests/test_kernel.py
@@ -15,7 +15,9 @@ import geopandas
 import numpy as np
 import pandas as pd
 import pytest
+from shapely import Point
 
+from libpysal.graph import Graph
 from libpysal.graph._kernel import (
     HAS_SKLEARN,
     _distance_band,
@@ -359,6 +361,28 @@ def test_coplanar(grocs):
     assert tail.shape == head.shape
     assert weight.shape == head.shape
     np.testing.assert_array_equal(pd.unique(head), grocs_duplicated.index)
+
+
+def test_coplanar_clique_duplicate_labels():
+    gs = geopandas.GeoSeries(
+        [
+            Point(0, 0),
+            Point(0, 0),
+            Point(1, 0),
+            Point(2, 0),
+            Point(3, 0),
+            Point(4, 0),
+        ]
+    )
+    g = Graph.build_kernel(gs, k=2, coplanar="clique")
+    assert g.n == 6
+
+    assert 0 in g.adjacency.index.get_level_values("focal")
+    assert 1 in g.adjacency.index.get_level_values("focal")
+
+    neighbors_0 = set(g.adjacency.loc[0].index) - {1}
+    neighbors_1 = set(g.adjacency.loc[1].index) - {0}
+    assert neighbors_0 == neighbors_1
 
 
 def test_shape_preservation():


### PR DESCRIPTION
1. [x] You have run tests on this submission locally using `pytest` on your changes. Continuous integration will be run on all PRs with [GitHub Actions](https://github.com/pysal/libpysal/blob/master/.github/workflows/unittests.yml), but it is good practice to test changes locally prior to a making a PR.
2. [x] This pull request is directed to the `pysal/master` branch.
3. [x] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [ ] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
   
5. [x] The justification for this PR is: 

- fixes: #897 

after fixing, i ran a script with clique as the co planar, it worked as expected

<img width="566" height="360" alt="image" src="https://github.com/user-attachments/assets/da2c542a-cd1e-46d0-a60e-42e85bf4eade" />
