### PR TITLE
GHA: use dedicated environment for docs action

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        environment-file: [ci/314-latest.yaml]
+        environment-file: [ci/docs.yaml]
         experimental: [false]
     defaults:
       run:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        environment-file: [ci/docs.yaml]
+        environment-file: [docs/environment.yaml]
         experimental: [false]
     defaults:
       run:

--- a/ci/docs.yaml
+++ b/ci/docs.yaml
@@ -1,4 +1,4 @@
-name: test
+name: docs
 channels:
   - conda-forge
 dependencies:
@@ -13,14 +13,9 @@ dependencies:
   - scipy
   - shapely
   # testing
-  - codecov
   - matplotlib
   - tobler
   - h3-py
-  - pytest
-  - pytest-cov
-  - pytest-mpl
-  - pytest-xdist
   # optional
   - geodatasets
   - joblib
@@ -32,6 +27,19 @@ dependencies:
   - zstd
   - pandarm
   - xarray
+  # for docs build action (this env only)
+  - ipykernel
+  - myst-nb
+  - sphinx
+  - sphinxcontrib-bibtex
+  - sphinx-autosummary-accessors
+  - sphinx-copybutton
+  - sphinx-immaterial
+  - pandoc
+  - seaborn
+  - esda
+  - splot
+  - watermark
   - pip
   - pip:
     - pulp

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -30,7 +30,7 @@ dependencies:
   # for docs build action (this env only)
   - ipykernel
   - myst-nb
-  - sphinx
+  - sphinx<9
   - sphinxcontrib-bibtex
   - sphinx-autosummary-accessors
   - sphinx-copybutton


### PR DESCRIPTION
As discussed during the dev call, this implements dedicated docs environment for GHA, split away from those used for tests. It should be easier to maintain the envs this way. I am not sure if we striclty need all of this but it certainly won't hurt. And trying it is a pain :).