### PR TITLE
GHA: fix reverse dependency testing

### DIFF
--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -1,7 +1,8 @@
 name: Test reverse dependencies
 on:
   push:
-    branches: [main]
+    branches:
+      - "*"
   schedule:
     - cron: "0 0 * * 1,4"
   workflow_dispatch:
@@ -53,7 +54,10 @@ jobs:
             fast_hdbscan
             numba
           installation_command: >-
-            pip install pulp -U --force-reinstall; pip install -e .; python -c 'import libpysal; libpysal.examples.fetch_all()';
+              git config --global --add safe.directory /github/workspace;
+              pip install pulp -U --force-reinstall;
+              pip install -e .;
+              python -c 'import libpysal; libpysal.examples.fetch_all()';
           fail_on_failure: true
           xfail: >-
             mgwr

--- a/.github/workflows/reverse.yml
+++ b/.github/workflows/reverse.yml
@@ -1,8 +1,7 @@
 name: Test reverse dependencies
 on:
   push:
-    branches:
-      - "*"
+    branches: [main]
   schedule:
     - cron: "0 0 * * 1,4"
   workflow_dispatch:


### PR DESCRIPTION
This ensures that the action properly installs the env. That is currently not the case.

In the [successful run](https://github.com/martinfleis/libpysal/actions/runs/27530337870), I see segregation and spint failing. It might be worth exploring why is that and whether it has been fixed on main in the meantime.