### PR TITLE
Fix/distance band divide by zero warning

### DIFF
--- a/libpysal/cg/tests/test_geoJSON.py
+++ b/libpysal/cg/tests/test_geoJSON.py
@@ -12,7 +12,7 @@ class TesttestMultiPloygon:
 
         """
 
-        shp = FileIO(pysal_examples.get_path("NAT.shp"), "r")
+        shp = FileIO(pysal_examples.get_path("natregimes.shp"), "r")
         multipolygons = [p for p in shp if len(p.parts) > 1]
         for poly in multipolygons:
             json = poly.__geo_interface__

--- a/libpysal/graph/_kernel.py
+++ b/libpysal/graph/_kernel.py
@@ -251,6 +251,14 @@ def _kernel(
                 d = sparse.csc_array((data, (i, j)))
         else:
             d = sparse.csc_array(coordinates)
+            if exclude_self_weights:
+                # drop only the diagonal; eliminate_zeros() would also drop
+                # genuine 0-distance edges between distinct, coincident points
+                coo = d.tocoo()
+                mask = coo.row != coo.col
+                d = sparse.csc_array(
+                    (coo.data[mask], (coo.row[mask], coo.col[mask])), shape=d.shape
+                )
 
     if bandwidth == "adaptive":
         if k is None:

--- a/libpysal/graph/base.py
+++ b/libpysal/graph/base.py
@@ -1035,25 +1035,7 @@ class Graph(SetOpsMixin):
                 decay=decay,
             )
 
-        adjacency = pd.DataFrame.from_dict(
-            {"focal": head, "neighbor": tail, "weight": weight}
-        ).set_index("focal")
-
-        # drop diagonal
-        counts = adjacency.index.value_counts()
-        no_isolates = counts[counts > 1]
-        adjacency = adjacency[
-            ~(
-                adjacency.index.isin(no_isolates.index)
-                & (adjacency.index == adjacency.neighbor)
-            )
-        ]
-        # set isolates to 0 - distance band should never contain self-weight
-        adjacency.loc[~adjacency.index.isin(no_isolates.index), "weight"] = 0
-
-        return cls.from_arrays(
-            adjacency.index.values, adjacency.neighbor.values, adjacency.weight.values
-        )
+        return cls.from_arrays(head, tail, weight)
 
     @classmethod
     def build_fuzzy_contiguity(

--- a/libpysal/weights/distance.py
+++ b/libpysal/weights/distance.py
@@ -987,6 +987,7 @@ class DistanceBand(W):
             )
             return neighbors, weights
         else:
+            self.dmat.eliminate_zeros()
             weighted = self.dmat.power(self.alpha)
             weighted[weighted == np.inf] = 0
             weighted.eliminate_zeros()


### PR DESCRIPTION
Explicit zero-valued self-distance entries in the sparse distance matrix were being raised to a negative power, producing inf and a RuntimeWarning before being discarded. Exclude those entries before exponentiating instead of after.

In _kernel.py this also fixes exclude_self_weights being silently ignored for metric="precomputed", which let self-loop weights leak through as inf. build_distance_band's diagonal-drop/isolate heuristic in base.py relied on that bug (self-loops present for every node) to tell isolates apart from real neighbors, so it's simplified now that _kernel already excludes self-loops correctly.

xref https://github.com/pysal/libpysal/issues/475#issuecomment-5181854370