### PR TITLE
fix adaptive bandwidth crashes when combined with coplanar='clique'

### DIFF
--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -261,7 +261,12 @@ def _kernel(
             )
         # each observation's bandwidth is its distance to its k-th neighbor,
         d_csr = d.tocsr()
-        rows, _ = d_csr.nonzero()
+        # NOTE: derive `rows` from indptr rather than d_csr.nonzero(). nonzero()
+        # only returns indices of truthy values, so it silently drops explicit
+        # stored zeros (e.g. the zero-distance edges coplanar="clique" induces
+        # between coincident points), leaving `rows` shorter than `d_csr.data`
+        # and breaking the maximum.at call below.
+        rows = numpy.repeat(numpy.arange(d_csr.shape[0]), numpy.diff(d_csr.indptr))
         bw_per_row = numpy.zeros(d_csr.shape[0])
         numpy.maximum.at(bw_per_row, rows, d_csr.data)
         bandwidth = bw_per_row[rows] * 1.0000001

--- a/libpysal/graph/tests/test_kernel.py
+++ b/libpysal/graph/tests/test_kernel.py
@@ -385,6 +385,29 @@ def test_coplanar_clique_duplicate_labels():
     assert neighbors_0 == neighbors_1
 
 
+def test_coplanar_clique_adaptive_bandwidth():
+    """bandwidth='adaptive' + coplanar='clique' used to crash with
+    'ValueError: array is not broadcastable to correct shape', because the
+    clique-induced zero-distance edges between coincident points are stored
+    explicitly (not eliminated), so d_csr.nonzero() disagreed in length with
+    d_csr.data. See GH issue for the adaptive-bandwidth + clique interaction.
+    """
+    gs = geopandas.GeoSeries(
+        [
+            Point(0, 0),
+            Point(0, 0),
+            Point(1, 0),
+            Point(2, 0),
+            Point(3, 0),
+        ]
+    )
+    g = Graph.build_kernel(
+        gs, k=1, bandwidth="adaptive", kernel="gaussian", coplanar="clique"
+    )
+    assert np.isfinite(g.sparse.data).all()
+    assert (g.sparse.data > 0).all()
+
+
 def test_shape_preservation():
     coordinates = np.vstack(
         [np.repeat(np.arange(10), 10), np.tile(np.arange(10), 10)]


### PR DESCRIPTION
This addresses #932. See that issue for replication information and discussion. 