### PR TITLE
ENH: add kernel input validation

### DIFF
--- a/libpysal/kernels.py
+++ b/libpysal/kernels.py
@@ -288,12 +288,20 @@ def kernel(distances, bandwidth, kernel="gaussian", taper=True, decay=False):
         Kernel function evaluated at distance values.
 
     """
+    if isinstance(kernel, str) and kernel not in _kernel_functions:
+        raise ValueError(
+            f"Invalid kernel '{kernel}'. "
+            f"Supported kernels are: {list(_kernel_functions.keys())}, "
+            "None, or a callable."
+        )
     if callable(kernel):
         func = kernel
     elif kernel is None:
         func = _kernel_functions[None]
-    else:
+    elif isinstance(kernel, str):
         func = _kernel_functions[kernel]
+    else:
+        raise ValueError("kernel must be either a valid string, None, or a callable.")
 
     k = func(distances, bandwidth)
     if taper is True:

--- a/libpysal/tests/test_kernels.py
+++ b/libpysal/tests/test_kernels.py
@@ -122,7 +122,7 @@ def test_kernel_dispatcher_invalid_name(distances, bandwidth):
         kernels.kernel(distances, bandwidth, kernel="not-a-kernel")
 
 def test_kernel_taper(distances, bandwidth):
-    
+
     result = kernels.kernel(distances, bandwidth, kernel="gaussian", taper=True)
     expected = kernels._gaussian(distances, bandwidth)
     expected[distances > bandwidth] = 0.0
@@ -139,3 +139,18 @@ def test_kernel_taper(distances, bandwidth):
     expected = kernels._gaussian(distances, bandwidth)
     expected[distances > taper_val] = 0.0
     np.testing.assert_array_almost_equal(result, expected)
+
+
+@pytest.mark.parametrize("kernel", ["invalid", "abc", "wrong_kernel"])
+def test_invalid_kernel_raises(distances, bandwidth, kernel):
+    """Ensure ValueError is raised for invalid kernel during fit."""
+
+    with pytest.raises(ValueError, match="Invalid kernel"):
+        kernels.kernel(distances, bandwidth, kernel=kernel)
+
+
+def test_kernel_not_callable_or_string(distances, bandwidth):
+    """Ensure invalid kernel type (not string/callable) raises ValueError."""
+
+    with pytest.raises(ValueError, match="kernel must"):
+        kernels.kernel(distances, bandwidth, kernel=123)

--- a/libpysal/tests/test_kernels.py
+++ b/libpysal/tests/test_kernels.py
@@ -118,9 +118,14 @@ def test_kernel_dispatcher_callable(distances, bandwidth):
 
 
 def test_kernel_dispatcher_invalid_name(distances, bandwidth):
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError, match="Invalid kernel"):
         kernels.kernel(distances, bandwidth, kernel="not-a-kernel")
 
+def test_kernel_not_callable_or_string(distances, bandwidth):
+    """Ensure invalid kernel type (not string/callable) raises ValueError."""
+
+    with pytest.raises(ValueError, match="kernel must"):
+        kernels.kernel(distances, bandwidth, kernel=123)
 def test_kernel_taper(distances, bandwidth):
 
     result = kernels.kernel(distances, bandwidth, kernel="gaussian", taper=True)
@@ -141,16 +146,4 @@ def test_kernel_taper(distances, bandwidth):
     np.testing.assert_array_almost_equal(result, expected)
 
 
-@pytest.mark.parametrize("kernel", ["invalid", "abc", "wrong_kernel"])
-def test_invalid_kernel_raises(distances, bandwidth, kernel):
-    """Ensure ValueError is raised for invalid kernel during fit."""
 
-    with pytest.raises(ValueError, match="Invalid kernel"):
-        kernels.kernel(distances, bandwidth, kernel=kernel)
-
-
-def test_kernel_not_callable_or_string(distances, bandwidth):
-    """Ensure invalid kernel type (not string/callable) raises ValueError."""
-
-    with pytest.raises(ValueError, match="kernel must"):
-        kernels.kernel(distances, bandwidth, kernel=123)


### PR DESCRIPTION
Moving this from gwlearn. Adds explicit kernel input validation with useful errors, rather than a plain KeyError we're getting now.