### PR TITLE
GHA: fix the version switcher update

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -92,6 +92,7 @@ jobs:
       - name: Update the versions switcher
         if: ${{ github.ref_type == 'tag' }}
         run: |
+          git reset --hard HEAD
           git checkout gh-pages
           git fetch
           git pull


### PR DESCRIPTION
The version switcher is broken on libpysal because we run the code that autogenerates migration file tracking W->Graph. So the git repo contains changes and `git checkout gh-pages` fails. This should resolve it.

See the issue https://github.com/pysal/libpysal/actions/runs/28667616773/job/85206084706

I think that this is specific to libpysal but if it gets copied elsewhere, it should make no difference.