### PR TITLE
DEP: pin Pulp to <4

### DIFF
--- a/ci/314-dev.yaml
+++ b/ci/314-dev.yaml
@@ -36,7 +36,7 @@ dependencies:
       --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
       --extra-index-url https://pypi.org/simple
     - pandas
-    - pulp
+    - pulp<4
     - scikit-learn
     - scipy
     - shapely

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ plus = [
     "networkx>=3.4",
     "numba>=0.60",
     "pandarm>=0.0",
-    "pulp",
+    "pulp<4",
     "pyarrow>=16.1",
     "sqlalchemy>=2.0",
     "xarray>=2024.5",


### PR DESCRIPTION
Given Pulp currently undergoes major change of API, which is not yet stable, I think we should indicate that libpysal is currently not compatible with Pulp 4. Especially since the next release or lib is imminent.