### PR TITLE
add libjxl for build_docs action

### DIFF
--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -29,6 +29,7 @@ dependencies:
   - xarray
   # for docs build action (this env only)
   - ipykernel
+  - libjxl 
   - myst-nb
   - sphinx<9
   - sphinxcontrib-bibtex

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -29,7 +29,8 @@ dependencies:
   - xarray
   # for docs build action (this env only)
   - ipykernel
-  - libjxl 
+  - libjxl>=0.11
+  - pyogrio
   - myst-nb
   - sphinx<9
   - sphinxcontrib-bibtex


### PR DESCRIPTION
Attempting to fix https://github.com/pysal/libpysal/actions/runs/28667616773