### PR TITLE
BUG: fix situations where linear geometries disappear in voronoi_frames

### DIFF
--- a/libpysal/cg/tests/test_voronoi.py
+++ b/libpysal/cg/tests/test_voronoi.py
@@ -95,6 +95,24 @@ class TestVoronoi:
         )
         assert_geoseries_equal(geoms.simplify(0.1), expected, check_less_precise=True)
 
+    def test_from_lines_raises_when_line_disappears(self):
+        lines = gpd.GeoSeries(
+            [
+                shapely.LineString([(0, 0), (1, 0)]),
+                shapely.LineString([(1, 0), (1, 1)]),
+                shapely.LineString([(0, 1), (1, 1)]),
+            ],
+            crs="EPSG:3857",
+        )
+
+        with pytest.raises(
+            ValueError, match="Geometries collapsed during the preprocessing."
+        ):
+            voronoi_frames(lines, as_gdf=False, return_input=False)
+
+        geoms = voronoi_frames(lines, shrink=1e-6, as_gdf=False, return_input=False)
+        assert len(geoms) == 3
+
     def test_clip_none(self):
         geoms = voronoi_frames(
             self.points2, as_gdf=False, return_input=False, clip=None

--- a/libpysal/cg/voronoi.py
+++ b/libpysal/cg/voronoi.py
@@ -402,12 +402,13 @@ def voronoi_frames(
                 objects.loc[mask_poly] = shapely.segmentize(objects[mask_poly], segment)
 
         if mask_line.any():
-            objects.loc[mask_line] = objects.loc[mask_line].apply(
-                shapely.ops.substring,
-                start_dist=shrink,
-                end_dist=1 - shrink,
-                normalized=True,
-            )
+            if shrink != 0:
+                objects.loc[mask_line] = objects.loc[mask_line].apply(
+                    shapely.ops.substring,
+                    start_dist=shrink,
+                    end_dist=1 - shrink,
+                    normalized=True,
+                )
             if segment != 0:
                 objects.loc[mask_line] = shapely.segmentize(objects[mask_line], segment)
 

--- a/libpysal/cg/voronoi.py
+++ b/libpysal/cg/voronoi.py
@@ -346,8 +346,10 @@ def voronoi_frames(
         * ``shapely.Polygon`` -- Clip to an arbitrary Polygon.
 
     shrink : float, optional
-        Distance for the negative buffer of polygons required when there are polygons
-        sharing portion of their exterior, by default 0
+        For Polygons, ``shrink`` represents the distance for the negative buffer
+        required when there are polygons sharing portion of their exterior. For
+        LineStrings, represents the fraction of the length of each LineString clipped on
+        each end to avoid co-located points. By default 0
     segment : float, optional
         Distance for the segmentation of lines used to add coordinates to lines or
         polygons prior Voronoi tessellation, by default 0
@@ -400,11 +402,17 @@ def voronoi_frames(
                 objects.loc[mask_poly] = shapely.segmentize(objects[mask_poly], segment)
 
         if mask_line.any():
+            objects.loc[mask_line] = objects.loc[mask_line].apply(
+                shapely.ops.substring,
+                start_dist=shrink,
+                end_dist=1 - shrink,
+                normalized=True,
+            )
             if segment != 0:
                 objects.loc[mask_line] = shapely.segmentize(objects[mask_line], segment)
 
             # Remove duplicate coordinates from lines
-            objects.loc[mask_line] = (
+            deduplicated = (
                 objects.loc[mask_line]
                 .get_coordinates(index_parts=True)
                 .drop_duplicates(keep=False)
@@ -412,6 +420,13 @@ def voronoi_frames(
                 .apply(shapely.multipoints)
                 .values
             )
+            if len(deduplicated) == mask_line.sum():
+                objects.loc[mask_line] = deduplicated
+            else:
+                raise ValueError(
+                    "Geometries collapsed during the preprocessing. "
+                    "Please adapt `shrink` or `segment` arguments."
+                )
     else:
         geometry = np.asarray(geometry)
         objects = geometry = gpd.GeoSeries.from_xy(geometry[:, 0], geometry[:, 1])


### PR DESCRIPTION
The deduplication step means that some lines completely disappear. We need to clip them on both sides to ensure that they all have their unique endpoints that can go to the voronoi algorithm. The `shapely.ops.substring ` works but is a loop since there's no vectorized version. I'll see if I can quickly craft one, otherwise I'll leave it. It is not that slow.

Tests are missing but this already fixes the case I ran into.