### PR TITLE
Fix: float[] to float  in legacy bandwidth

### DIFF
--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -269,9 +269,11 @@ def _kernel(
         if callable(kernel):
             func = kernel
         else:
-            func = lambda distances, bw: _lps_kernel(
-                distances, bw, kernel=kernel, taper=taper, decay=decay
-            )
+
+            def func(distances, bw):
+                return _lps_kernel(
+                    distances, bw, kernel=kernel, taper=taper, decay=decay
+                )
 
         for i in range(d_csr.shape[0]):
             start = d_csr.indptr[i]

--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -264,18 +264,39 @@ def _kernel(
         rows, _ = d_csr.nonzero()
         bw_per_row = numpy.zeros(d_csr.shape[0])
         numpy.maximum.at(bw_per_row, rows, d_csr.data)
-        bandwidth = bw_per_row[rows] * 1.0000001
-    elif bandwidth is None:
-        bandwidth = numpy.percentile(d.data, 25) if k is None else d.data.max()
-    elif bandwidth == "auto":
-        if (kernel == "identity") or (kernel is None):
-            bandwidth = numpy.nan  # ignored by identity
+        bw_per_row = bw_per_row * 1.0000001
+
+        if callable(kernel):
+            func = kernel
         else:
-            bandwidth = _optimize_bandwidth(d, kernel)
-    if callable(kernel):
-        d.data = kernel(d.data, bandwidth)
+            func = lambda distances, bw: _lps_kernel(
+                distances, bw, kernel=kernel, taper=taper, decay=decay
+            )
+
+        for i in range(d_csr.shape[0]):
+            start = d_csr.indptr[i]
+            end = d_csr.indptr[i + 1]
+            if start < end:
+                d_csr.data[start:end] = func(
+                    d_csr.data[start:end], float(bw_per_row[i])
+                )
+        d = d_csr.tocsc()
+
     else:
-        d.data = _lps_kernel(d.data, bandwidth, kernel=kernel, taper=taper, decay=decay)
+        if bandwidth is None:
+            bandwidth = numpy.percentile(d.data, 25) if k is None else d.data.max()
+        elif bandwidth == "auto":
+            if (kernel == "identity") or (kernel is None):
+                bandwidth = numpy.nan  # ignored by identity
+            else:
+                bandwidth = _optimize_bandwidth(d, kernel)
+
+        if callable(kernel):
+            d.data = kernel(d.data, bandwidth)
+        else:
+            d.data = _lps_kernel(
+                d.data, bandwidth, kernel=kernel, taper=taper, decay=decay
+            )
     if taper:
         d.eliminate_zeros()
     return _sparse_to_arrays(d, ids=ids, resolve_isolates=resolve_isolates)

--- a/libpysal/graph/tests/test_builders.py
+++ b/libpysal/graph/tests/test_builders.py
@@ -310,6 +310,25 @@ class TestKernel:
         assert g_adaptive.adjacency.values.mean() == pytest.approx(0.2946159834)
         assert g_adaptive.adjacency.values.max() == pytest.approx(0.3978916872)
 
+    def test_adaptive_bandwidth_custom_kernel_scalar(self):
+        """Ensure adaptive bandwidth provides a scalar float to custom kernels."""
+        from shapely.geometry import Point
+
+        rng = np.random.default_rng(6301)
+        coords = gpd.GeoSeries([Point(*p) for p in rng.laplace(size=(20, 2)) / 50])
+
+        def safe_custom_kernel(distances, bw):
+            # Capping the bandwidth to a minimum value to prevent division by zero
+            if bw < 0.001:
+                bw = 0.001
+
+            return np.exp(-distances / bw)
+
+        g = graph.Graph.build_kernel(
+            coords, k=4, bandwidth="adaptive", kernel=safe_custom_kernel
+        )
+        assert len(g.adjacency) > 0
+
     def test_knn_intids(self):
         g = graph.Graph.build_knn(self.gdf, k=3, coplanar="jitter")
 


### PR DESCRIPTION
In my last merged Pull Request https://github.com/pysal/libpysal/pull/905:

```python
bandwidth = bw_per_row[rows] * 1.0000001
# ... (some code)
d.data = _lps_kernel(d.data, bandwidth, ...)
```

on discussion with @sjsrey , here, it was passing bandwidth as an entire array of floats (float[]) directly into the kernel functions all at once for the entire sparse matrix. This caused issues because some custom kernel functions (or internal ones) expect bandwidth to be a single scalar float, which might lead to broadcasting errors.

Now, the code has been refactored to iterate through the data observation-by-observation (row-by-row):
```python
bw_per_row = bw_per_row * 1.0000001
# ... (some codee)
for i in range(d_csr.shape[0]):
    start = d_csr.indptr[i]
    end = d_csr.indptr[i + 1]
    if start < end:
        d_csr.data[start:end] = func(
            d_csr.data[start:end], float(bw_per_row[i])
        )

```

i'm aware that numpy vectorization is definitely going to be faster, yet this change it's a necessary trade-off for correctness and API compliance. By iterating row by row, the code can pass a single scalar float to the kernel function.

So it completely resolves the issue by ensuring the kernel functions always receive a single float bandwidth, even when we are using adaptive (variable) bandwidths across the datasets..


I wrote a quick script to test both versions with a dataset of 100,000 points and a relatively large neighbor count ($k=50$), simulating a moderately intensive spatial operation.
Here are the benchmark results:
Older Code (Vectorized, but buggy): 11.2725 seconds
New Code (Iterative, fixed): 11.5369 seconds

it's only a 0.26 seconds tradeoff, i believe it's feasible to ensure api compliance.